### PR TITLE
feat: save references in local storage

### DIFF
--- a/src/atoms/referencesState.ts
+++ b/src/atoms/referencesState.ts
@@ -1,4 +1,5 @@
 import { atom } from 'jotai';
+import { atomWithStorage } from 'jotai/utils';
 
 import { ReferenceItem } from '../types/ReferenceItem';
 
@@ -8,7 +9,7 @@ type ReferencesState = Record<string, ReferenceItem>;
  * INTERNAL ATOMS
  */
 // This is the internal representation of the references and is not exposed so that all business logic lives in this file to enable us to easily change the structure and/or switch to another state management library
-const referencesAtom = atom<ReferencesState>({});
+const referencesAtom = atomWithStorage<ReferencesState>('references', {});
 
 /**
  * EXTERNAL ATOMS


### PR DESCRIPTION
Fixes #96 
Save references in local storage so that restarting/reloading the app does not reset the references list