### PR TITLE
refactor: use internal FileEntry type

### DIFF
--- a/src/atoms/openFilesState.ts
+++ b/src/atoms/openFilesState.ts
@@ -1,7 +1,7 @@
-import { FileEntry } from '@tauri-apps/api/fs';
 import { atom, Getter } from 'jotai';
 
 import { isNonNullish } from '../lib/isNonNullish';
+import { FileEntry } from '../types/FileEntry';
 
 export type PaneId = 'LEFT' | 'RIGHT';
 export const DEFAULT_PANE: PaneId = 'LEFT';

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -1,7 +1,7 @@
-import { FileEntry } from '@tauri-apps/api/fs';
 import { VscFile, VscFolder } from 'react-icons/vsc';
 
 import { cx } from '../cx';
+import { FileEntry } from '../types/FileEntry';
 
 interface FileTreeBaseProps {
   root?: boolean;
@@ -26,10 +26,11 @@ function FileTreeNode({ file, onClick, rightAction, selectedFiles }: FileTreeBas
   if (!file) {
     return null;
   }
-  const isFolder = !!file.children;
+
+  const { isFolder } = file;
 
   // Hide DOT_FILES
-  if (file.name?.startsWith('.')) {
+  if (file.name.startsWith('.')) {
     return null;
   }
 
@@ -57,7 +58,7 @@ function FileTreeNode({ file, onClick, rightAction, selectedFiles }: FileTreeBas
       </div>
 
       {isFolder && (
-        <FileTree files={file.children!} rightAction={rightAction} selectedFiles={selectedFiles} onClick={onClick} />
+        <FileTree files={file.children} rightAction={rightAction} selectedFiles={selectedFiles} onClick={onClick} />
       )}
     </li>
   );

--- a/src/panels/ExplorerPanel.tsx
+++ b/src/panels/ExplorerPanel.tsx
@@ -1,4 +1,3 @@
-import { FileEntry } from '@tauri-apps/api/fs';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect, useState } from 'react';
 import { VscSplitHorizontal } from 'react-icons/vsc';
@@ -16,6 +15,7 @@ import { PanelSection } from '../components/PanelSection';
 import { PanelWrapper } from '../components/PanelWrapper';
 import { readAllProjectFiles } from '../filesystem';
 import { isNonNullish } from '../lib/isNonNullish';
+import { FileEntry } from '../types/FileEntry';
 
 export function ExplorerPanel() {
   const left = useAtomValue(leftPaneAtom);

--- a/src/panels/MainPanel.tsx
+++ b/src/panels/MainPanel.tsx
@@ -1,4 +1,3 @@
-import { FileEntry } from '@tauri-apps/api/fs';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useCallback } from 'react';
 import { Panel, PanelGroup } from 'react-resizable-panels';
@@ -7,6 +6,7 @@ import { activateFileInPaneAtom, closeFileInPaneAtom, leftPaneAtom, rightPaneAto
 import { TabPane } from '../components/TabPane';
 import { VerticalResizeHandle } from '../components/VerticalResizeHandle';
 import { EditorAPI } from '../types/EditorAPI';
+import { FileEntry } from '../types/FileEntry';
 import { PdfViewerAPI } from '../types/PdfViewerAPI';
 import { EmptyView } from '../views/EmptyView';
 import { PdfViewer } from '../views/PdfViewer';
@@ -75,7 +75,7 @@ export function MainPanelPane({
 }: MainPanelPaneProps & MainPanelProps) {
   const items = files.map((file) => ({
     key: file.path,
-    text: file.name ?? '',
+    text: file.name,
     value: file.path,
   }));
 

--- a/src/types/FileEntry.ts
+++ b/src/types/FileEntry.ts
@@ -1,0 +1,17 @@
+interface FileEntryBase {
+  name: string;
+  path: string;
+}
+
+interface FileFileEntry extends FileEntryBase {
+  isFile: true;
+  isFolder: false;
+}
+
+interface FolderFileEntry extends FileEntryBase {
+  isFile: false;
+  isFolder: true;
+  children: FileEntry[];
+}
+
+export type FileEntry = FileFileEntry | FolderFileEntry;

--- a/src/views/PdfViewer.tsx
+++ b/src/views/PdfViewer.tsx
@@ -1,13 +1,13 @@
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
 import 'react-pdf/dist/esm/Page/TextLayer.css';
 
-import { FileEntry } from '@tauri-apps/api/fs';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Document, Page, pdfjs } from 'react-pdf';
 
 import { readFileEntryAsBinary } from '../filesystem';
 import { useDebouncedCallback } from '../hooks/useDebouncedCallback';
 import { usePromise } from '../hooks/usePromise';
+import { FileEntry } from '../types/FileEntry';
 import { PdfViewerAPI } from '../types/PdfViewerAPI';
 
 pdfjs.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.js', import.meta.url).toString();

--- a/src/views/TextView.tsx
+++ b/src/views/TextView.tsx
@@ -1,7 +1,7 @@
-import { FileEntry } from '@tauri-apps/api/fs';
 import { useEffect, useState } from 'react';
 
 import { readFileEntryAsText } from '../filesystem';
+import { FileEntry } from '../types/FileEntry';
 
 export function TextView({
   file,

--- a/src/views/TipTapView.tsx
+++ b/src/views/TipTapView.tsx
@@ -1,10 +1,10 @@
-import { FileEntry } from '@tauri-apps/api/fs';
 import { useCallback } from 'react';
 
 import { readFileEntryAsText } from '../filesystem';
 import { usePromise } from '../hooks/usePromise';
 import { TipTapEditor } from '../TipTapEditor/TipTapEditor';
 import { EditorAPI } from '../types/EditorAPI';
+import { FileEntry } from '../types/FileEntry';
 
 export function TipTapView({
   file,


### PR DESCRIPTION
Fixes #75 
** Problem **
Our code should not rely on the tauri `FileEntry` type. Moreover, this type lacks some useful fields like `isFolder`
** Solution **
Create our own internal `FileEntry` type with a discriminating union. The tauri type should only appear in the interface (`filesystem.ts`), which then converts it to our internal type, which is used acrossed the rest of the app