### PR TITLE
Open devtools if env DEV_TOOLS is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,40 @@
-# refstudio
+# Reference Studio
 
-Reference Studio
 
 ## Setup
-```
-$ npm install yarn
+
+```bash
 $ yarn install
 ```
+
+### Python
 
 For running the python sidecar, you will need to [install poetry](https://python-poetry.org/).
 
 Once you have poetry installed, you can install the python dependencies via:
-```
+```bash
 $ poetry install
 ```
 
 To compile the python sidecar as a binary:
-```
+```bash
 $ yarn python
 ```
 This will generate the binary at `src-tauri/bin/python` and append the appropriate [target triple](https://tauri.app/v1/guides/building/sidecar) required by Tauri.
 
+
+## Development
+
 You should then be able to launch the app via:
-```
+```bash
 $ yarn tauri dev
+$ yarn tauri:dev
 ```
 
+### Debug
 
+To automatically open the browser devtools you can launch the app via:
 
+```bash
+$ yarn tauri:dev:debug
+```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint:fix": "eslint --fix --ext .js,.ts,.tsx ./src",
     "preview": "vite preview",
     "python": "poetry run pyinstaller src-python/main.py --noconfirm --distpath src-tauri/bin/python && bash scripts/move_binary.sh",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "tauri:dev": "tauri dev",
+    "tauri:dev:debug": "DEV_TOOLS=1 tauri dev"
   },
   "dependencies": {
     "@tauri-apps/api": "^1.2.0",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,13 +16,14 @@ fn interact_with_ai(selection: &str) -> String {
 }
 
 use tauri::Manager;
+use std::env;
 
 fn main() {
     tauri::Builder::default()
         .setup(|app| {
             #[cfg(debug_assertions)] // only include this code on debug builds
             {
-                let dev_tools_visible = false;
+                let dev_tools_visible = env::var("DEV_TOOLS").is_ok();
                 if dev_tools_visible {
                     app.get_window("main").unwrap().open_devtools();
                 };


### PR DESCRIPTION
This PR adds two startup scripts for tauri dev 

   - `yarn tauri:dev` to run the Tauri app in dev mode (for consistence with the other command)
   - `yarn tauri:dev:debug` to run the Tauri app in dev mode **with the developer tools opened** 

This feature is implemented by checking for the presence of the environment variable `DEV_TOOLS` (in `main.rs`). 

Also updates the `README.md` file with these instructions.

The advantage of this solution (over a global shortcut) is that it simplifies the discoverability of the command by having it listed in the package.json startup scripts. And we can easily extend the available options by adding new scripts.


Related to #38 