### PR TITLE
feat: 131 open editable files in the left and non editable ex pdfs in the right

### DIFF
--- a/src/atoms/fileActions.test.ts
+++ b/src/atoms/fileActions.test.ts
@@ -234,9 +234,6 @@ describe('fileActions', () => {
   });
 });
 
-const PDF_FILE = makeFile('file.pdf');
-const TXT_FILE = makeFile('file.txt');
-
 function makeFile(name: string, extension?: string): FileFileEntry {
   name = extension ? name + '.' + extension : name;
   return {

--- a/src/atoms/fileActions.test.ts
+++ b/src/atoms/fileActions.test.ts
@@ -1,0 +1,41 @@
+import { act, renderHook } from '@testing-library/react';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { describe, expect, test } from 'vitest';
+
+import { fileEntryAtom } from './core/fileEntry';
+import { openFileAtom, rightPaneAtom } from './fileActions';
+import { FileFileEntry } from './types/FileEntry';
+import { PaneId } from './types/PaneGroup';
+
+const pdfFile: FileFileEntry = {
+  name: 'file.pdf',
+  path: './file.pdf',
+  fileExtension: 'pdf',
+  isFolder: false,
+  isDotfile: false,
+  isFile: true,
+};
+describe('fileActions', () => {
+  test('should open PDF file as fileEntry', () => {
+    const { result } = renderHook(() => useSetAtom(openFileAtom));
+    const setOpenFile = result.current;
+
+    act(() => setOpenFile(pdfFile));
+
+    const { result: fileEntryResult } = renderHook(() => useAtomValue(fileEntryAtom));
+
+    expect(fileEntryResult.current.has(pdfFile.path)).toBe(true);
+    const fileEntry = fileEntryResult.current.get(pdfFile.path);
+    expect(fileEntry).toEqual({ ...pdfFile });
+  });
+
+  test('should open PDF file in the right pane', () => {
+    const { result: setOpenFileResult } = renderHook(() => useSetAtom(openFileAtom));
+    act(() => setOpenFileResult.current(pdfFile));
+
+    const { result: rightPanelResult } = renderHook(() => useAtomValue(rightPaneAtom));
+    expect(rightPanelResult.current.id).toBe(<PaneId>'RIGHT');
+    expect(rightPanelResult.current.files.length).toBe(1);
+    expect(rightPanelResult.current.files).toStrictEqual([pdfFile]);
+  });
+});

--- a/src/atoms/fileActions.test.ts
+++ b/src/atoms/fileActions.test.ts
@@ -3,11 +3,103 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { describe, expect, test } from 'vitest';
 
 import { fileEntryAtom } from './core/fileEntry';
-import { openFileAtom, rightPaneAtom } from './fileActions';
-import { FileFileEntry } from './types/FileEntry';
+import { paneGroupAtom } from './core/paneGroup';
+import { closeFileFromPaneAtom, leftPaneAtom, openFileAtom, rightPaneAtom } from './fileActions';
+import { FileFileEntry, FolderFileEntry } from './types/FileEntry';
 import { PaneId } from './types/PaneGroup';
 
-const pdfFile: FileFileEntry = {
+describe('fileActions', () => {
+  // HACK: This seems a very fragile way to reset the file atoms (maybe we can have a reset atom)
+  beforeEach(() => {
+    const { result: fileEntry } = renderHook(() => useSetAtom(fileEntryAtom));
+    const { result: paneGroup } = renderHook(() => useSetAtom(paneGroupAtom));
+    act(() => {
+      fileEntry.current(new Map());
+      paneGroup.current({
+        LEFT: {
+          openFiles: [],
+        },
+        RIGHT: {
+          openFiles: [],
+        },
+      });
+    });
+  });
+
+  test('left pane ID should be LEFT and start empty', () => {
+    const { result: pane } = renderHook(() => useAtomValue(leftPaneAtom));
+    expect(pane.current.id).toBe(<PaneId>'LEFT');
+    expect(pane.current.activeFile).toBeUndefined();
+    expect(pane.current.files.length).toBe(0);
+  });
+
+  test('right pane ID should be RIGHT and start empty', () => {
+    const { result: pane } = renderHook(() => useAtomValue(rightPaneAtom));
+    expect(pane.current.id).toBe(<PaneId>'RIGHT');
+    expect(pane.current.activeFile).toBeUndefined();
+    expect(pane.current.files.length).toBe(0);
+  });
+
+  test('should open PDF file in the right pane, and be active', () => {
+    const { result: openFile } = renderHook(() => useSetAtom(openFileAtom));
+    const { result: rightPane } = renderHook(() => useAtomValue(rightPaneAtom));
+
+    expect(rightPane.current.files.length).toBe(0);
+    act(() => openFile.current(PDF_FILE));
+
+    expect(rightPane.current.id).toBe(<PaneId>'RIGHT');
+    expect(rightPane.current.files.length).toBe(1);
+    expect(rightPane.current.files).toStrictEqual([PDF_FILE]);
+    expect(rightPane.current.activeFile).toStrictEqual(PDF_FILE);
+  });
+
+  test('should open TXT file in the left pane', () => {
+    const { result: openFile } = renderHook(() => useSetAtom(openFileAtom));
+    const { result: leftPane } = renderHook(() => useAtomValue(leftPaneAtom));
+
+    expect(leftPane.current.files.length).toBe(0);
+    act(() => openFile.current(TXT_FILE));
+
+    expect(leftPane.current.id).toBe(<PaneId>'LEFT');
+    expect(leftPane.current.files.length).toBe(1);
+    expect(leftPane.current.files).toStrictEqual([TXT_FILE]);
+    expect(leftPane.current.activeFile).toStrictEqual(TXT_FILE);
+  });
+
+  test('should close opened file in pane', () => {
+    const { result: openFile } = renderHook(() => useSetAtom(openFileAtom));
+    const { result: closeFileFromPane } = renderHook(() => useSetAtom(closeFileFromPaneAtom));
+    const { result: rightPane } = renderHook(() => useAtomValue(rightPaneAtom));
+    const { result: leftPane } = renderHook(() => useAtomValue(leftPaneAtom));
+
+    expect(leftPane.current.files.length).toBe(0);
+    expect(rightPane.current.files.length).toBe(0);
+    act(() => {
+      openFile.current(TXT_FILE);
+      openFile.current(TXT_FILE2);
+    });
+    expect(leftPane.current.files.length).toBe(2);
+
+    act(() => {
+      closeFileFromPane.current({ paneId: 'LEFT', fileId: TXT_FILE.path });
+    });
+    expect(leftPane.current.files.length).toBe(1);
+  });
+
+  test('closing active file should make another active in the same pane', () => {});
+  test('closing non-active file should keep the active file active', () => {});
+
+  test('should not open folder entries', () => {
+    const { result: openFileResult } = renderHook(() => useSetAtom(openFileAtom));
+    const { result: fileEntryResult } = renderHook(() => useAtomValue(fileEntryAtom));
+
+    expect(fileEntryResult.current.size).toBe(0);
+    act(() => openFileResult.current(FOLDER));
+    expect(fileEntryResult.current.size).toBe(0);
+  });
+});
+
+const PDF_FILE: FileFileEntry = {
   name: 'file.pdf',
   path: './file.pdf',
   fileExtension: 'pdf',
@@ -15,27 +107,30 @@ const pdfFile: FileFileEntry = {
   isDotfile: false,
   isFile: true,
 };
-describe('fileActions', () => {
-  test('should open PDF file as fileEntry', () => {
-    const { result } = renderHook(() => useSetAtom(openFileAtom));
-    const setOpenFile = result.current;
 
-    act(() => setOpenFile(pdfFile));
+const TXT_FILE: FileFileEntry = {
+  name: 'file.txt',
+  path: './file.txt',
+  fileExtension: 'txt',
+  isFolder: false,
+  isDotfile: false,
+  isFile: true,
+};
 
-    const { result: fileEntryResult } = renderHook(() => useAtomValue(fileEntryAtom));
+const TXT_FILE2: FileFileEntry = {
+  name: 'file2.txt',
+  path: './file2.txt',
+  fileExtension: 'txt',
+  isFolder: false,
+  isDotfile: false,
+  isFile: true,
+};
 
-    expect(fileEntryResult.current.has(pdfFile.path)).toBe(true);
-    const fileEntry = fileEntryResult.current.get(pdfFile.path);
-    expect(fileEntry).toEqual({ ...pdfFile });
-  });
-
-  test('should open PDF file in the right pane', () => {
-    const { result: setOpenFileResult } = renderHook(() => useSetAtom(openFileAtom));
-    act(() => setOpenFileResult.current(pdfFile));
-
-    const { result: rightPanelResult } = renderHook(() => useAtomValue(rightPaneAtom));
-    expect(rightPanelResult.current.id).toBe(<PaneId>'RIGHT');
-    expect(rightPanelResult.current.files.length).toBe(1);
-    expect(rightPanelResult.current.files).toStrictEqual([pdfFile]);
-  });
-});
+const FOLDER: FolderFileEntry = {
+  name: 'uploads',
+  path: './uploads',
+  isFolder: true,
+  isDotfile: false,
+  isFile: false,
+  children: [],
+};

--- a/src/atoms/fileActions.test.ts
+++ b/src/atoms/fileActions.test.ts
@@ -2,135 +2,259 @@ import { act, renderHook } from '@testing-library/react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { describe, expect, test } from 'vitest';
 
-import { fileEntryAtom } from './core/fileEntry';
-import { paneGroupAtom } from './core/paneGroup';
-import { closeFileFromPaneAtom, leftPaneAtom, openFileAtom, rightPaneAtom } from './fileActions';
+import {
+  activePaneAtom,
+  closeAllFilesAtom,
+  closeFileFromPaneAtom,
+  focusPaneAtom,
+  leftPaneAtom,
+  openFileAtom,
+  rightPaneAtom,
+  splitFileToPaneAtom,
+} from './fileActions';
 import { FileFileEntry, FolderFileEntry } from './types/FileEntry';
 import { PaneId } from './types/PaneGroup';
 
 describe('fileActions', () => {
-  // HACK: This seems a very fragile way to reset the file atoms (maybe we can have a reset atom)
-  beforeEach(() => {
-    const { result: fileEntry } = renderHook(() => useSetAtom(fileEntryAtom));
-    const { result: paneGroup } = renderHook(() => useSetAtom(paneGroupAtom));
-    act(() => {
-      fileEntry.current(new Map());
-      paneGroup.current({
-        LEFT: {
-          openFiles: [],
-        },
-        RIGHT: {
-          openFiles: [],
-        },
-      });
-    });
-  });
+  test('should open TXT file in the left pane, and be active', () => {
+    const { result: openFile } = renderHook(() => useSetAtom(openFileAtom));
+    const { result: leftPane } = renderHook(() => useAtomValue(leftPaneAtom));
 
-  test('left pane ID should be LEFT and start empty', () => {
-    const { result: pane } = renderHook(() => useAtomValue(leftPaneAtom));
-    expect(pane.current.id).toBe(<PaneId>'LEFT');
-    expect(pane.current.activeFile).toBeUndefined();
-    expect(pane.current.files.length).toBe(0);
-  });
+    const numFilesBefore = leftPane.current.files.length;
+    const fileToOpen = makeFile('openTXT.txt');
 
-  test('right pane ID should be RIGHT and start empty', () => {
-    const { result: pane } = renderHook(() => useAtomValue(rightPaneAtom));
-    expect(pane.current.id).toBe(<PaneId>'RIGHT');
-    expect(pane.current.activeFile).toBeUndefined();
-    expect(pane.current.files.length).toBe(0);
+    act(() => openFile.current(fileToOpen));
+
+    expect(leftPane.current.id).toBe('LEFT' as PaneId);
+    expect(leftPane.current.files.length).toBe(numFilesBefore + 1);
+    expect(leftPane.current.files).toContainEqual(fileToOpen);
+    expect(leftPane.current.activeFile).toEqual(fileToOpen);
   });
 
   test('should open PDF file in the right pane, and be active', () => {
     const { result: openFile } = renderHook(() => useSetAtom(openFileAtom));
     const { result: rightPane } = renderHook(() => useAtomValue(rightPaneAtom));
 
-    expect(rightPane.current.files.length).toBe(0);
-    act(() => openFile.current(PDF_FILE));
+    const numFilesBefore = rightPane.current.files.length;
+    const fileToOpen = makeFile('openPDF.pdf');
 
-    expect(rightPane.current.id).toBe(<PaneId>'RIGHT');
-    expect(rightPane.current.files.length).toBe(1);
-    expect(rightPane.current.files).toStrictEqual([PDF_FILE]);
-    expect(rightPane.current.activeFile).toStrictEqual(PDF_FILE);
+    act(() => openFile.current(fileToOpen));
+
+    expect(rightPane.current.id).toBe('RIGHT' as PaneId);
+    expect(rightPane.current.files.length).toBe(numFilesBefore + 1);
+    expect(rightPane.current.files).toContainEqual(fileToOpen);
+    expect(rightPane.current.activeFile).toEqual(fileToOpen);
   });
 
-  test('should open TXT file in the left pane', () => {
+  test('should not open file twice in same panel', () => {
     const { result: openFile } = renderHook(() => useSetAtom(openFileAtom));
     const { result: leftPane } = renderHook(() => useAtomValue(leftPaneAtom));
 
-    expect(leftPane.current.files.length).toBe(0);
-    act(() => openFile.current(TXT_FILE));
+    const numFilesBefore = leftPane.current.files.length;
+    const fileToOpen = makeFile('openTwice.txt');
+    act(() => {
+      openFile.current(fileToOpen);
+      openFile.current(fileToOpen);
+      openFile.current(fileToOpen);
+    });
 
-    expect(leftPane.current.id).toBe(<PaneId>'LEFT');
-    expect(leftPane.current.files.length).toBe(1);
-    expect(leftPane.current.files).toStrictEqual([TXT_FILE]);
-    expect(leftPane.current.activeFile).toStrictEqual(TXT_FILE);
+    expect(leftPane.current.files.length).toBe(numFilesBefore + 1);
   });
 
-  test('should close opened file in pane', () => {
+  test('should close opened file in LEFT pane', () => {
     const { result: openFile } = renderHook(() => useSetAtom(openFileAtom));
     const { result: closeFileFromPane } = renderHook(() => useSetAtom(closeFileFromPaneAtom));
-    const { result: rightPane } = renderHook(() => useAtomValue(rightPaneAtom));
     const { result: leftPane } = renderHook(() => useAtomValue(leftPaneAtom));
 
-    expect(leftPane.current.files.length).toBe(0);
-    expect(rightPane.current.files.length).toBe(0);
-    act(() => {
-      openFile.current(TXT_FILE);
-      openFile.current(TXT_FILE2);
-    });
-    expect(leftPane.current.files.length).toBe(2);
+    const numFilesOpened = leftPane.current.files.length;
+
+    const fileA = makeFile('closeOpenedA.txt');
+    const fileB = makeFile('closeOpenedB.txt');
 
     act(() => {
-      closeFileFromPane.current({ paneId: 'LEFT', fileId: TXT_FILE.path });
+      openFile.current(fileA);
+      openFile.current(fileB);
     });
-    expect(leftPane.current.files.length).toBe(1);
+    expect(leftPane.current.files.length).toBe(numFilesOpened + 2);
+
+    act(() => {
+      closeFileFromPane.current({ paneId: leftPane.current.id, fileId: fileA.path });
+    });
+
+    expect(leftPane.current.files.length).toBe(numFilesOpened + 1);
   });
 
-  test('closing active file should make another active in the same pane', () => {});
-  test('closing non-active file should keep the active file active', () => {});
+  test("should close file that isn't opened in pane", () => {
+    const { result: openFile } = renderHook(() => useSetAtom(openFileAtom));
+    const { result: closeFileFromPane } = renderHook(() => useSetAtom(closeFileFromPaneAtom));
+    const { result: leftPane } = renderHook(() => useAtomValue(leftPaneAtom));
+
+    const fileA = makeFile('closeNotOpenedA.txt');
+    const fileB = makeFile('closeNotOpenedB.txt');
+    const fileC = makeFile('closeNotOpenedC.txt');
+
+    act(() => {
+      openFile.current(fileA);
+      openFile.current(fileB);
+    });
+
+    expect(leftPane.current.files).toContainEqual(fileA);
+    expect(leftPane.current.files).toContainEqual(fileB);
+    expect(leftPane.current.files).not.toContainEqual(fileC);
+
+    act(() => {
+      closeFileFromPane.current({ paneId: leftPane.current.id, fileId: fileC.path });
+    });
+
+    expect(leftPane.current.files).toContainEqual(fileA);
+    expect(leftPane.current.files).toContainEqual(fileB);
+    expect(leftPane.current.files).not.toContainEqual(fileC);
+  });
+
+  test('should close all opened files with closeAllFilesAtom', () => {
+    const { result: openFile } = renderHook(() => useSetAtom(openFileAtom));
+    const { result: closeAllFiles } = renderHook(() => useSetAtom(closeAllFilesAtom));
+    const { result: leftPane } = renderHook(() => useAtomValue(leftPaneAtom));
+    const { result: rightPane } = renderHook(() => useAtomValue(rightPaneAtom));
+
+    const fileA = makeFile('closeAllFilesAtom.txt');
+    const fileB = makeFile('closeAllFilesAtom.pdf');
+
+    act(() => {
+      openFile.current(fileA);
+      openFile.current(fileB);
+    });
+
+    const paneFiles = [...leftPane.current.files, ...rightPane.current.files];
+    expect(paneFiles).toContainEqual(fileA);
+    expect(paneFiles).toContainEqual(fileB);
+
+    act(() => closeAllFiles.current());
+
+    const totalOpenedFiles = leftPane.current.files.length + rightPane.current.files.length;
+    expect(totalOpenedFiles).toBe(0);
+  });
+
+  test('should split (move) file from one tab to the other', () => {
+    const { result: openFile } = renderHook(() => useSetAtom(openFileAtom));
+    const { result: leftPane } = renderHook(() => useAtomValue(leftPaneAtom));
+    const { result: rightPane } = renderHook(() => useAtomValue(rightPaneAtom));
+    const { result: splitFileToPane } = renderHook(() => useSetAtom(splitFileToPaneAtom));
+
+    const fileA = makeFile('splitFileToPane.txt');
+
+    act(() => {
+      openFile.current(fileA);
+    });
+
+    expect(leftPane.current.files).toContainEqual(fileA);
+    expect(rightPane.current.files).not.toContainEqual(fileA);
+
+    act(() => {
+      splitFileToPane.current({ fileId: fileA.path, fromPaneId: 'LEFT', toPaneId: 'RIGHT' });
+    });
+
+    expect(leftPane.current.files).not.toContainEqual(fileA);
+    expect(rightPane.current.files).toContainEqual(fileA);
+  });
+
+  test('should make another file active, in same pane, after closing the active', () => {
+    const { result: openFile } = renderHook(() => useSetAtom(openFileAtom));
+    const { result: closeFileFromPane } = renderHook(() => useSetAtom(closeFileFromPaneAtom));
+    const { result: leftPane } = renderHook(() => useAtomValue(leftPaneAtom));
+
+    const fileA = makeFile('fileActiveA1.txt');
+    const fileB = makeFile('fileActiveB1.txt');
+    const fileC = makeFile('fileActiveC1.txt');
+
+    act(() => {
+      openFile.current(fileA);
+      openFile.current(fileB);
+      openFile.current(fileC);
+    });
+
+    expect(leftPane.current.activeFile).toEqual(fileC);
+
+    act(() => {
+      closeFileFromPane.current({ paneId: leftPane.current.id, fileId: fileC.path });
+    });
+
+    expect(leftPane.current.activeFile).not.toEqual(fileC);
+    expect(leftPane.current.activeFile).toEqual(fileB);
+  });
+
+  test('should not make another file active, in same pane, after closing other than the active', () => {
+    const { result: openFile } = renderHook(() => useSetAtom(openFileAtom));
+    const { result: closeFileFromPane } = renderHook(() => useSetAtom(closeFileFromPaneAtom));
+    const { result: leftPane } = renderHook(() => useAtomValue(leftPaneAtom));
+
+    const fileA = makeFile('fileActiveA2.txt');
+    const fileB = makeFile('fileActiveB2.txt');
+    const fileC = makeFile('fileActiveC2.txt');
+
+    act(() => {
+      openFile.current(fileA);
+      openFile.current(fileB);
+      openFile.current(fileC);
+    });
+
+    expect(leftPane.current.activeFile).toEqual(fileC);
+
+    act(() => {
+      closeFileFromPane.current({ paneId: leftPane.current.id, fileId: fileB.path });
+    });
+
+    expect(leftPane.current.activeFile).toEqual(fileC);
+  });
 
   test('should not open folder entries', () => {
     const { result: openFileResult } = renderHook(() => useSetAtom(openFileAtom));
-    const { result: fileEntryResult } = renderHook(() => useAtomValue(fileEntryAtom));
+    const { result: leftPane } = renderHook(() => useAtomValue(leftPaneAtom));
+    const { result: rightPane } = renderHook(() => useAtomValue(rightPaneAtom));
 
-    expect(fileEntryResult.current.size).toBe(0);
-    act(() => openFileResult.current(FOLDER));
-    expect(fileEntryResult.current.size).toBe(0);
+    const sizeBeforeOpenFolder = leftPane.current.files.length + rightPane.current.files.length;
+
+    act(() => openFileResult.current(makeFolder('uploads')));
+
+    const sizeAfterOpenFolder = leftPane.current.files.length + rightPane.current.files.length;
+    expect(sizeBeforeOpenFolder).toBe(sizeAfterOpenFolder);
+  });
+
+  test('should focus panel to make active', () => {
+    const { result: activePane } = renderHook(() => useAtomValue(activePaneAtom));
+    const { result: focusPanel } = renderHook(() => useSetAtom(focusPaneAtom));
+
+    const paneToFocus: PaneId = activePane.current.id === 'LEFT' ? 'RIGHT' : 'LEFT';
+
+    act(() => {
+      focusPanel.current(paneToFocus);
+    });
+
+    expect(activePane.current.id).toBe(paneToFocus);
   });
 });
 
-const PDF_FILE: FileFileEntry = {
-  name: 'file.pdf',
-  path: './file.pdf',
-  fileExtension: 'pdf',
-  isFolder: false,
-  isDotfile: false,
-  isFile: true,
-};
+const PDF_FILE = makeFile('file.pdf');
+const TXT_FILE = makeFile('file.txt');
 
-const TXT_FILE: FileFileEntry = {
-  name: 'file.txt',
-  path: './file.txt',
-  fileExtension: 'txt',
-  isFolder: false,
-  isDotfile: false,
-  isFile: true,
-};
-
-const TXT_FILE2: FileFileEntry = {
-  name: 'file2.txt',
-  path: './file2.txt',
-  fileExtension: 'txt',
-  isFolder: false,
-  isDotfile: false,
-  isFile: true,
-};
-
-const FOLDER: FolderFileEntry = {
-  name: 'uploads',
-  path: './uploads',
-  isFolder: true,
-  isDotfile: false,
-  isFile: false,
-  children: [],
-};
+function makeFile(name: string, extension?: string): FileFileEntry {
+  name = extension ? name + '.' + extension : name;
+  return {
+    name,
+    path: './' + name,
+    fileExtension: extension ?? name.split('.').pop() ?? '',
+    isFolder: false,
+    isDotfile: false,
+    isFile: true,
+  };
+}
+function makeFolder(name: string): FolderFileEntry {
+  return {
+    name,
+    path: './' + name,
+    isFolder: true,
+    isDotfile: false,
+    isFile: false,
+    children: [],
+  };
+}

--- a/src/atoms/fileActions.ts
+++ b/src/atoms/fileActions.ts
@@ -7,6 +7,7 @@ import { addFileToPane, getPane, paneGroupAtom, removeFileFromPane, selectFileIn
 import { FileEntry, FileFileEntry, FileId } from './types/FileEntry';
 import { PaneFileId, PaneId } from './types/PaneGroup';
 
+export { activePaneAtom } from './core/activePane';
 export { selectFileInPaneAtom } from './core/paneGroup';
 
 /** Open a file in the a pane (depending on the file extension) */
@@ -78,6 +79,12 @@ export const splitFileToPaneAtom = atom(null, (_get, set, { fileId, fromPaneId, 
 
 export const focusPaneAtom = atom(null, (_get, set, paneId: PaneId) => {
   set(activePaneIdAtom, paneId);
+});
+
+export const closeAllFilesAtom = atom(null, (get, set) => {
+  const panes = get(paneGroupAtom);
+  panes.LEFT.openFiles.forEach((file) => set(closeFileFromPaneAtom, { fileId: file, paneId: 'LEFT' }));
+  panes.RIGHT.openFiles.forEach((file) => set(closeFileFromPaneAtom, { fileId: file, paneId: 'RIGHT' }));
 });
 
 function targetPaneIdFor(file: FileFileEntry): PaneId {

--- a/src/atoms/fileActions.ts
+++ b/src/atoms/fileActions.ts
@@ -1,10 +1,10 @@
 import { atom } from 'jotai';
 
-import { activePaneAtom, activePaneIdAtom } from './core/activePane';
+import { activePaneIdAtom } from './core/activePane';
 import { fileContentAtom, loadFile, unloadFile } from './core/fileContent';
 import { addFileEntry, removeFileEntry } from './core/fileEntry';
 import { addFileToPane, getPane, paneGroupAtom, removeFileFromPane, selectFileInPaneAtom } from './core/paneGroup';
-import { FileEntry, FileId } from './types/FileEntry';
+import { FileEntry, FileFileEntry, FileId } from './types/FileEntry';
 import { PaneFileId, PaneId } from './types/PaneGroup';
 
 export { selectFileInPaneAtom } from './core/paneGroup';
@@ -25,14 +25,16 @@ export const openFileAtom = atom(null, (get, set, file: FileEntry) => {
   set(addFileEntry, file);
 
   // Add file to panes state
-  const activePane = get(activePaneAtom);
+  const targetPaneId = targetPaneIdFor(file);
+  const panes = get(paneGroupAtom);
+  const targetPane = panes[targetPaneId];
   const fileId = file.path;
-  if (!activePane.openFiles.includes(fileId)) {
-    set(addFileToPane, { fileId, paneId: activePane.id });
+  if (!targetPane.openFiles.includes(fileId)) {
+    set(addFileToPane, { fileId, paneId: targetPaneId });
   }
 
   // Select file in pane
-  set(selectFileInPaneAtom, { fileId, paneId: activePane.id });
+  set(selectFileInPaneAtom, { fileId, paneId: targetPaneId });
 });
 
 /** Removes file from the given pane and unload content from memory if the file is not open in another pane */
@@ -77,3 +79,14 @@ export const splitFileToPaneAtom = atom(null, (_get, set, { fileId, fromPaneId, 
 export const focusPaneAtom = atom(null, (_get, set, paneId: PaneId) => {
   set(activePaneIdAtom, paneId);
 });
+
+function targetPaneIdFor(file: FileFileEntry): PaneId {
+  switch (file.fileExtension) {
+    case 'pdf':
+    case 'xml':
+    case 'json':
+      return 'RIGHT';
+    default:
+      return 'LEFT';
+  }
+}

--- a/src/atoms/fileActions.ts
+++ b/src/atoms/fileActions.ts
@@ -9,7 +9,7 @@ import { PaneFileId, PaneId } from './types/PaneGroup';
 
 export { selectFileInPaneAtom } from './core/paneGroup';
 
-/** Open a file in the active pane */
+/** Open a file in the a pane (depending on the file extension) */
 export const openFileAtom = atom(null, (get, set, file: FileEntry) => {
   if (file.isFolder) {
     console.warn('Cannot open directory ', file.path);

--- a/src/atoms/selectionState.test.ts
+++ b/src/atoms/selectionState.test.ts
@@ -1,5 +1,5 @@
-import { renderHook } from '@testing-library/react';
-import { useAtom, useAtomValue } from 'jotai';
+import { act, renderHook } from '@testing-library/react';
+import { useAtom } from 'jotai';
 import { describe, expect, test } from 'vitest';
 
 import { selectionAtom } from './selectionState';
@@ -14,20 +14,13 @@ describe('selectionState', () => {
   });
 
   test('should change to string value', () => {
-    const {
-      result: {
-        current: [selection, setSelection],
-      },
-    } = renderHook(() => useAtom(selectionAtom));
-    setSelection('Some text that is selected');
-
-    // Note that the atom value here is the default ("")
+    const { result } = renderHook(() => useAtom(selectionAtom));
+    const [selection, setSelection] = result.current;
     expect(selection).toBe('');
 
-    // The updated setSelection value needs to be read again with useAtomValue
-    const {
-      result: { current: newSelection },
-    } = renderHook(() => useAtomValue(selectionAtom));
+    act(() => setSelection('Some text that is selected'));
+
+    const [newSelection] = result.current;
     expect(newSelection).toBe('Some text that is selected');
   });
 });


### PR DESCRIPTION
Fixes #131 

With this PR PDF files are opened in the right panel, while the others open on the left. Note that the split file feature is still available as an action from the open files tree.

This PR also adds unit tests for the atom `fileActions` (and indirectly to the related core atoms). I've added also an action atom to close all files `closeAllFilesAtom`.

<img width="1169" alt="image" src="https://github.com/refstudio/refstudio/assets/174127/f69b69a0-7998-46fa-bfc3-8bfe5161fd20">
