### PR TITLE
fix: add back style rules for ordered and unordered lists

### DIFF
--- a/src/TipTapEditor/TipTapEditor.css
+++ b/src/TipTapEditor/TipTapEditor.css
@@ -5,6 +5,19 @@
   @apply mx-1 my-1 rounded-lg bg-gray-200 px-2 py-1 hover:bg-gray-500 hover:text-white;
 }
 
+.tiptap-editor ul,
+ol {
+  @apply pl-3;
+}
+
+.tiptap-editor ul > li {
+  @apply list-disc;
+}
+
+.tiptap-editor ol > li {
+  @apply list-decimal;
+}
+
 .tiptap-editor .ProseMirror-focused {
   outline: none;
 }


### PR DESCRIPTION
Fixes #117 
Adds CSS rules to add bullet points/numbers for unordered and ordered list
<img width="1512" alt="image" src="https://github.com/refstudio/refstudio/assets/58954208/4b3fd92e-82c7-47cb-8897-3ccb210cc549">
