### PR TITLE
fix: prevent infinite rerendering in reference view

### DIFF
--- a/src/components/FileEntryTree.tsx
+++ b/src/components/FileEntryTree.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { VscFile, VscFolder } from 'react-icons/vsc';
 
 import { FileId } from '../atoms/types/FileData';
@@ -32,10 +33,10 @@ export function FileEntryTree(props: FileEntryTreeProps) {
             .filter((file) => !file.isDotfile)
             .map((file) =>
               file.isFolder ? (
-                <>
-                  <FileTreeNode fileName={file.name} isFolder key={file.path} />
-                  <FileEntryTree key={file.path} {...props} files={file.children} root={false} />
-                </>
+                <React.Fragment key={file.path}>
+                  <FileTreeNode fileName={file.name} isFolder />
+                  <FileEntryTree {...props} files={file.children} root={false} />
+                </React.Fragment>
               ) : (
                 <FileTreeNode
                   fileName={file.name}

--- a/src/views/ReferenceView.tsx
+++ b/src/views/ReferenceView.tsx
@@ -1,12 +1,14 @@
 import './ReferenceView.css';
 
 import { useAtomValue } from 'jotai';
+import { useMemo } from 'react';
 
 import { getDerivedReferenceAtom } from '../atoms/referencesState';
 import { ReferenceFileContent } from '../atoms/types/FileContent';
 
 export function ReferenceView({ referenceId }: { referenceId: ReferenceFileContent['referenceId'] }) {
-  const reference = useAtomValue(getDerivedReferenceAtom(referenceId));
+  const referenceAtom = useMemo(() => getDerivedReferenceAtom(referenceId), [referenceId]);
+  const reference = useAtomValue(referenceAtom);
 
   if (!reference) {
     return null;


### PR DESCRIPTION
Fixes #183 
This adds `useMemo` to memoize reference atom and prevent the infinite render loop
This also removes a duplicated key, that was triggering a warning message