### PR TITLE
fix: use home variable in script to reset uploads

### DIFF
--- a/scripts/remove_binary.sh
+++ b/scripts/remove_binary.sh
@@ -3,6 +3,4 @@
 # Remove binary files from the repository
 rm -rf src-tauri/bin/python
 rm -rf build
-
-# Ensure main.spec exists before removing
-touch main.spec && rm main.spec
+rm -f main.spec

--- a/scripts/reset_uploads.sh
+++ b/scripts/reset_uploads.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-PROJECT_DIR="~/Library/Application Support/com.tauri.dev/project-x"
+PROJECT_DIR="$HOME/Library/Application Support/com.tauri.dev/project-x"
 
-rm "$PROJECT_DIR/uploads/"*.pdf
+rm -f "$PROJECT_DIR/uploads/"*.pdf
 rm -rf "$PROJECT_DIR/.grobid"
 rm -rf "$PROJECT_DIR/.storage"
 rm -rf "$PROJECT_DIR/.lancedb"


### PR DESCRIPTION
Fixes #98 

- use `$HOME` instead of `~` in the path to get the valid path
- add `-f` to `rm "$PROJECT_DIR/uploads/"*.pdf` so that the script does not fail when the `uploads` directory is empty