### PR TITLE
feat: improve collapsible blocks

### DIFF
--- a/src/TipTapEditor/CollapsibleBlock/CollapsibleBlock.css
+++ b/src/TipTapEditor/CollapsibleBlock/CollapsibleBlock.css
@@ -17,6 +17,10 @@ collapsible-block > button.folded:before {
   content: '\25b6';
 }
 
+collapsible-block:not(:has(collapsible-content)) > button:before {
+  color: #93928e;
+}
+
 collapsible-block .content {
   @apply flex-1;
 }

--- a/src/TipTapEditor/CollapsibleBlock/CollapsibleBlock.tsx
+++ b/src/TipTapEditor/CollapsibleBlock/CollapsibleBlock.tsx
@@ -1,7 +1,8 @@
 import './CollapsibleBlock.css';
 
 import { Node } from '@tiptap/pm/model';
-import { NodeViewContent, NodeViewWrapper } from '@tiptap/react';
+import { TextSelection } from '@tiptap/pm/state';
+import { Editor, NodeViewContent, NodeViewWrapper } from '@tiptap/react';
 import { ElementType } from 'react';
 
 import { cx } from '../../cx';
@@ -9,26 +10,63 @@ import { CollapsibleBlockNodeAttributes } from './nodes/CollapsibleBlockNode';
 
 // The attributes in this interface must correspond to the attributes defined in the `addAttributes` method of CollapsibleBlockNode
 export interface CollapsibleBlockProps {
-  updateAttributes: (attributes: CollapsibleBlockNodeAttributes) => void;
+  editor: Editor;
+  getPos: () => number;
   node: Node & { attrs: CollapsibleBlockNodeAttributes };
+  updateAttributes: (attributes: CollapsibleBlockNodeAttributes) => void;
 }
 
-export const CollapsibleBlock = (props: CollapsibleBlockProps) => {
+export const CollapsibleBlock = ({ editor, getPos, node, updateAttributes }: CollapsibleBlockProps) => {
+  const { folded } = node.attrs;
+
   const handleButtonClick = () => {
-    props.updateAttributes({
-      folded: !props.node.attrs.folded,
+    if (!('collapsibleContent' in editor.schema.nodes)) {
+      console.warn();
+      return;
+    }
+    // If the collapsible block does not have content, add an empty content block
+    if (folded && node.childCount === 1) {
+      editor.commands.command(({ dispatch, tr }) => {
+        if (dispatch) {
+          const emptyParagraph = editor.schema.nodes.paragraph.createChecked();
+          const draggableBlock = editor.schema.nodes.draggableBlock.createChecked(null, emptyParagraph);
+          const contentBlock = editor.schema.nodes.collapsibleContent.createChecked(null, draggableBlock);
+
+          const pos = getPos() + node.nodeSize - 1;
+
+          tr.insert(pos, contentBlock);
+          tr.setSelection(TextSelection.near(tr.doc.resolve(pos)));
+          dispatch(tr);
+        }
+        return true;
+      });
+      // If the block was collapsed and with empty content block, remove the content block
+    } else if (!folded && node.childCount === 2 && node.child(1).nodeSize === 6) {
+      editor.commands.command(({ dispatch, tr }) => {
+        if (dispatch) {
+          const start = getPos() + node.child(0).nodeSize;
+          const end = start + 8;
+
+          tr.delete(start, end);
+          dispatch(tr);
+        }
+        return true;
+      });
+    }
+
+    updateAttributes({
+      folded: !folded,
     });
   };
+
   return (
     <NodeViewWrapper as={'collapsible-block' as ElementType}>
       <button
-        className={cx({
-          folded: props.node.attrs.folded,
-        })}
+        className={cx({ folded })}
         onClick={handleButtonClick}
       />
 
-      <NodeViewContent className={cx('content', { folded: props.node.attrs.folded })} />
+      <NodeViewContent className={cx('content', { folded })} />
     </NodeViewWrapper>
   );
 };

--- a/src/TipTapEditor/CollapsibleBlock/CollapsibleBlock.tsx
+++ b/src/TipTapEditor/CollapsibleBlock/CollapsibleBlock.tsx
@@ -61,10 +61,7 @@ export const CollapsibleBlock = ({ editor, getPos, node, updateAttributes }: Col
 
   return (
     <NodeViewWrapper as={'collapsible-block' as ElementType}>
-      <button
-        className={cx({ folded })}
-        onClick={handleButtonClick}
-      />
+      <button className={cx({ folded })} onClick={handleButtonClick} />
 
       <NodeViewContent className={cx('content', { folded })} />
     </NodeViewWrapper>

--- a/src/TipTapEditor/CollapsibleBlock/nodes/CollapsibleBlockNode.ts
+++ b/src/TipTapEditor/CollapsibleBlock/nodes/CollapsibleBlockNode.ts
@@ -1,5 +1,6 @@
 import { Node } from '@tiptap/core';
-import { ReactNodeViewRenderer } from '@tiptap/react';
+import { TextSelection } from '@tiptap/pm/state';
+import { InputRule, ReactNodeViewRenderer } from '@tiptap/react';
 
 import { CollapsibleBlock } from '../CollapsibleBlock';
 
@@ -7,10 +8,26 @@ export interface CollapsibleBlockNodeAttributes {
   folded: boolean;
 }
 
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    collapsibleBlock: {
+      setCollapsibleBlock: () => ReturnType;
+      toggleCollapsibleBlock: () => ReturnType;
+      unsetCollapsibleBlock: () => ReturnType;
+    };
+  }
+}
+
+const inputRegex = /^>\s/;
+
 export const CollapsibleBlockNode = Node.create({
   name: 'collapsibleBlock',
+
   group: 'block',
-  content: 'collapsibleSummary collapsibleContent',
+
+  content: 'collapsibleSummary collapsibleContent?',
+  defining: true,
+  selectable: false,
 
   parseHTML() {
     return [
@@ -38,5 +55,76 @@ export const CollapsibleBlockNode = Node.create({
 
   addNodeView() {
     return ReactNodeViewRenderer(CollapsibleBlock);
+  },
+
+  addCommands() {
+    return {
+      ...this.parent?.(),
+      setCollapsibleBlock:
+        () =>
+        ({ tr, dispatch, editor }) => {
+          if (!('collapsibleSummary' in editor.schema.nodes)) {
+            console.warn(
+              'Collapsible summary can not be found in the schema. Did you forget to add it to configuration?',
+            );
+            return false;
+          }
+
+          const { $from } = tr.selection;
+          const node = $from.parent;
+          if (node.type.name !== 'paragraph') {
+            return false;
+          }
+
+          if (!editor.schema.nodes.collapsibleSummary.validContent(node.content)) {
+            return false;
+          }
+
+          if (dispatch) {
+            const summary = editor.schema.nodes.collapsibleSummary.create(null, node.content, node.marks);
+            const collapsibleBlock = this.type.create({ folded: true }, summary);
+
+            tr.replaceRangeWith($from.before(-1), $from.after(-1), collapsibleBlock);
+            dispatch(tr);
+          }
+          return true;
+        },
+      toggleCollapsibleBlock:
+        () =>
+        ({ tr, dispatch }) => {
+          const { selection } = tr;
+
+          if (dispatch) {
+            //
+          }
+          return true;
+        },
+    };
+  },
+
+  addInputRules() {
+    return [
+      new InputRule({
+        find: inputRegex,
+        handler({ chain, range: { from, to } }) {
+          chain()
+            .command(({ tr, dispatch, state }) => {
+              if (dispatch) {
+                const start = state.doc.resolve(from);
+                const end = state.doc.resolve(to);
+
+                tr.setSelection(new TextSelection(start, end));
+                tr.deleteSelection();
+
+                dispatch(tr);
+              }
+              return true;
+            })
+            .setCollapsibleBlock()
+            .setTextSelection(from)
+            .run();
+        },
+      }),
+    ];
   },
 });

--- a/src/TipTapEditor/DraggableBlock/DraggableBlockNode.ts
+++ b/src/TipTapEditor/DraggableBlock/DraggableBlockNode.ts
@@ -1,8 +1,8 @@
 import { Node } from '@tiptap/core';
 import { Fragment, Slice } from '@tiptap/pm/model';
-import { NodeSelection, TextSelection } from '@tiptap/pm/state';
+import { TextSelection } from '@tiptap/pm/state';
 import { ReplaceStep } from '@tiptap/pm/transform';
-import { ReactNodeViewRenderer } from '@tiptap/react';
+import { isNodeSelection, ReactNodeViewRenderer } from '@tiptap/react';
 
 import { DraggableBlock } from './DraggableBlock';
 
@@ -43,11 +43,11 @@ export const DraggableBlockNode = Node.create({
       ...this.parent?.(),
       splitDraggableBlock:
         () =>
-        ({ tr, state, dispatch }) => {
-          const { selection } = state;
+        ({ tr, dispatch }) => {
+          const { selection } = tr;
           const { $from, $to } = selection;
 
-          if (('node' in selection && (selection as NodeSelection).node.isBlock) || $from.depth < 2) {
+          if ((isNodeSelection(selection) && selection.node.isBlock) || $from.depth < 2) {
             return false;
           }
 

--- a/src/TipTapEditor/TipTapEditorConfigs.tsx
+++ b/src/TipTapEditor/TipTapEditorConfigs.tsx
@@ -30,6 +30,7 @@ export const EDITOR_EXTENSIONS: Extensions = [
       keepMarks: true,
       keepAttributes: false,
     },
+    blockquote: false,
     codeBlock: false,
     document: false,
     orderedList: {


### PR DESCRIPTION
Fixes #139 

- Typing `> ` now creates a collapsible (or transforms the current block into a collapsible block)
- The arrow's colour becomes lighter when the content is empty
- Pressing Backspace at the beginning of a collapsible block removes the block

This is a WIP branch, the behaviours when pressing Enter and when deleting content across nodes containing a collapsible block still need to be defined.