### PR TITLE
fix: allow flexboxes to scroll

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,28 +27,28 @@ function App() {
 
   return (
     <PanelGroup autoSaveId="refstudio" direction="horizontal">
-      <Panel defaultSize={20} collapsible className="p-4 flex flex-col h-full w-full">
+      <Panel defaultSize={20} collapsible className="p-4">
         <FoldersView onClick={handleFolderClick} />
       </Panel>
       <VerticalResizeHandle />
 
-      <Panel defaultSize={60} className="p-3 flex flex-col h-full w-full">
+      <Panel defaultSize={60}>
         <CenterPaneView onSelectionChange={setSelection} editorRef={editorRef} file={selectedFile} />
       </Panel>
 
       <VerticalResizeHandle />
       <Panel>
         <PanelGroup autoSaveId="rs-right-sidebar" direction="vertical">
-          <Panel className="p-3 flex flex-col h-full w-full">
+          <Panel className="p-3">
             <ReferencesView onRefClicked={handleReferenceClicked} />
           </Panel>
           <HorizontalResizeHandle />
-          <Panel className="p-3 flex flex-col h-full w-full">
+          <Panel className="p-3">
             <AIView selection={debouncedSelection} />
           </Panel>
         </PanelGroup>
       </Panel>
-    </PanelGroup>
+    </PanelGroup >
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,23 +27,23 @@ function App() {
 
   return (
     <PanelGroup autoSaveId="refstudio" direction="horizontal">
-      <Panel defaultSize={20} collapsible className="overflow-scroll p-4">
+      <Panel defaultSize={20} collapsible className="p-4 flex flex-col h-full w-full">
         <FoldersView onClick={handleFolderClick} />
       </Panel>
       <VerticalResizeHandle />
 
-      <Panel defaultSize={60} className="overflow-scroll p-3">
+      <Panel defaultSize={60} className="p-3 flex flex-col h-full w-full">
         <CenterPaneView onSelectionChange={setSelection} editorRef={editorRef} file={selectedFile} />
       </Panel>
 
       <VerticalResizeHandle />
       <Panel>
         <PanelGroup autoSaveId="rs-right-sidebar" direction="vertical">
-          <Panel className="overflow-scroll p-3">
+          <Panel className="p-3 flex flex-col h-full w-full">
             <ReferencesView onRefClicked={handleReferenceClicked} />
           </Panel>
           <HorizontalResizeHandle />
-          <Panel className="overflow-scroll p-3">
+          <Panel className="p-3 flex flex-col h-full w-full">
             <AIView selection={debouncedSelection} />
           </Panel>
         </PanelGroup>

--- a/src/TipTapEditor/MenuBar.css
+++ b/src/TipTapEditor/MenuBar.css
@@ -1,6 +1,5 @@
-
 .toolbar {
-  @apply flex items-stretch p-1 mb-4;
+  @apply flex items-stretch p-1;
   @apply bg-slate-100;
   @apply rounded-t-xl;
 }
@@ -8,7 +7,7 @@
 .toolbar button.toolbar-item {
   @apply !bg-transparent;
   @apply flex items-center;
-  @apply border-0 p-2 rounded-lg cursor-pointer
+  @apply cursor-pointer rounded-lg border-0 p-2;
 }
 
 .toolbar button.toolbar-item:disabled {
@@ -32,7 +31,6 @@
 
 .toolbar button.toolbar-item.active {
   @apply !bg-slate-200;
-  
 }
 
 .toolbar button.toolbar-item.active i {
@@ -48,7 +46,6 @@
   background-color: #eee;
   margin: 0 4px;
 }
-
 
 .toolbar i.undo {
   background-image: url(images/icons/arrow-counterclockwise.svg);

--- a/src/TipTapEditor/MenuBar.tsx
+++ b/src/TipTapEditor/MenuBar.tsx
@@ -35,7 +35,7 @@ export function MenuBar({ editor }: { editor: Editor }) {
   }, [editor, refreshToggle]);
 
   return (
-    <menu className="toolbar menu-bar">
+    <menu className="toolbar menu-bar m-5 mb-0">
       <button
         onClick={() => editor.chain().focus().undo().run()}
         disabled={!editor.can().chain().focus().undo().run()}

--- a/src/TipTapEditor/TipTapEditor.tsx
+++ b/src/TipTapEditor/TipTapEditor.tsx
@@ -36,9 +36,9 @@ export function TipTapEditor({ editorRef, editorContent, onSelectionChange }: Ed
   if (!editor) return <div>...</div>;
 
   return (
-    <div className="tiptap-editor">
+    <div className="tiptap-editor flex flex-col h-full w-full">
       <MenuBar editor={editor} />
-      <EditorContent className="px-2" editor={editor} />
+      <EditorContent className="px-2 flex-1 overflow-scroll pt-4" editor={editor} />
     </div>
   );
 }

--- a/src/TipTapEditor/TipTapEditor.tsx
+++ b/src/TipTapEditor/TipTapEditor.tsx
@@ -36,9 +36,9 @@ export function TipTapEditor({ editorRef, editorContent, onSelectionChange }: Ed
   if (!editor) return <div>...</div>;
 
   return (
-    <div className="tiptap-editor flex flex-col h-full w-full">
+    <div className="tiptap-editor flex flex-col h-full">
       <MenuBar editor={editor} />
-      <EditorContent className="px-2 flex-1 overflow-scroll pt-4" editor={editor} />
+      <EditorContent className="pt-4 pl-5 pr-2 flex-1 overflow-scroll" editor={editor} />
     </div>
   );
 }

--- a/src/views/AIView.tsx
+++ b/src/views/AIView.tsx
@@ -10,18 +10,20 @@ export function AIView({ selection }: { selection: string | null }) {
   }, [selection]);
 
   return (
-    <div>
+    <>
       <h1>AI Interactions</h1>
-      <p className="my-4 italic">Select some text in the editor to see it here.</p>
+      <div className='flex-1 overflow-scroll'>
+        <p className="my-4 italic">Select some text in the editor to see it here.</p>
 
-      {selection && (
-        <div className="flex flex-col gap-4">
-          <div className="border border-yellow-100 bg-yellow-50 p-4">{selection}</div>
-          <strong>REPLY</strong>
-          <div className="border border-green-100 bg-green-50 p-4">{reply}</div>
-        </div>
-      )}
-    </div>
+        {selection && (
+          <div className="flex flex-col gap-4">
+            <div className="border border-yellow-100 bg-yellow-50 p-4">{selection}</div>
+            <strong>REPLY</strong>
+            <div className="border border-green-100 bg-green-50 p-4">{reply}</div>
+          </div>
+        )}
+      </div>
+    </>
   );
 }
 

--- a/src/views/AIView.tsx
+++ b/src/views/AIView.tsx
@@ -10,7 +10,7 @@ export function AIView({ selection }: { selection: string | null }) {
   }, [selection]);
 
   return (
-    <>
+    <div className='flex flex-col h-full w-full'>
       <h1>AI Interactions</h1>
       <div className='flex-1 overflow-scroll'>
         <p className="my-4 italic">Select some text in the editor to see it here.</p>
@@ -23,7 +23,7 @@ export function AIView({ selection }: { selection: string | null }) {
           </div>
         )}
       </div>
-    </>
+    </div>
   );
 }
 

--- a/src/views/CenterPaneView.tsx
+++ b/src/views/CenterPaneView.tsx
@@ -25,12 +25,12 @@ export function CenterPaneView({ file, ...props }: CenterPaneViewProps) {
     }
   }, [file]);
 
-  if (loading) return <div><strong>Loading...</strong></div>;
+  if (loading) return <div className="p-3"><strong>Loading...</strong></div>;
 
   if (file && isTipTap(file)) return <TipTapEditor {...props} editorContent={content} />;
 
   return (
-    <div>
+    <div className='p-3'>
       <strong>FILE:</strong>
       <div>{file?.name} at <code>{file?.path}</code></div>
     </div>

--- a/src/views/FoldersView.tsx
+++ b/src/views/FoldersView.tsx
@@ -37,7 +37,7 @@ export function FoldersView({ onClick }: { onClick?: (fileEntry: FileEntry) => v
 
   return (
     <div className="flex h-full flex-col justify-between">
-      <div>
+      <div className='flex-1 flex flex-col h-full w-full'>
         <h1 className="flex flex-col">
           Project X<code className="block text-xs font-normal">{BASE_DIR}</code>
         </h1>
@@ -58,7 +58,7 @@ interface FileTreeBaseProps {
 
 const FileTree = ({ files, root, ...props }: FileTreeBaseProps) => {
   return (
-    <div>
+    <div className="flex-1 overflow-scroll">
       <ul
         className={cx('', {
           'ml-6': !root,

--- a/src/views/ReferencesView.tsx
+++ b/src/views/ReferencesView.tsx
@@ -2,28 +2,30 @@ import { ReferenceItem } from '../types/ReferenceItem';
 
 export function ReferencesView({ onRefClicked }: { onRefClicked?: (item: ReferenceItem) => void }) {
   return (
-    <div>
+    <>
       <h1>References</h1>
-      <p className="my-4 italic">Click on a reference to add it to the document.</p>
+      <div className='flex-1 overflow-scroll'>
+        <p className="my-4 italic">Click on a reference to add it to the document.</p>
 
-      <ul className="divide-y-2 border">
-        {REFS_DATABASE.map((reference) => (
-          <li
-            key={reference.id}
-            className="mb-0 cursor-pointer p-1 hover:bg-slate-100"
-            onClick={() => onRefClicked && onRefClicked(reference)}
-          >
-            <strong>{reference.id}</strong> - {reference.title}
-            <br />
-            <small>
-              <em>
-                {reference.author}, {reference.year} by {reference.publisher}
-              </em>
-            </small>
-          </li>
-        ))}
-      </ul>
-    </div>
+        <ul className="divide-y-2 border">
+          {REFS_DATABASE.map((reference) => (
+            <li
+              key={reference.id}
+              className="mb-0 cursor-pointer p-1 hover:bg-slate-100"
+              onClick={() => onRefClicked && onRefClicked(reference)}
+            >
+              <strong>{reference.id}</strong> - {reference.title}
+              <br />
+              <small>
+                <em>
+                  {reference.author}, {reference.year} by {reference.publisher}
+                </em>
+              </small>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
   );
 }
 

--- a/src/views/ReferencesView.tsx
+++ b/src/views/ReferencesView.tsx
@@ -2,7 +2,7 @@ import { ReferenceItem } from '../types/ReferenceItem';
 
 export function ReferencesView({ onRefClicked }: { onRefClicked?: (item: ReferenceItem) => void }) {
   return (
-    <>
+    <div className='flex flex-col h-full w-full'>
       <h1>References</h1>
       <div className='flex-1 overflow-scroll'>
         <p className="my-4 italic">Click on a reference to add it to the document.</p>
@@ -25,7 +25,7 @@ export function ReferencesView({ onRefClicked }: { onRefClicked?: (item: Referen
           ))}
         </ul>
       </div>
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
**Problem**
Panel components have an `overflow` property set to `hidden`, that is why adding the tailwind `overflow-scroll` class does not make the views scrollable. #35 
**Solution**
Remove `overflow-scroll` class and make views flexes, with a scrollable child

https://github.com/refstudio/refstudio/assets/58954208/ee89dc39-8969-4a60-8b5c-59f8a1fcc2ea

