### PR TITLE
Adds Redux store

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.9.5",
     "@tauri-apps/api": "^1.2.0",
     "@tiptap/extension-code-block-lowlight": "^2.0.3",
     "@tiptap/extension-color": "^2.0.3",
@@ -31,6 +32,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-drag-drop-files": "^2.3.10",
+    "react-redux": "^8.0.5",
     "react-resizable-panels": "^0.0.42",
     "tailwindcss": "^3.3.2",
     "tiptap-markdown": "^0.7.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import { FileEntry } from '@tauri-apps/api/fs';
 import * as React from 'react';
 import { useCallback } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
-import { useDebounce } from 'usehooks-ts';
 
 import { EditorAPI } from './types/EditorAPI';
 import { ReferenceItem } from './types/ReferenceItem';
@@ -14,8 +13,6 @@ import { ReferencesView } from './views/ReferencesView';
 function App() {
   const [selectedFile, setSelectedFile] = React.useState<FileEntry | undefined>();
 
-  const [selection, setSelection] = React.useState<string | null>(null);
-  const debouncedSelection = useDebounce(selection, 200);
   const editorRef = React.useRef<EditorAPI>();
   const handleReferenceClicked = (reference: ReferenceItem) => {
     editorRef.current?.insertReference(reference);
@@ -33,7 +30,7 @@ function App() {
       <VerticalResizeHandle />
 
       <Panel defaultSize={60} className="overflow-scroll p-3">
-        <CenterPaneView onSelectionChange={setSelection} editorRef={editorRef} file={selectedFile} />
+        <CenterPaneView editorRef={editorRef} file={selectedFile} />
       </Panel>
 
       <VerticalResizeHandle />
@@ -44,7 +41,7 @@ function App() {
           </Panel>
           <HorizontalResizeHandle />
           <Panel className="overflow-scroll p-3">
-            <AIView selection={debouncedSelection} />
+            <AIView />
           </Panel>
         </PanelGroup>
       </Panel>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,4 @@
-import { FileEntry } from '@tauri-apps/api/fs';
 import * as React from 'react';
-import { useCallback } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 
 import { EditorAPI } from './types/EditorAPI';
@@ -8,31 +6,25 @@ import { ReferenceItem } from './types/ReferenceItem';
 import { AIView } from './views/AIView';
 import { CenterPaneView } from './views/CenterPaneView';
 import { FoldersView } from './views/FoldersView';
+import { OpenedFilesView } from './views/OpenedFilesView';
 import { ReferencesView } from './views/ReferencesView';
 
 function App() {
-  const [selectedFile, setSelectedFile] = React.useState<FileEntry | undefined>();
-
   const editorRef = React.useRef<EditorAPI>();
   const handleReferenceClicked = (reference: ReferenceItem) => {
     editorRef.current?.insertReference(reference);
   };
 
-  const handleFolderClick = useCallback((file: FileEntry) => {
-    setSelectedFile(file);
-  }, []);
-
   return (
     <PanelGroup autoSaveId="refstudio" direction="horizontal">
       <Panel defaultSize={20} collapsible className="overflow-scroll p-4">
-        <FoldersView onClick={handleFolderClick} />
+        <FoldersView />
       </Panel>
       <VerticalResizeHandle />
-
-      <Panel defaultSize={60} className="overflow-scroll p-3">
-        <CenterPaneView editorRef={editorRef} file={selectedFile} />
+      <Panel defaultSize={60} className="overflow-scroll px-3">
+        <OpenedFilesView />
+        <CenterPaneView editorRef={editorRef} />
       </Panel>
-
       <VerticalResizeHandle />
       <Panel>
         <PanelGroup autoSaveId="rs-right-sidebar" direction="vertical">

--- a/src/TipTapEditor/TipTapEditor.tsx
+++ b/src/TipTapEditor/TipTapEditor.tsx
@@ -9,7 +9,7 @@ import { setTextSelection } from '../features/selection/selectionSlice';
 import { EditorProps } from '../types/EditorProps';
 import { MenuBar } from './MenuBar';
 import { ReferenceNode } from './ReferenceBlock/ReferenceNode';
-import { EDITOR_EXTENSIONS, INITIAL_CONTENT } from './TipTapEditorConfigs';
+import { EDITOR_EXTENSIONS } from './TipTapEditorConfigs';
 
 export function TipTapEditor({ editorRef, editorContent }: EditorProps) {
   const [selection, setSelection] = useState('');
@@ -19,7 +19,7 @@ export function TipTapEditor({ editorRef, editorContent }: EditorProps) {
     setEditor(
       new Editor({
         extensions: EDITOR_EXTENSIONS,
-        content: editorContent ?? INITIAL_CONTENT,
+        content: editorContent,
         onSelectionUpdate({ editor }) {
           const { from, to } = editor.view.state.selection;
           const text = editor.view.state.doc.textBetween(from, to);

--- a/src/TipTapEditor/TipTapEditor.tsx
+++ b/src/TipTapEditor/TipTapEditor.tsx
@@ -2,24 +2,39 @@ import './TipTapEditor.css';
 
 import { Editor, EditorContent } from '@tiptap/react';
 import { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useDebounce } from 'usehooks-ts';
 
+import { setTextSelection } from '../features/selection/selectionSlice';
 import { EditorProps } from '../types/EditorProps';
 import { MenuBar } from './MenuBar';
 import { ReferenceNode } from './ReferenceBlock/ReferenceNode';
 import { EDITOR_EXTENSIONS, INITIAL_CONTENT } from './TipTapEditorConfigs';
 
-export function TipTapEditor({ editorRef, editorContent, onSelectionChange }: EditorProps) {
+export function TipTapEditor({ editorRef, editorContent }: EditorProps) {
+  const [selection, setSelection] = useState('');
+
   const [editor, setEditor] = useState<Editor | null>(null);
   useEffect(() => {
-    setEditor(new Editor({
-      extensions: EDITOR_EXTENSIONS,
-      content: editorContent ?? INITIAL_CONTENT,
-      onSelectionUpdate({ editor }) {
-        const { from, to } = editor.view.state.selection;
-        onSelectionChange(editor.view.state.doc.textBetween(from, to));
-      },
-    }));
-  }, [editorContent, onSelectionChange]);
+    setEditor(
+      new Editor({
+        extensions: EDITOR_EXTENSIONS,
+        content: editorContent ?? INITIAL_CONTENT,
+        onSelectionUpdate({ editor }) {
+          const { from, to } = editor.view.state.selection;
+          const text = editor.view.state.doc.textBetween(from, to);
+          setSelection(text);
+        },
+      }),
+    );
+  }, [editorContent]);
+
+  // Dispatch (debounced) selection changed
+  const dispatch = useDispatch();
+  const debouncedSelection = useDebounce(selection, 200);
+  useEffect(() => {
+    dispatch(setTextSelection(debouncedSelection));
+  }, [dispatch, debouncedSelection]);
 
   useEffect(() => {
     if (!editor) return;

--- a/src/features/openedFiles/openedFilesSlice.ts
+++ b/src/features/openedFiles/openedFilesSlice.ts
@@ -1,0 +1,59 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { FileEntry } from '@tauri-apps/api/fs';
+
+type FileEntryType = 'TipTap' | 'PDF' | 'Unknown';
+
+export interface FileEntryInfo {
+  entry: FileEntry;
+  type: FileEntryType;
+  isDirectory: boolean;
+}
+
+export interface OpenedFilesState {
+  selectedFile?: FileEntryInfo;
+  files: FileEntryInfo[];
+}
+
+const initialState: OpenedFilesState = {
+  selectedFile: undefined,
+  files: [],
+};
+
+export const openedFilesSlice = createSlice({
+  name: 'openedFiles',
+  initialState,
+
+  reducers: {
+    openFile: (state, action: PayloadAction<FileEntryInfo>) => {
+      const exists = state.files.find(sameFileAs(action.payload));
+      if (!exists) {
+        state.files.push(action.payload);
+      }
+      state.selectedFile = state.files.find(sameFileAs(action.payload));
+    },
+
+    selectFile: (state, action: PayloadAction<FileEntryInfo>) => {
+      state.selectedFile = state.files.find(sameFileAs(action.payload));
+    },
+
+    closeFile: (state, action: PayloadAction<FileEntryInfo>) => {
+      state.files = state.files.filter((e) => e.entry.path !== action.payload.entry.path);
+      if (sameFile(state.selectedFile, action.payload)) {
+        state.selectedFile = state.files[0];
+      }
+    },
+  },
+});
+
+export const { openFile, selectFile, closeFile } = openedFilesSlice.actions;
+
+export default openedFilesSlice.reducer;
+
+function sameFile(a?: FileEntryInfo, b?: FileEntryInfo) {
+  if (!a || !b) return false;
+  return a.entry.path === b.entry.path;
+}
+
+function sameFileAs(a?: FileEntryInfo) {
+  return (b?: FileEntryInfo) => sameFile(a, b);
+}

--- a/src/features/selection/selectionSlice.ts
+++ b/src/features/selection/selectionSlice.ts
@@ -1,7 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { RootState } from '../../redux/store';
-
 export interface SelectionState {
   text: string;
 }
@@ -13,7 +11,6 @@ const initialState: SelectionState = {
 export const selectionSlice = createSlice({
   name: 'selection',
   initialState,
-  // The `reducers` field lets us define reducers and generate associated actions
   reducers: {
     setTextSelection: (state, action: PayloadAction<string>) => {
       state.text = action.payload;
@@ -25,10 +22,5 @@ export const selectionSlice = createSlice({
 });
 
 export const { setTextSelection, clearTextSelection } = selectionSlice.actions;
-
-// The function below is called a selector and allows us to select a value from
-// the state. Selectors can also be defined inline where they're used instead of
-// in the slice file. For example: `useSelector((state: RootState) => state.selection)`
-export const selectSelection = (state: RootState) => state.selection;
 
 export default selectionSlice.reducer;

--- a/src/features/selection/selectionSlice.ts
+++ b/src/features/selection/selectionSlice.ts
@@ -1,0 +1,34 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { RootState } from '../../redux/store';
+
+export interface SelectionState {
+  text: string;
+}
+
+const initialState: SelectionState = {
+  text: '',
+};
+
+export const selectionSlice = createSlice({
+  name: 'selection',
+  initialState,
+  // The `reducers` field lets us define reducers and generate associated actions
+  reducers: {
+    setTextSelection: (state, action: PayloadAction<string>) => {
+      state.text = action.payload;
+    },
+    clearTextSelection: (state) => {
+      state.text = '';
+    },
+  },
+});
+
+export const { setTextSelection, clearTextSelection } = selectionSlice.actions;
+
+// The function below is called a selector and allows us to select a value from
+// the state. Selectors can also be defined inline where they're used instead of
+// in the slice file. For example: `useSelector((state: RootState) => state.selection)`
+export const selectSelection = (state: RootState) => state.selection;
+
+export default selectionSlice.reducer;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,15 @@ import './index.css';
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
 
 import App from './App';
+import { store } from './redux/store';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
 );

--- a/src/redux/hooks.ts
+++ b/src/redux/hooks.ts
@@ -1,0 +1,7 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+
+import type { AppDispatch, RootState } from './store';
+
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,10 +1,12 @@
 import { Action, configureStore, ThunkAction } from '@reduxjs/toolkit';
 
+import openedFilesSlice from '../features/openedFiles/openedFilesSlice';
 import selectionReducer from '../features/selection/selectionSlice';
 
 export const store = configureStore({
   reducer: {
     selection: selectionReducer,
+    openedFiles: openedFilesSlice,
   },
 });
 

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,0 +1,13 @@
+import { Action, configureStore, ThunkAction } from '@reduxjs/toolkit';
+
+import selectionReducer from '../features/selection/selectionSlice';
+
+export const store = configureStore({
+  reducer: {
+    selection: selectionReducer,
+  },
+});
+
+export type AppDispatch = typeof store.dispatch;
+export type RootState = ReturnType<typeof store.getState>;
+export type AppThunk<ReturnType = void> = ThunkAction<ReturnType, RootState, unknown, Action<string>>;

--- a/src/types/CenterPaneViewProps.ts
+++ b/src/types/CenterPaneViewProps.ts
@@ -1,8 +1,0 @@
-import { FileEntry } from '@tauri-apps/api/fs';
-
-import { EditorAPI } from './EditorAPI';
-
-export interface CenterPaneViewProps {
-  editorRef: React.MutableRefObject<EditorAPI | undefined>;
-  file?: FileEntry;
-}

--- a/src/types/CenterPaneViewProps.ts
+++ b/src/types/CenterPaneViewProps.ts
@@ -5,5 +5,4 @@ import { EditorAPI } from './EditorAPI';
 export interface CenterPaneViewProps {
   editorRef: React.MutableRefObject<EditorAPI | undefined>;
   file?: FileEntry;
-  onSelectionChange(text: string): void;
 }

--- a/src/types/EditorProps.tsx
+++ b/src/types/EditorProps.tsx
@@ -2,6 +2,5 @@ import { EditorAPI } from './EditorAPI';
 
 export interface EditorProps {
   editorRef: React.MutableRefObject<EditorAPI | undefined>;
-  editorContent: string | null
-  onSelectionChange(text: string): void;
+  editorContent: string | null;
 }

--- a/src/views/AIView.tsx
+++ b/src/views/AIView.tsx
@@ -1,7 +1,10 @@
 import { Command } from '@tauri-apps/api/shell';
 import { useEffect, useState } from 'react';
 
-export function AIView({ selection }: { selection: string | null }) {
+import { useAppSelector } from '../redux/hooks';
+
+export function AIView() {
+  const selection = useAppSelector((state) => state.selection.text);
   const [reply, setReply] = useState('');
 
   useEffect(() => {

--- a/src/views/CenterPaneView.tsx
+++ b/src/views/CenterPaneView.tsx
@@ -21,18 +21,25 @@ export function CenterPaneView({ file, ...props }: CenterPaneViewProps) {
         const textContent = new TextDecoder('utf-8').decode(content);
         setContent(textContent);
         setLoading(false);
-      })()
+      })();
     }
   }, [file]);
 
-  if (loading) return <div><strong>Loading...</strong></div>;
+  if (loading)
+    return (
+      <div>
+        <strong>Loading...</strong>
+      </div>
+    );
 
   if (file && isTipTap(file)) return <TipTapEditor {...props} editorContent={content} />;
 
   return (
     <div>
       <strong>FILE:</strong>
-      <div>{file?.name} at <code>{file?.path}</code></div>
+      <div>
+        {file?.name} at <code>{file?.path}</code>
+      </div>
     </div>
   );
 }

--- a/src/views/OpenedFilesView.tsx
+++ b/src/views/OpenedFilesView.tsx
@@ -1,0 +1,57 @@
+import { useDispatch } from 'react-redux';
+
+import { cx } from '../cx';
+import { closeFile, selectFile } from '../features/openedFiles/openedFilesSlice';
+import { useAppSelector } from '../redux/hooks';
+
+export function OpenedFilesView() {
+  const dispatch = useDispatch();
+  const openedFiles = useAppSelector((state) => state.openedFiles);
+
+  if (openedFiles.files.length === 0) return null;
+
+  return (
+    <div
+      className={cx(
+        'm-2 flex items-center gap-2', //
+        'border-b-1 border-b border-slate-400 ',
+      )}
+    >
+      {openedFiles.files.map((fileInfo) => (
+        <span
+          onClick={(evt) => {
+            evt.stopPropagation();
+            dispatch(selectFile(fileInfo));
+          }}
+          className={cx(
+            'flex flex-wrap items-center justify-between',
+            'cursor-pointer select-none whitespace-nowrap',
+            'px-2 py-1', //
+            'group',
+            'border border-b-0 border-slate-400',
+            'hover:bg-slate-100',
+            {
+              'border-t-2 !border-t-primary bg-slate-100': openedFiles.selectedFile === fileInfo,
+            },
+          )}
+          key={fileInfo.entry.path}
+        >
+          {fileInfo.entry.name}
+          <span
+            onClick={(evt) => {
+              evt.stopPropagation();
+              dispatch(closeFile(fileInfo));
+            }}
+            className={cx(
+              'ml-4 px-1 text-lg font-semibold', //
+              'hover:bg-slate-200 ',
+              'invisible group-hover:visible',
+            )}
+          >
+            &times;
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/views/OpenedFilesView.tsx
+++ b/src/views/OpenedFilesView.tsx
@@ -31,7 +31,7 @@ export function OpenedFilesView() {
             'border border-b-0 border-slate-400',
             'hover:bg-slate-100',
             {
-              'border-t-2 !border-t-primary bg-slate-100': openedFiles.selectedFile === fileInfo,
+              'border-t-2 !border-t-green-500 bg-slate-100': openedFiles.selectedFile === fileInfo,
             },
           )}
           key={fileInfo.entry.path}

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,7 +294,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.21.0":
+"@babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.9.2":
   version: 7.21.5
   resolution: "@babel/runtime@npm:7.21.5"
   dependencies:
@@ -749,6 +749,26 @@ __metadata:
   version: 2.11.7
   resolution: "@popperjs/core@npm:2.11.7"
   checksum: 5b6553747899683452a1d28898c1b39173a4efd780e74360bfcda8eb42f1c5e819602769c81a10920fc68c881d07fb40429604517d499567eac079cfa6470f19
+  languageName: node
+  linkType: hard
+
+"@reduxjs/toolkit@npm:^1.9.5":
+  version: 1.9.5
+  resolution: "@reduxjs/toolkit@npm:1.9.5"
+  dependencies:
+    immer: ^9.0.21
+    redux: ^4.2.1
+    redux-thunk: ^2.4.2
+    reselect: ^4.1.8
+  peerDependencies:
+    react: ^16.9.0 || ^17.0.0 || ^18
+    react-redux: ^7.2.1 || ^8.0.2
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-redux:
+      optional: true
+  checksum: 54672c5593d05208af577e948a338f23128d3aa01ef056ab0d40bcfa14400cf6566be99e11715388f12c1d7655cdf7c5c6b63cb92eb0fecf996c454a46a3914c
   languageName: node
   linkType: hard
 
@@ -1238,6 +1258,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hoist-non-react-statics@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@types/hoist-non-react-statics@npm:3.3.1"
+  dependencies:
+    "@types/react": "*"
+    hoist-non-react-statics: ^3.3.0
+  checksum: 2c0778570d9a01d05afabc781b32163f28409bb98f7245c38d5eaf082416fdb73034003f5825eb5e21313044e8d2d9e1f3fe2831e345d3d1b1d20bcd12270719
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.9":
   version: 7.0.11
   resolution: "@types/json-schema@npm:7.0.11"
@@ -1342,6 +1372,13 @@ __metadata:
   version: 2.0.6
   resolution: "@types/unist@npm:2.0.6"
   checksum: 25cb860ff10dde48b54622d58b23e66214211a61c84c0f15f88d38b61aa1b53d4d46e42b557924a93178c501c166aa37e28d7f6d994aba13d24685326272d5db
+  languageName: node
+  linkType: hard
+
+"@types/use-sync-external-store@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@types/use-sync-external-store@npm:0.0.3"
+  checksum: 161ddb8eec5dbe7279ac971531217e9af6b99f7783213566d2b502e2e2378ea19cf5e5ea4595039d730aa79d3d35c6567d48599f69773a02ffcff1776ec2a44e
   languageName: node
   linkType: hard
 
@@ -3081,7 +3118,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.0.0":
+"hoist-non-react-statics@npm:^3.0.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -3156,6 +3193,13 @@ __metadata:
   version: 5.2.4
   resolution: "ignore@npm:5.2.4"
   checksum: 3d4c309c6006e2621659311783eaea7ebcd41fe4ca1d78c91c473157ad6666a57a2df790fe0d07a12300d9aac2888204d7be8d59f9aaf665b1c7fcdb432517ef
+  languageName: node
+  linkType: hard
+
+"immer@npm:^9.0.21":
+  version: 9.0.21
+  resolution: "immer@npm:9.0.21"
+  checksum: 70e3c274165995352f6936695f0ef4723c52c92c92dd0e9afdfe008175af39fa28e76aafb3a2ca9d57d1fb8f796efc4dd1e1cc36f18d33fa5b74f3dfb0375432
   languageName: node
   linkType: hard
 
@@ -4706,6 +4750,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^18.0.0":
+  version: 18.2.0
+  resolution: "react-is@npm:18.2.0"
+  checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
+  languageName: node
+  linkType: hard
+
+"react-redux@npm:^8.0.5":
+  version: 8.0.5
+  resolution: "react-redux@npm:8.0.5"
+  dependencies:
+    "@babel/runtime": ^7.12.1
+    "@types/hoist-non-react-statics": ^3.3.1
+    "@types/use-sync-external-store": ^0.0.3
+    hoist-non-react-statics: ^3.3.2
+    react-is: ^18.0.0
+    use-sync-external-store: ^1.0.0
+  peerDependencies:
+    "@types/react": ^16.8 || ^17.0 || ^18.0
+    "@types/react-dom": ^16.8 || ^17.0 || ^18.0
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+    react-native: ">=0.59"
+    redux: ^4
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+    redux:
+      optional: true
+  checksum: a108f4f7ead6ac005e656d46051474a2bbdb31ede481bbbb3d8d779c1a35e1940b8655577cc5021313411864d305f67fc719aa48d6e5ed8288cf9cbe8b7042e4
+  languageName: node
+  linkType: hard
+
 "react-refresh@npm:^0.14.0":
   version: 0.14.0
   resolution: "react-refresh@npm:0.14.0"
@@ -4761,10 +4844,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redux-thunk@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "redux-thunk@npm:2.4.2"
+  peerDependencies:
+    redux: ^4
+  checksum: c7f757f6c383b8ec26152c113e20087818d18ed3edf438aaad43539e9a6b77b427ade755c9595c4a163b6ad3063adf3497e5fe6a36c68884eb1f1cfb6f049a5c
+  languageName: node
+  linkType: hard
+
+"redux@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "redux@npm:4.2.1"
+  dependencies:
+    "@babel/runtime": ^7.9.2
+  checksum: f63b9060c3a1d930ae775252bb6e579b42415aee7a23c4114e21a0b4ba7ec12f0ec76936c00f546893f06e139819f0e2855e0d55ebfce34ca9c026241a6950dd
+  languageName: node
+  linkType: hard
+
 "refstudio@workspace:.":
   version: 0.0.0-use.local
   resolution: "refstudio@workspace:."
   dependencies:
+    "@reduxjs/toolkit": ^1.9.5
     "@tauri-apps/api": ^1.2.0
     "@tauri-apps/cli": ^1.2.3
     "@tiptap/extension-code-block-lowlight": ^2.0.3
@@ -4796,6 +4898,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     react-drag-drop-files: ^2.3.10
+    react-redux: ^8.0.5
     react-resizable-panels: ^0.0.42
     tailwindcss: ^3.3.2
     tiptap-markdown: ^0.7.2
@@ -4820,6 +4923,13 @@ __metadata:
     define-properties: ^1.2.0
     functions-have-names: ^1.2.3
   checksum: c541687cdbdfff1b9a07f6e44879f82c66bbf07665f9a7544c5fd16acdb3ec8d1436caab01662d2fbcad403f3499d49ab0b77fbc7ef29ef961d98cc4bc9755b4
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^4.1.8":
+  version: 4.1.8
+  resolution: "reselect@npm:4.1.8"
+  checksum: a4ac87cedab198769a29be92bc221c32da76cfdad6911eda67b4d3e7136dca86208c3b210e31632eae31ebd2cded18596f0dd230d3ccc9e978df22f233b5583e
   languageName: node
   linkType: hard
 
@@ -5608,6 +5718,15 @@ __metadata:
   dependencies:
     punycode: ^2.1.0
   checksum: 7167432de6817fe8e9e0c9684f1d2de2bb688c94388f7569f7dbdb1587c9f4ca2a77962f134ec90be0cc4d004c939ff0d05acc9f34a0db39a3c797dada262633
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.0.0":
+  version: 1.2.0
+  resolution: "use-sync-external-store@npm:1.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 5c639e0f8da3521d605f59ce5be9e094ca772bd44a4ce7322b055a6f58eeed8dda3c94cabd90c7a41fb6fa852210092008afe48f7038792fd47501f33299116a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds [redux](https://react-redux.js.org/) using [redux toolkit](https://redux-toolkit.js.org/) to simplify the application data flow and closes issue #33 

**Slices**

With this change, two slices were created: 

* `selection` - store for the selected text in the editor
* `openedFiles` - store for the opened files, and the selected file.

**UI Component Changes**

With the addition of the redux store, the following components were changed/added:
* `TipTapEditor` - to dispatch selection changes (debounced)
* `AIView` - use the store instead of props
* `FoldersView` - use the store instead of props
* `CenterPaneView` - rewrite to display different types of center views depending on the selected file
* `OpenedFilesView` - added to display and manage the selected files. It allow file selection and close

**Current UI**

![image](https://github.com/refstudio/refstudio/assets/174127/a9f12237-0685-46a5-9092-8d0151ade780)
