### PR TITLE
bug: Update binary build script to first remove existing binary (#70)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:check": "eslint --ext .js,.ts,.tsx ./src",
     "lint:fix": "eslint --fix --ext .js,.ts,.tsx ./src",
     "preview": "vite preview",
-    "python": "poetry run pyinstaller --onefile --noconfirm --hidden-import torch --collect-data torch --recursive-copy-metadata torch --hidden-import pyarrow --collect-data pyarrow --recursive-copy-metadata pyarrow --collect-binaries pyarrow --collect-submodules pyarrow --recursive-copy-metadata tqdm --recursive-copy-metadata sentence-transformers --distpath src-tauri/bin/python python/main.py && bash scripts/move_binary.sh",
+    "python": "bash scripts/remove_binary.sh && poetry run pyinstaller --onefile --noconfirm --hidden-import torch --collect-data torch --recursive-copy-metadata torch --hidden-import pyarrow --collect-data pyarrow --recursive-copy-metadata pyarrow --collect-binaries pyarrow --collect-submodules pyarrow --recursive-copy-metadata tqdm --recursive-copy-metadata sentence-transformers --distpath src-tauri/bin/python python/main.py && bash scripts/move_binary.sh",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:dev:debug": "DEV_TOOLS=1 tauri dev"

--- a/scripts/remove_binary.sh
+++ b/scripts/remove_binary.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Remove binary files from the repository
+rm -rf src-tauri/bin/python
+rm -rf build
+rm *.spec


### PR DESCRIPTION
- #70 

Trying to rebuild the binary while some of these files are still around results in the new binary being created from older specs.

Running `yarn python` should take ~2 minutes to complete.

After running this script, there should be a single `main` file at `src-tauri/bin/python/main-aarch64-apple-darwin/` (the last directory name will be slightly different if you are not on a Mac).