### PR TITLE
feat: add button to close all files to Open Files panel

### DIFF
--- a/src/atoms/fileActions.ts
+++ b/src/atoms/fileActions.ts
@@ -77,3 +77,9 @@ export const splitFileToPaneAtom = atom(null, (_get, set, { fileId, fromPaneId, 
 export const focusPaneAtom = atom(null, (_get, set, paneId: PaneId) => {
   set(activePaneIdAtom, paneId);
 });
+
+export const closeAllFilesAtom = atom(null, (get, set) => {
+  const panes = get(paneGroupAtom);
+  panes.LEFT.openFiles.forEach((file) => set(closeFileFromPaneAtom, { fileId: file, paneId: 'LEFT' }));
+  panes.RIGHT.openFiles.forEach((file) => set(closeFileFromPaneAtom, { fileId: file, paneId: 'RIGHT' }));
+});

--- a/src/components/PanelSection.tsx
+++ b/src/components/PanelSection.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { IconType } from 'react-icons';
 import { VscChevronDown, VscChevronRight } from 'react-icons/vsc';
 
 import { cx } from '../cx';
@@ -7,10 +8,12 @@ export function PanelSection({
   title,
   children,
   grow = false,
+  rightIcons = [],
 }: {
   title: string;
   children: React.ReactNode;
   grow?: boolean;
+  rightIcons?: { key: string; Icon: IconType; title?: string; onClick: () => void }[];
 }) {
   const [expanded, setExpanded] = useState(true);
 
@@ -23,6 +26,7 @@ export function PanelSection({
     >
       <div
         className={cx(
+          'group/header',
           'flex flex-row items-center gap-1', //
           'mb-2 cursor-pointer text-sm',
         )}
@@ -30,7 +34,21 @@ export function PanelSection({
       >
         {expanded ? <VscChevronDown /> : <VscChevronRight />}
         <span className="font-bold uppercase">{title}</span>
-        <div className="ml-auto text-xs">{/* NOTE: This is the placeholder for actions */}</div>
+        <div className="group/icon invisible ml-auto text-xs group-hover/header:visible">
+          {rightIcons.map(({ key, Icon, title: iconTitle, onClick }) => (
+            <Icon
+              className="cursor-pointer group-hover/icon:bg-slate-200"
+              key={key}
+              size={16}
+              title={iconTitle}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onClick();
+              }}
+            />
+          ))}
+        </div>
       </div>
       {expanded && <div className={cx({ 'overflow-y-auto': grow })}>{children}</div>}
     </div>

--- a/src/panels/ExplorerPanel.tsx
+++ b/src/panels/ExplorerPanel.tsx
@@ -1,8 +1,9 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect, useState } from 'react';
-import { VscSplitHorizontal } from 'react-icons/vsc';
+import { VscCloseAll, VscSplitHorizontal } from 'react-icons/vsc';
 
 import {
+  closeAllFilesAtom,
   leftPaneAtom,
   openFileAtom,
   rightPaneAtom,
@@ -22,6 +23,7 @@ export function ExplorerPanel() {
   const selectFileInPane = useSetAtom(selectFileInPaneAtom);
   const openFile = useSetAtom(openFileAtom);
   const splitFileToPane = useSetAtom(splitFileToPaneAtom);
+  const closeAllFiles = useSetAtom(closeAllFilesAtom);
 
   const [allFiles, setFiles] = useState<FileEntry[]>([]);
   useEffect(() => {
@@ -35,7 +37,10 @@ export function ExplorerPanel() {
 
   return (
     <PanelWrapper title="Explorer">
-      <PanelSection title="Open Files">
+      <PanelSection
+        rightIcons={[{ key: 'closeAll', Icon: VscCloseAll, title: 'Close All Open Files', onClick: closeAllFiles }]}
+        title="Open Files"
+      >
         {hasRightPanelFiles && <div className="ml-4 text-xs font-bold">LEFT</div>}
         {left.files.length > 0 && (
           <FileTree


### PR DESCRIPTION
This PR closes issue #142 by adding a close all files action in the OPEN FILES panel.

<img width="937" alt="image" src="https://github.com/refstudio/refstudio/assets/174127/61c183b1-d993-491c-8cd8-719bcb2cd007">
