### PR TITLE
chore: add ruff for Python linting

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,3 +4,4 @@
 yarn lint:check
 # yarn test
 
+ruff src-python

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,4 +4,4 @@
 yarn lint:check
 # yarn test
 
-poetry run ruff src-python
+yarn pylint:check

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,4 +4,4 @@
 yarn lint:check
 # yarn test
 
-ruff src-python
+poetry run ruff src-python

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "fmt": "prettier --config package.json --write '**/*'",
+    "pylint:check": "poetry run ruff check ./src-python",
+    "pylint:fix": "poetry run ruff check --fix ./src-python",
     "lint:check": "eslint --ext .js,.ts,.tsx ./src",
     "lint:fix": "eslint --fix --ext .js,.ts,.tsx ./src",
     "preview": "vite preview",

--- a/poetry.lock
+++ b/poetry.lock
@@ -265,6 +265,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "ruff"
+version = "0.0.270"
+description = "An extremely fast Python linter, written in Rust."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "setuptools"
 version = "67.8.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -332,7 +340,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9,<3.12"
-content-hash = "1d4b0076972f76dc3ebf98f8876610bc1eb772868211b373c39f2c54eb1e96b9"
+content-hash = "5b98d51e3760f855cbc4a81719ac3d8a81d19916f03759a6227655247aef9561"
 
 [metadata.files]
 altgraph = [
@@ -436,6 +444,25 @@ pyinstaller-hooks-contrib = [
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
     {file = "pywin32_ctypes-0.2.0-py2.py3-none-any.whl", hash = "sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"},
+]
+ruff = [
+    {file = "ruff-0.0.270-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:f74c4d550f7b8e808455ac77bbce38daafc458434815ba0bc21ae4bdb276509b"},
+    {file = "ruff-0.0.270-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:643de865fd35cb76c4f0739aea5afe7b8e4d40d623df7e9e6ea99054e5cead0a"},
+    {file = "ruff-0.0.270-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eca02e709b3308eb7255b5f74e779be23b5980fca3862eae28bb23069cd61ae4"},
+    {file = "ruff-0.0.270-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3ed3b198768d2b3a2300fb18f730cd39948a5cc36ba29ae9d4639a11040880be"},
+    {file = "ruff-0.0.270-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:739495d2dbde87cf4e3110c8d27bc20febf93112539a968a4e02c26f0deccd1d"},
+    {file = "ruff-0.0.270-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:08188f8351f4c0b6216e8463df0a76eb57894ca59a3da65e4ed205db980fd3ae"},
+    {file = "ruff-0.0.270-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0827b074635d37984fc98d99316bfab5c8b1231bb83e60dacc83bd92883eedb4"},
+    {file = "ruff-0.0.270-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0d61ae4841313f6eeb8292dc349bef27b4ce426e62c36e80ceedc3824e408734"},
+    {file = "ruff-0.0.270-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0eb412f20e77529a01fb94d578b19dcb8331b56f93632aa0cce4a2ea27b7aeba"},
+    {file = "ruff-0.0.270-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b775e2c5fc869359daf8c8b8aa0fd67240201ab2e8d536d14a0edf279af18786"},
+    {file = "ruff-0.0.270-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:21f00e47ab2308617c44435c8dfd9e2e03897461c9e647ec942deb2a235b4cfd"},
+    {file = "ruff-0.0.270-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0bbfbf6fd2436165566ca85f6e57be03ed2f0a994faf40180cfbb3604c9232ef"},
+    {file = "ruff-0.0.270-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8af391ef81f7be960be10886a3c1aac0b298bde7cb9a86ec2b05faeb2081ce6b"},
+    {file = "ruff-0.0.270-py3-none-win32.whl", hash = "sha256:b4c037fe2f75bcd9aed0c89c7c507cb7fa59abae2bd4c8b6fc331a28178655a4"},
+    {file = "ruff-0.0.270-py3-none-win_amd64.whl", hash = "sha256:0012f9b7dc137ab7f1f0355e3c4ca49b562baf6c9fa1180948deeb6648c52957"},
+    {file = "ruff-0.0.270-py3-none-win_arm64.whl", hash = "sha256:9613456b0b375766244c25045e353bc8890c856431cd97893c97b10cc93bd28d"},
+    {file = "ruff-0.0.270.tar.gz", hash = "sha256:95db07b7850b30ebf32b27fe98bc39e0ab99db3985edbbf0754d399eb2f0e690"},
 ]
 setuptools = [
     {file = "setuptools-67.8.0-py3-none-any.whl", hash = "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ grobid-tei-xml = "^0.1.3"
 [tool.poetry.group.dev.dependencies]
 pyinstaller = "^5.11.0"
 ipython = "^8.13.2"
+ruff = "^0.0.270"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src-python/main.py
+++ b/src-python/main.py
@@ -1,9 +1,10 @@
-from argparse import ArgumentParser
-from pathlib import Path
-from grobid_tei_xml.types import GrobidDocument
-import grobid_tei_xml
 import json
 import sys
+from argparse import ArgumentParser
+from pathlib import Path
+
+import grobid_tei_xml
+from grobid_tei_xml.types import GrobidDocument
 
 
 def parse_xml_file(filepath: Path) -> GrobidDocument:
@@ -24,7 +25,7 @@ def main(text: str):
     try:
         data = {"num_words": get_word_count(text)}
         print(json.dumps(data))
-    except:
+    except Exception:
         print("Error processing text", file=sys.stderr)
 
 


### PR DESCRIPTION
- https://github.com/refstudio/refstudio/issues/26

Adding ruff with its default settings as a pre-push hook for now. I imagine we'll want to tweak some settings later (like line length).

Once this is merged, devs will need to run:
```
$ poetry install
```