### PR TITLE
fix: disallow transparent text in the editor

### DIFF
--- a/src/TipTapEditor/TipTapEditor.tsx
+++ b/src/TipTapEditor/TipTapEditor.tsx
@@ -9,7 +9,7 @@ import { EditorAPI } from '../types/EditorAPI';
 import { MenuBar } from './MenuBar';
 import { ReferenceNode } from './ReferenceNode/ReferenceNode';
 import { getReferenceLabel } from './ReferenceNode/ReferencesList';
-import { EDITOR_EXTENSIONS, INITIAL_CONTENT } from './TipTapEditorConfigs';
+import { EDITOR_EXTENSIONS, INITIAL_CONTENT, transformPasted } from './TipTapEditorConfigs';
 
 interface EditorProps {
   editorRef: React.MutableRefObject<EditorAPI | null>;
@@ -31,8 +31,10 @@ export function TipTapEditor({ editorRef, editorContent }: EditorProps) {
           const text = newEditor.view.state.doc.textBetween(from, to);
           setSelection(text);
         },
-      }),
-    );
+      editorProps: {
+        transformPasted,
+      },
+    });
   }, [editorContent, setSelection]);
 
   useEffect(() => {

--- a/src/TipTapEditor/TipTapEditorConfigs.tsx
+++ b/src/TipTapEditor/TipTapEditorConfigs.tsx
@@ -91,8 +91,8 @@ export function transformPasted(slice: Slice) {
 
 function stripTransparentMarksFromFragment(fragment: Fragment) {
   const updatedNodes: Node[] = [];
-  fragment.forEach(node => {
-    updatedNodes.push(node.mark(node.marks.filter(mark => mark.attrs.color !== 'transparent')));
+  fragment.forEach((node) => {
+    updatedNodes.push(node.mark(node.marks.filter((mark) => mark.attrs.color !== 'transparent')));
   });
   return Fragment.fromArray(updatedNodes);
 }

--- a/src/TipTapEditor/TipTapEditorConfigs.tsx
+++ b/src/TipTapEditor/TipTapEditorConfigs.tsx
@@ -2,6 +2,7 @@ import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
 import Color from '@tiptap/extension-color';
 import ListItem from '@tiptap/extension-list-item';
 import TextStyle from '@tiptap/extension-text-style';
+import { Fragment, Node, Slice } from '@tiptap/pm/model';
 import { Extensions } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import markdown from 'highlight.js/lib/languages/markdown';
@@ -15,12 +16,6 @@ import { ReferenceNode } from './ReferenceNode/ReferenceNode';
 lowlight.registerLanguage('markdown', markdown);
 
 export const EDITOR_EXTENSIONS: Extensions = [
-  // Custom extensions
-  CollapsibleBlockNode,
-  CollapsibleBlockContentNode,
-  CollapsibleBlockSummaryNode,
-  ReferenceNode,
-
   Markdown,
   CodeBlockLowlight.configure({
     lowlight,
@@ -37,6 +32,12 @@ export const EDITOR_EXTENSIONS: Extensions = [
       keepAttributes: false, // TODO : Making this as `false` becase marks are not preserved when I try to preserve attrs, awaiting a bit of help
     },
   }),
+
+  // Custom extensions
+  CollapsibleBlockNode,
+  CollapsibleBlockContentNode,
+  CollapsibleBlockSummaryNode,
+  ReferenceNode,
 ];
 export const INITIAL_CONTENT = `
   <h2>Hi there,</h2>
@@ -83,3 +84,15 @@ export const INITIAL_CONTENT = `
     — Mom
   </blockquote>
 `;
+
+export function transformPasted(slice: Slice) {
+  return new Slice(stripTransparentMarksFromFragment(slice.content), slice.openStart, slice.openEnd);
+}
+
+function stripTransparentMarksFromFragment(fragment: Fragment) {
+  const updatedNodes: Node[] = [];
+  fragment.forEach(node => {
+    updatedNodes.push(node.mark(node.marks.filter(mark => mark.attrs.color !== 'transparent')));
+  });
+  return Fragment.fromArray(updatedNodes);
+}


### PR DESCRIPTION
Fixes #115 
Removes the `color: 'transparent'` attribute when pasting content in the editor