### PR TITLE
fix: prefix reset project storage directories with a dot

### DIFF
--- a/scripts/reset_uploads.sh
+++ b/scripts/reset_uploads.sh
@@ -3,6 +3,6 @@
 PROJECT_DIR="/Users/greg/Library/Application Support/com.tauri.dev/project-x"
 
 rm "$PROJECT_DIR/uploads/"*.pdf
-rm -rf "$PROJECT_DIR/grobid"
-rm -rf "$PROJECT_DIR/storage"
+rm -rf "$PROJECT_DIR/.grobid"
+rm -rf "$PROJECT_DIR/.storage"
 rm -rf "$PROJECT_DIR/.lancedb"


### PR DESCRIPTION
Forgot to update `reset_uploads.sh` as part of #72 and #73