### PR TITLE
feat: add chat interaction UI

### DIFF
--- a/src/api/chat.test.ts
+++ b/src/api/chat.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest';
+
+import { chatWithAI } from './chat';
+import { callSidecar } from './sidecar';
+
+vi.mock('./sidecar');
+
+describe('chatWithAI', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('should return list of strings with content returned by sidecar', async () => {
+    vi.mocked(callSidecar).mockResolvedValue([
+      {
+        index: 0,
+        text: 'some reply',
+      },
+    ]);
+
+    const response = await chatWithAI('input text');
+    expect(response).toStrictEqual(['some reply']);
+  });
+
+  test('should return list of strings with content returned by sidecar', async () => {
+    vi.mocked(callSidecar).mockResolvedValue([
+      {
+        index: 0,
+        text: 'some reply',
+      },
+      {
+        index: 1,
+        text: 'Another reply',
+      },
+    ]);
+
+    const response = await chatWithAI('input text');
+    expect(response).toStrictEqual(['some reply', 'Another reply']);
+  });
+
+  test('should return empty list, and not call sidecar, if provided text is empty', async () => {
+    const callSidecarMock = vi.mocked(callSidecar).mockResolvedValue([]);
+
+    const response = await chatWithAI('');
+    expect(response).toStrictEqual([]);
+    expect(callSidecarMock.mock.calls.length).toBe(0);
+  });
+
+  test('should return error message reply if exception thrown calling sidecar', async () => {
+    vi.mocked(callSidecar).mockRejectedValue(new Error('Invalid API Key'));
+
+    const response = await chatWithAI('input text');
+    expect(response.length).toBe(1);
+    expect(response[0]).toMatch(/Invalid API Key/);
+  });
+});

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -1,0 +1,13 @@
+import { callSidecar } from './sidecar';
+
+export async function chatWithAI(text: string): Promise<string[]> {
+  try {
+    if (!text) {
+      return [];
+    }
+    const response = await callSidecar('chat', ['--text', String(text)]);
+    return response.map((choice) => choice.text);
+  } catch (err) {
+    return [`Chat error: ${String(err)}`];
+  }
+}

--- a/src/api/rewrite.ts
+++ b/src/api/rewrite.ts
@@ -1,0 +1,10 @@
+import { callSidecar } from './sidecar';
+
+export async function askForRewrite(selection: string): Promise<string> {
+  try {
+    const response = await callSidecar('rewrite', ['--text', String(selection)]);
+    return response[0].text;
+  } catch (err) {
+    return `Rewrite error: ${String(err)}`;
+  }
+}

--- a/src/components/PrimarySideBar.test.tsx
+++ b/src/components/PrimarySideBar.test.tsx
@@ -2,26 +2,26 @@ import { render, screen, userEvent } from '../utils/test-utils';
 import { PrimarySideBar } from './PrimarySideBar';
 
 describe('PrimarySideBar', () => {
-  it('should display Explorer and References icons', () => {
+  test('should display Explorer and References icons', () => {
     render(<PrimarySideBar activePane="Explorer" onClick={() => 0} />);
     expect(screen.getByRole('menubar')).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Explorer' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'References' })).toBeInTheDocument();
   });
 
-  it('should display active icon with 100% opacity ', () => {
+  test('should display active icon with 100% opacity ', () => {
     render(<PrimarySideBar activePane="References" onClick={() => 0} />);
     expect(screen.getByRole('menubar')).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'References' })).toHaveClass('opacity-100');
   });
 
-  it('should display inactive icon with 50% opacity ', () => {
+  test('should display inactive icon with 50% opacity ', () => {
     render(<PrimarySideBar activePane="References" onClick={() => 0} />);
     expect(screen.getByRole('menubar')).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Explorer' })).toHaveClass('opacity-50');
   });
 
-  it('should call onClick with pane name', async () => {
+  test('should call onClick with pane name', async () => {
     const fn = vi.fn();
     render(<PrimarySideBar activePane="References" onClick={fn} />);
 

--- a/src/components/TabPane.test.tsx
+++ b/src/components/TabPane.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, userEvent, within } from './../utils/test-utils';
 import { TabPane } from './TabPane';
 
 describe('TabPane component', () => {
-  it('should render the one tab', () => {
+  test('should render the one tab', () => {
     render(
       <TabPane
         items={[{ key: 'k1', value: '1', text: 'File 1.txt' }]}
@@ -14,7 +14,7 @@ describe('TabPane component', () => {
     expect(screen.getByText('File 1.txt')).toBeInTheDocument();
   });
 
-  it('should render the two tabs', () => {
+  test('should render the two tabs', () => {
     render(
       <TabPane
         items={[
@@ -30,7 +30,7 @@ describe('TabPane component', () => {
     expect(screen.getByText('File 2.txt')).toBeInTheDocument();
   });
 
-  it('should render aria tablist with two aria tabs, one selected', () => {
+  test('should render aria tablist with two aria tabs, one selected', () => {
     render(
       <TabPane
         items={[
@@ -47,7 +47,7 @@ describe('TabPane component', () => {
     expect(screen.getByRole('tab', { selected: true, name: 'File 1.txt' })).toBeInTheDocument();
   });
 
-  it('should call onClick when clicked', async () => {
+  test('should call onClick when clicked', async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();
 
@@ -71,7 +71,7 @@ describe('TabPane component', () => {
     expect(onClick).toBeCalled();
   });
 
-  it('should call onCloseClick when X is clicked (and no call to onClick)', async () => {
+  test('should call onCloseClick when X is clicked (and no call to onClick)', async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();
     const onCloseClick = vi.fn();

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,15 @@
   }
 }
 
+@layer components {
+  .btn-primary {
+    @apply cursor-pointer rounded-xl bg-primary hover:bg-primary-hover;
+  }
+  .btn-primary[disabled] {
+    @apply pointer-events-none opacity-50;
+  }
+}
+
 h1,
 h2,
 h3,

--- a/src/panels/AIPanel.tsx
+++ b/src/panels/AIPanel.tsx
@@ -1,56 +1,12 @@
-import { useAtomValue } from 'jotai';
-import { useDebounce } from 'usehooks-ts';
-
-import { callSidecar } from '../api/sidecar';
-import { selectionAtom } from '../atoms/selectionState';
-import { PanelSection } from '../components/PanelSection';
 import { PanelWrapper } from '../components/PanelWrapper';
-import { useCallablePromise } from '../hooks/useCallablePromise';
+import { ChatPanelSection } from './ai/ChatPanelSection';
+import { SelectionPanelSection } from './ai/SelectionPanelSection';
 
 export function AIPanel({ onCloseClick }: { onCloseClick?: () => void }) {
-  const selection = useAtomValue(selectionAtom);
-  const debouncedSelection = useDebounce(selection, 200);
-
-  const [rewriteCallState, callRewrite] = useCallablePromise(askForRewrite);
-
   return (
     <PanelWrapper closable title="AI" onCloseClick={onCloseClick}>
-      <PanelSection title="Selection">
-        <p className="my-4 italic">Select some text in the editor to see it here.</p>
-
-        {selection && (
-          <div className="flex flex-col gap-4">
-            <div className="border border-yellow-100 bg-yellow-50 p-4">{debouncedSelection}</div>
-            <button
-              className="btn cursor-pointer rounded-xl bg-yellow-100 hover:bg-yellow-200"
-              disabled={rewriteCallState.state === 'loading'}
-              onClick={() => callRewrite(debouncedSelection)}
-            >
-              REWRITE
-            </button>
-            {rewriteCallState.state === 'error' && <span className="bg-red-50">{String(rewriteCallState.error)}</span>}
-            {rewriteCallState.state === 'loading' && <span>Processing...</span>}
-            {rewriteCallState.state === 'ok' && (
-              <>
-                <div className="border border-green-100 bg-green-50 p-4">{rewriteCallState.data}</div>
-                {/* <button className="btn rounded-xl bg-green-100 hover:bg-green-200" onClick={handleReplaceClicked}>
-                  REPLACE
-                </button> */}
-              </>
-            )}
-          </div>
-        )}
-      </PanelSection>
+      <SelectionPanelSection />
+      <ChatPanelSection />
     </PanelWrapper>
   );
-}
-
-async function askForRewrite(selection: string) {
-  try {
-    const response = await callSidecar('rewrite', ['--text', selection]);
-    const aiReply = response[0].text;
-    return aiReply;
-  } catch (reason) {
-    throw new Error(`ERROR: ${reason}`);
-  }
 }

--- a/src/panels/ai/ChatPanelSection.test.tsx
+++ b/src/panels/ai/ChatPanelSection.test.tsx
@@ -44,6 +44,17 @@ describe('ChatPanelSection component', () => {
     expect(chatWithAiMock.mock.calls.length).toBe(1);
   });
 
+  // https://testing-library.com/docs/user-event/keyboard/
+  test('should display ERROR if chatWithAI throw exception', async () => {
+    const chatWithAiMock = vi.mocked(chatWithAI).mockRejectedValue('Error message.');
+    const user = userEvent.setup();
+    render(<ChatPanelSection />);
+    await user.type(screen.getByRole('textbox'), 'This is a question.');
+    await user.type(screen.getByRole('textbox'), '{enter}');
+    expect(chatWithAiMock.mock.calls.length).toBe(1);
+    expect(screen.getByText('ERROR: Error message.')).toBeInTheDocument();
+  });
+
   test('should NOT call api on SHIFT+ENTER in the textbox', async () => {
     const chatWithAiMock = vi.mocked(chatWithAI).mockResolvedValue([]);
     const user = userEvent.setup();

--- a/src/panels/ai/ChatPanelSection.test.tsx
+++ b/src/panels/ai/ChatPanelSection.test.tsx
@@ -1,0 +1,104 @@
+import { screen, waitFor } from '@testing-library/react';
+
+import { chatWithAI } from '../../api/chat';
+import { render, userEvent } from '../../utils/test-utils';
+import { ChatPanelSection } from './ChatPanelSection';
+
+vi.mock('../../api/chat');
+
+describe('ChatPanelSection component', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('should render the panel without history content and a textbox', () => {
+    render(<ChatPanelSection />);
+    expect(screen.getByText(/your chat history will be shown here\./i)).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  test('should call api if textbox has text', async () => {
+    const chatWithAiMock = vi.mocked(chatWithAI).mockResolvedValue([]);
+    const user = userEvent.setup();
+    render(<ChatPanelSection />);
+    await user.type(screen.getByRole('textbox'), 'This is a question.');
+    await user.click(screen.getByTitle('Send'));
+    expect(chatWithAiMock.mock.calls.length).toBe(1);
+  });
+
+  test('should NOT call api if textbox has empty text', async () => {
+    const chatWithAiMock = vi.mocked(chatWithAI).mockResolvedValue([]);
+    const user = userEvent.setup();
+    render(<ChatPanelSection />);
+    await user.click(screen.getByTitle('Send'));
+    expect(chatWithAiMock.mock.calls.length).toBe(0);
+  });
+
+  // https://testing-library.com/docs/user-event/keyboard/
+  test('should call api on ENTER in the textbox', async () => {
+    const chatWithAiMock = vi.mocked(chatWithAI).mockResolvedValue([]);
+    const user = userEvent.setup();
+    render(<ChatPanelSection />);
+    await user.type(screen.getByRole('textbox'), 'This is a question.');
+    await user.type(screen.getByRole('textbox'), '{enter}');
+    expect(chatWithAiMock.mock.calls.length).toBe(1);
+  });
+
+  test('should NOT call api on SHIFT+ENTER in the textbox', async () => {
+    const chatWithAiMock = vi.mocked(chatWithAI).mockResolvedValue([]);
+    const user = userEvent.setup();
+    render(<ChatPanelSection />);
+    await user.type(screen.getByRole('textbox'), 'This is a question.');
+    await user.type(screen.getByRole('textbox'), '{Shift>}{enter}');
+    expect(chatWithAiMock.mock.calls.length).toBe(0);
+  });
+
+  test('should render question and reply in the screen', async () => {
+    const chatWithAiMock = vi.mocked(chatWithAI).mockResolvedValue(['Sure!']);
+    const user = userEvent.setup();
+    render(<ChatPanelSection />);
+    await user.type(screen.getByRole('textbox'), 'Will this test pass?');
+    await user.click(screen.getByTitle('Send'));
+    expect(chatWithAiMock.mock.calls.length).toBe(1);
+    expect(screen.getByText('Will this test pass?')).toBeInTheDocument();
+    expect(screen.getByText('Sure!')).toBeInTheDocument();
+  });
+
+  test('should render ... while waiting for reply', async () => {
+    // Note: this is a promise that _don't resolve_ so that we can test the "..." below.
+    vi.mocked(chatWithAI).mockImplementation(async () => new Promise<string[]>(() => ['---']));
+    const user = userEvent.setup();
+    render(<ChatPanelSection />);
+
+    await user.type(screen.getByRole('textbox'), 'Will this test pass?');
+    await user.click(screen.getByTitle('Send'));
+
+    expect(screen.getByText('Will this test pass?')).toBeInTheDocument();
+    expect(screen.getByText('...')).toBeInTheDocument();
+  });
+
+  test('should render ... and then the ### reply text', async () => {
+    let resolveFn: () => void = vi.fn();
+    vi.mocked(chatWithAI).mockImplementation(async () => {
+      await new Promise<void>((resolve) => {
+        // Capture resolve function to call after assertion
+        resolveFn = resolve;
+      });
+      return ['###'];
+    });
+    const user = userEvent.setup();
+    render(<ChatPanelSection />);
+
+    await user.type(screen.getByRole('textbox'), 'Will this test pass?');
+    await user.click(screen.getByTitle('Send'));
+
+    expect(screen.getByText('Will this test pass?')).toBeInTheDocument();
+    expect(screen.getByText('...')).toBeInTheDocument();
+
+    resolveFn();
+
+    await waitFor(() => {
+      expect(screen.getByText('###')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/panels/ai/ChatPanelSection.tsx
+++ b/src/panels/ai/ChatPanelSection.tsx
@@ -52,6 +52,11 @@ export function ChatPanelSection() {
       })
       .catch((err) => {
         console.error('Error calling chat', err);
+        setChatThread([
+          ...chatThread,
+          { id: String(chatThread.length + 1), question: text, answer: `ERROR: ${String(err)}` },
+        ]);
+        setCurrentChatThreadItem(null);
       });
   }
 

--- a/src/panels/ai/ChatPanelSection.tsx
+++ b/src/panels/ai/ChatPanelSection.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { VscMegaphone, VscRunAll, VscWand } from 'react-icons/vsc';
+
+import { chatWithAI } from '../../api/chat';
+import { PanelSection } from '../../components/PanelSection';
+import { cx } from '../../cx';
+
+interface ChatThreadItem {
+  id: string;
+  question: string;
+  answer?: string;
+}
+type ChatThread = ChatThreadItem[];
+
+export function ChatPanelSection() {
+  const [text, setText] = useState('');
+
+  const [chatThread, setChatThread] = useState<ChatThread>([
+    // {
+    //   id: '1',
+    //   question: 'What is your name?',
+    //   answer:
+    //     'I am an AI language model and do not have a name. How may I assist you with your query related to the given context?',
+    // },
+    // {
+    //   id: '2',
+    //   question: 'What can you tell me about hidden feedback loops in machine learning?',
+    //   answer:
+    //     'Hidden feedback loops in machine learning refer to situations where two systems indirectly influence each other through the world, leading to changes in behavior that may not be immediately visible. These loops may exist between completely disjoint systems and can make analyzing the effect of proposed changes extremely difficult, adding cost to even simple improvements. It is recommended to look carefully for hidden feedback loops and remove them whenever feasible.',
+    // },
+  ]);
+  const [currentChatThreadItem, setCurrentChatThreadItem] = useState<ChatThreadItem | undefined>();
+
+  function handleKeyDown(evt: React.KeyboardEvent<HTMLTextAreaElement>): void {
+    if (!evt.shiftKey && evt.code === 'Enter') {
+      evt.preventDefault();
+      handleChat(text);
+      return;
+    }
+  }
+
+  function handleChat(question: string) {
+    if (!question || currentChatThreadItem) {
+      return;
+    }
+    setCurrentChatThreadItem({ id: String(chatThread.length + 1), question: text });
+    setText('');
+    chatWithAI(question)
+      .then((reply) => {
+        setChatThread([...chatThread, { id: String(chatThread.length + 1), question: text, answer: reply[0] }]);
+        setCurrentChatThreadItem(undefined);
+      })
+      .catch((err) => {
+        console.error('Error calling chat', err);
+      });
+  }
+
+  return (
+    <PanelSection grow title="Chat">
+      <div className="ml-4 mr-6 grid min-h-[400px] grid-rows-[1fr_auto] gap-4">
+        <ChatThreadBlock
+          className="border border-slate-100 bg-slate-50"
+          thread={currentChatThreadItem ? [...chatThread, currentChatThreadItem] : chatThread}
+        />
+        <div className="flex grow gap-2 rounded-xl border border-slate-200 p-2 shadow-lg shadow-slate-200">
+          <textarea
+            className="grow resize-none p-2 outline-none"
+            disabled={currentChatThreadItem !== undefined}
+            placeholder="Send a message."
+            rows={3}
+            value={text}
+            onChange={(evt) => setText(evt.currentTarget.value)}
+            onKeyDown={handleKeyDown}
+          />
+          <div className="flex grow-0 items-end">
+            <VscRunAll className="cursor-pointer hover:text-primary-hover" size={20} onClick={() => handleChat(text)} />
+          </div>
+        </div>
+      </div>
+    </PanelSection>
+  );
+}
+
+function ChatThreadBlock({ thread, className = '' }: { className?: string; thread: ChatThread }) {
+  if (thread.length === 0) {
+    return (
+      <div className={cx(className, 'p-4 text-sm text-slate-500')}>
+        <em>Your chat history will be shown here.</em>
+      </div>
+    );
+  }
+  return (
+    <div className={className}>
+      {thread.map((chat) => (
+        <div key={chat.id}>
+          <ChatThreadItemBlock actor="user" text={chat.question} />
+          <ChatThreadItemBlock actor="ai" text={chat.answer} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ChatThreadItemBlock({ text, actor }: { text?: string; actor: 'user' | 'ai' }) {
+  return (
+    <div
+      className={cx('grid grid-cols-[auto_1fr] items-center gap-2 p-2 pb-4', {
+        'bg-gray-200': actor === 'ai',
+      })}
+    >
+      <div className="flex shrink-0 items-start self-start">
+        {actor === 'user' && <VscMegaphone size="24" />}
+        {actor === 'ai' && <VscWand size="24" />}
+      </div>
+      <div>
+        {text !== undefined && <div>{text}</div>}
+        {text === undefined && <div>...</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/panels/ai/ChatPanelSection.tsx
+++ b/src/panels/ai/ChatPanelSection.tsx
@@ -29,7 +29,7 @@ export function ChatPanelSection() {
     //     'Hidden feedback loops in machine learning refer to situations where two systems indirectly influence each other through the world, leading to changes in behavior that may not be immediately visible. These loops may exist between completely disjoint systems and can make analyzing the effect of proposed changes extremely difficult, adding cost to even simple improvements. It is recommended to look carefully for hidden feedback loops and remove them whenever feasible.',
     // },
   ]);
-  const [currentChatThreadItem, setCurrentChatThreadItem] = useState<ChatThreadItem | undefined>();
+  const [currentChatThreadItem, setCurrentChatThreadItem] = useState<ChatThreadItem | null>();
 
   function handleKeyDown(evt: React.KeyboardEvent<HTMLTextAreaElement>): void {
     if (!evt.shiftKey && evt.code === 'Enter') {
@@ -65,7 +65,7 @@ export function ChatPanelSection() {
         <div className="flex grow gap-2 rounded-xl border border-slate-200 p-2 shadow-lg shadow-slate-200">
           <textarea
             className="grow resize-none p-2 outline-none"
-            disabled={currentChatThreadItem !== undefined}
+            disabled={!!currentChatThreadItem}
             placeholder="Send a message."
             rows={3}
             value={text}
@@ -113,8 +113,7 @@ function ChatThreadItemBlock({ text, actor }: { text?: string; actor: 'user' | '
         {actor === 'ai' && <VscWand size="24" />}
       </div>
       <div>
-        {text !== undefined && <div>{text}</div>}
-        {text === undefined && <div>...</div>}
+        <div>{text ?? '...'}</div>
       </div>
     </div>
   );

--- a/src/panels/ai/ChatPanelSection.tsx
+++ b/src/panels/ai/ChatPanelSection.tsx
@@ -29,7 +29,7 @@ export function ChatPanelSection() {
     //     'Hidden feedback loops in machine learning refer to situations where two systems indirectly influence each other through the world, leading to changes in behavior that may not be immediately visible. These loops may exist between completely disjoint systems and can make analyzing the effect of proposed changes extremely difficult, adding cost to even simple improvements. It is recommended to look carefully for hidden feedback loops and remove them whenever feasible.',
     // },
   ]);
-  const [currentChatThreadItem, setCurrentChatThreadItem] = useState<ChatThreadItem | null>();
+  const [currentChatThreadItem, setCurrentChatThreadItem] = useState<ChatThreadItem | null>(null);
 
   function handleKeyDown(evt: React.KeyboardEvent<HTMLTextAreaElement>): void {
     if (!evt.shiftKey && evt.code === 'Enter') {
@@ -48,7 +48,7 @@ export function ChatPanelSection() {
     chatWithAI(question)
       .then((reply) => {
         setChatThread([...chatThread, { id: String(chatThread.length + 1), question: text, answer: reply[0] }]);
-        setCurrentChatThreadItem(undefined);
+        setCurrentChatThreadItem(null);
       })
       .catch((err) => {
         console.error('Error calling chat', err);

--- a/src/panels/ai/ChatPanelSection.tsx
+++ b/src/panels/ai/ChatPanelSection.tsx
@@ -73,7 +73,12 @@ export function ChatPanelSection() {
             onKeyDown={handleKeyDown}
           />
           <div className="flex grow-0 items-end">
-            <VscRunAll className="cursor-pointer hover:text-primary-hover" size={20} onClick={() => handleChat(text)} />
+            <VscRunAll
+              className="cursor-pointer hover:text-primary-hover"
+              size={20}
+              title="Send"
+              onClick={() => handleChat(text)}
+            />
           </div>
         </div>
       </div>

--- a/src/panels/ai/SelectionPanelSection.tsx
+++ b/src/panels/ai/SelectionPanelSection.tsx
@@ -1,0 +1,43 @@
+import { useAtomValue } from 'jotai';
+import { useDebounce } from 'usehooks-ts';
+
+import { askForRewrite } from '../../api/rewrite';
+import { selectionAtom } from '../../atoms/selectionState';
+import { PanelSection } from '../../components/PanelSection';
+import { useCallablePromise } from '../../hooks/useCallablePromise';
+
+export function SelectionPanelSection() {
+  const selection = useAtomValue(selectionAtom);
+  const debouncedSelection = useDebounce(selection, 200);
+
+  const [rewriteCallState, callRewrite] = useCallablePromise(askForRewrite);
+
+  return (
+    <PanelSection title="Selection">
+      <p className="my-4 italic">Select some text in the editor to see it here.</p>
+
+      {selection && (
+        <div className="mb-6 flex flex-col gap-4">
+          <div className="border border-slate-100 bg-slate-50 p-4">{debouncedSelection}</div>
+          <button
+            className="btn-primary"
+            disabled={rewriteCallState.state === 'loading'}
+            onClick={() => callRewrite(debouncedSelection)}
+          >
+            REWRITE
+          </button>
+          {rewriteCallState.state === 'error' && <span className="bg-red-50">{String(rewriteCallState.error)}</span>}
+          {rewriteCallState.state === 'loading' && <span>Processing...</span>}
+          {rewriteCallState.state === 'ok' && (
+            <>
+              <div className="border border-green-100 bg-green-50 p-4">{rewriteCallState.data}</div>
+              {/* <button className="rounded-xl bg-green-100 hover:bg-green-200" onClick={handleReplaceClicked}>
+                          REPLACE
+                        </button> */}
+            </>
+          )}
+        </div>
+      )}
+    </PanelSection>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,8 +18,22 @@ export default {
       }
     },
   },
-  plugins: [debugPlugin()],
+  plugins: [debugPlugin(), autocompleteCustomComponentsPlugin()], 
 };
+
+/**
+ * Custom plugin that provide auto-complete support for the listed classes.
+ *
+ * The style definitions can be found in `index.css` under the `@layer components {` section
+ * 
+ */
+function autocompleteCustomComponentsPlugin() {
+  return plugin(function ({ addComponents }) {
+    addComponents({
+      '.btn-primary': {},
+    })
+  })
+}
 
 /**
  * The debugPlugin adds utility `debug*` classes to outline HTML nodes and childs.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig(async () => ({
       // Instrument all files: https://github.com/bcoe/c8#checking-for-full-source-coverage-using---all
       all: true,
       include: ['src/**'],
-      exclude: ['src/**/types.ts', 'src/**/types/**.ts', 'src/**/*.test.ts', 'src/**/*.d.ts'],
+      exclude: ['src/**/types.ts', 'src/**/types/**.ts', 'src/**/*.test.{ts,tsx}', 'src/**/*.d.ts'],
     },
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
This PR closes #148 by adding a UI for chat interaction.

Note that currently the backend don't support threads and history (will be fixed by #144) so this PR adds that as a UI state in order to experiment the interaction pattern. 

![image](https://github.com/refstudio/refstudio/assets/174127/d8895c63-7a02-4d3b-bbcb-d02af4df6e95)
