### PR TITLE
Add vitest and arrow eslint plugins

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,6 +16,7 @@ module.exports = {
     'testing-library',
     'eslint-plugin-import',
     'jsdoc',
+    'vitest',
   ],
   extends: [
     'eslint:recommended',
@@ -27,6 +28,7 @@ module.exports = {
     'plugin:react-hooks/recommended',
     'plugin:jest-dom/recommended',
     'plugin:testing-library/react',
+    'plugin:vitest/recommended',
   ],
   settings: {
     react: {
@@ -183,5 +185,6 @@ module.exports = {
         allowStandaloneDeclarations: true,
       },
     ],
+    'vitest/consistent-test-it': 'error',
   },
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,5 @@
 /* eslint-disable no-undef */
+// eslint-disable-next-line jsdoc/no-restricted-syntax
 /** @type {import("@types/eslint").Linter.Config} */
 module.exports = {
   parser: '@typescript-eslint/parser',
@@ -9,6 +10,7 @@ module.exports = {
   },
   plugins: [
     '@typescript-eslint',
+    'prefer-arrow',
     'simple-import-sort',
     'jest-dom',
     'testing-library',
@@ -173,6 +175,12 @@ module.exports = {
             message: 'Use an implementation comment (//) instead of a JSDoc comment (/** ... */).',
           },
         ],
+      },
+    ],
+    'prefer-arrow/prefer-arrow-functions': [
+      'error',
+      {
+        allowStandaloneDeclarations: true,
       },
     ],
   },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -183,7 +183,6 @@ module.exports = {
       'error',
       {
         allowStandaloneDeclarations: true,
-        singleReturnOnly: true,
       },
     ],
     'vitest/consistent-test-it': 'error',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -183,6 +183,7 @@ module.exports = {
       'error',
       {
         allowStandaloneDeclarations: true,
+        singleReturnOnly: true,
       },
     ],
     'vitest/consistent-test-it': 'error',

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-testing-library": "^5.11.0",
+    "eslint-plugin-vitest": "^0.2.6",
     "husky": "^8.0.0",
     "jsdom": "^22.1.0",
     "json-schema-to-typescript": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest-dom": "^5.0.1",
     "eslint-plugin-jsdoc": "^46.2.6",
+    "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,7 @@ function LeftSidePanelWrapper() {
   const [primaryPane, setPrimaryPane] = useState<PrimarySideBarPane>('Explorer');
   const openReference = useSetAtom(openReferenceAtom);
 
-  function handleSideBarClick(selectedPane: PrimarySideBarPane) {
+  const handleSideBarClick = (selectedPane: PrimarySideBarPane) => {
     if (selectedPane === primaryPane) {
       // Toggle collapsing
       setPrimaryPaneCollapsed(!primaryPaneCollapsed);
@@ -56,7 +56,7 @@ function LeftSidePanelWrapper() {
       setPrimaryPaneCollapsed(false);
     }
     setPrimaryPane(selectedPane);
-  }
+  };
 
   React.useEffect(() => {
     if (primaryPaneCollapsed) {

--- a/src/api/chat.test.ts
+++ b/src/api/chat.test.ts
@@ -10,7 +10,7 @@ describe('chatWithAI', () => {
     vi.clearAllMocks();
   });
 
-  test('should return list of strings with content returned by sidecar', async () => {
+  it('should return list of strings with content returned by sidecar', async () => {
     vi.mocked(callSidecar).mockResolvedValue([
       {
         index: 0,
@@ -22,7 +22,7 @@ describe('chatWithAI', () => {
     expect(response).toStrictEqual(['some reply']);
   });
 
-  test('should return list of strings with content returned by sidecar', async () => {
+  it('should return list of strings with content returned by sidecar', async () => {
     vi.mocked(callSidecar).mockResolvedValue([
       {
         index: 0,
@@ -38,7 +38,7 @@ describe('chatWithAI', () => {
     expect(response).toStrictEqual(['some reply', 'Another reply']);
   });
 
-  test('should return empty list, and not call sidecar, if provided text is empty', async () => {
+  it('should return empty list, and not call sidecar, if provided text is empty', async () => {
     const callSidecarMock = vi.mocked(callSidecar).mockResolvedValue([]);
 
     const response = await chatWithAI('');
@@ -46,7 +46,7 @@ describe('chatWithAI', () => {
     expect(callSidecarMock.mock.calls.length).toBe(0);
   });
 
-  test('should return error message reply if exception thrown calling sidecar', async () => {
+  it('should return error message reply if exception thrown calling sidecar', async () => {
     vi.mocked(callSidecar).mockRejectedValue(new Error('Invalid API Key'));
 
     const response = await chatWithAI('input text');

--- a/src/api/chat.test.ts
+++ b/src/api/chat.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { chatWithAI } from './chat';
 import { callSidecar } from './sidecar';
@@ -22,7 +22,7 @@ describe('chatWithAI', () => {
     expect(response).toStrictEqual(['some reply']);
   });
 
-  it('should return list of strings with content returned by sidecar', async () => {
+  it('should return list of strings with content returned by sidecar 2', async () => {
     vi.mocked(callSidecar).mockResolvedValue([
       {
         index: 0,

--- a/src/api/ingestion.test.ts
+++ b/src/api/ingestion.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { getUploadsDir } from '../filesystem';
 import { runPDFIngestion } from './ingestion';
@@ -12,7 +12,7 @@ describe('runPDFIngestion', () => {
     vi.clearAllMocks();
   });
 
-  test('should call sidecar ingest with upload dir arg', async () => {
+  it('should call sidecar ingest with upload dir arg', async () => {
     const UPLOAD_DIR = '/some/upload/directory';
     vi.mocked(getUploadsDir).mockResolvedValue(UPLOAD_DIR);
     vi.mocked(callSidecar).mockResolvedValue({
@@ -25,7 +25,7 @@ describe('runPDFIngestion', () => {
     expect(vi.mocked(callSidecar).mock.calls[0]).toStrictEqual(['ingest', ['--pdf_directory', UPLOAD_DIR]]);
   });
 
-  test('Should map empty IngestResponse[] to empty ReferenceItem[]', async () => {
+  it('Should map empty IngestResponse[] to empty ReferenceItem[]', async () => {
     vi.mocked(callSidecar).mockResolvedValue({
       project_name: 'project-name',
       references: [],
@@ -35,7 +35,7 @@ describe('runPDFIngestion', () => {
     expect(response).toStrictEqual([]);
   });
 
-  test('Should map undefined IngestResponse to ReferenceItem', async () => {
+  it('Should map undefined IngestResponse to ReferenceItem', async () => {
     vi.mocked(callSidecar).mockResolvedValue({
       project_name: 'project-name',
       references: [
@@ -52,7 +52,7 @@ describe('runPDFIngestion', () => {
     expect(response[0].filename).toBe('file.pdf');
   });
 
-  test('Should map fullName of authors ReferenceItem', async () => {
+  it('Should map fullName of authors ReferenceItem', async () => {
     vi.mocked(callSidecar).mockResolvedValue({
       project_name: 'project-name',
       references: [

--- a/src/api/rewrite.test.ts
+++ b/src/api/rewrite.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { askForRewrite } from './rewrite';
 import { callSidecar } from './sidecar';
@@ -12,7 +12,7 @@ describe('askForRewrite', () => {
     vi.clearAllMocks();
   });
 
-  test('should call sidecar rewrite with text', async () => {
+  it('should call sidecar rewrite with text', async () => {
     vi.mocked(callSidecar).mockResolvedValue([] as RewriteChoice[]);
 
     const REWRITE_REQUEST_TEXT = 'Some text to rewrite';
@@ -21,7 +21,7 @@ describe('askForRewrite', () => {
     expect(vi.mocked(callSidecar).mock.calls[0]).toStrictEqual(['rewrite', ['--text', REWRITE_REQUEST_TEXT]]);
   });
 
-  test('Should return text from first RewriteChoice', async () => {
+  it('Should return text from first RewriteChoice', async () => {
     const REWRITE_REPLY_TEXT = 'The rewrite reply!';
     vi.mocked(callSidecar).mockResolvedValue([
       {
@@ -34,14 +34,14 @@ describe('askForRewrite', () => {
     expect(response).toBe(REWRITE_REPLY_TEXT);
   });
 
-  test('Should return error text for internal sidecar exception', async () => {
+  it('Should return error text for internal sidecar exception', async () => {
     vi.mocked(callSidecar).mockRejectedValue('some failure');
 
     const response = await askForRewrite('some input');
     expect(response).toMatch(/^rewrite error/i);
   });
 
-  test('Should return empty text and not call sidecar for empty selection', async () => {
+  it('Should return empty text and not call sidecar for empty selection', async () => {
     const response = await askForRewrite('  ');
     expect(response).toBe('');
     expect(vi.mocked(callSidecar).mock.calls).toHaveLength(0);

--- a/src/api/sidecar.test.ts
+++ b/src/api/sidecar.test.ts
@@ -54,7 +54,7 @@ describe('sidecar', () => {
     vi.clearAllMocks();
   });
 
-  test('should send settings values via ENV', async () => {
+  it('should send settings values via ENV', async () => {
     let env: undefined | Record<string, string>;
     vi.mocked(Command).mockImplementation((program: string, args?: string | string[], options?: SpawnOptions) => {
       env = options?.env;
@@ -82,7 +82,7 @@ describe('sidecar', () => {
     expect(env?.SIDECAR_LOG_DIR).toBe(mockSettings.sidecar.logging.path);
   });
 
-  test('should throw exception if stderr has content', async () => {
+  it('should throw exception if stderr has content', async () => {
     vi.mocked(Command).mockImplementation(
       () =>
         ({

--- a/src/api/sidecar.test.ts
+++ b/src/api/sidecar.test.ts
@@ -1,5 +1,5 @@
 import { Command, SpawnOptions } from '@tauri-apps/api/shell';
-import { describe, test } from 'vitest';
+import { describe, it } from 'vitest';
 
 import {
   getCachedSetting,

--- a/src/atoms/fileActions.test.ts
+++ b/src/atoms/fileActions.test.ts
@@ -26,7 +26,7 @@ describe('fileActions', () => {
     vi.clearAllMocks();
   });
 
-  test('should be empty by default', () => {
+  it('should be empty by default', () => {
     const store = createStore();
     const leftPane = runGetAtomHook(leftPaneAtom, store);
     const rightPane = runGetAtomHook(rightPaneAtom, store);
@@ -37,7 +37,7 @@ describe('fileActions', () => {
     expect(rightPane.current.activeFile).toBeUndefined();
   });
 
-  test('should open TXT file in the left pane, and be active', () => {
+  it('should open TXT file in the left pane, and be active', () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
     const leftPane = runGetAtomHook(leftPaneAtom, store);
@@ -54,7 +54,7 @@ describe('fileActions', () => {
     expect(leftPane.current.activeFile).toEqual(fileData.fileId);
   });
 
-  test('should open PDF file in the right pane, and be active', () => {
+  it('should open PDF file in the right pane, and be active', () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
     const rightPane = runGetAtomHook(rightPaneAtom, store);
@@ -71,7 +71,7 @@ describe('fileActions', () => {
     expect(rightPane.current.activeFile).toEqual(fileData.fileId);
   });
 
-  test('should open file once in same panel', () => {
+  it('should open file once in same panel', () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
     const leftPane = runGetAtomHook(leftPaneAtom, store);
@@ -87,7 +87,7 @@ describe('fileActions', () => {
     expect(leftPane.current.files.length).toBe(1);
   });
 
-  test('should open Reference in the right pane, and make it active', () => {
+  it('should open Reference in the right pane, and make it active', () => {
     const store = createStore();
     const setReferences = runSetAtomHook(setReferencesAtom, store);
     const openReference = runSetAtomHook(openReferenceAtom, store);
@@ -116,7 +116,7 @@ describe('fileActions', () => {
     expect(rightPane.current.activeFile).toEqual(referenceFileId);
   });
 
-  test('should close opened file in same pane', () => {
+  it('should close opened file in same pane', () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
     const closeFileFromPane = runSetAtomHook(closeFileFromPaneAtom, store);
@@ -138,7 +138,7 @@ describe('fileActions', () => {
     expect(leftPane.current.files.length).toBe(1);
   });
 
-  test('should not fail trying to close file that is not opened in pane', () => {
+  it('should not fail trying to close file that is not opened in pane', () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
     const closeFileFromPane = runSetAtomHook(closeFileFromPaneAtom, store);
@@ -162,7 +162,7 @@ describe('fileActions', () => {
     expect(leftPane.current.files).not.toContainEqual(notOpenedFileData);
   });
 
-  test('should not fail trying to select file that is not opened in pane', () => {
+  it('should not fail trying to select file that is not opened in pane', () => {
     const store = createStore();
     const selectFileInPane = runSetAtomHook(selectFileInPaneAtom, store);
     const leftPane = runGetAtomHook(leftPaneAtom, store);
@@ -176,7 +176,7 @@ describe('fileActions', () => {
     expect(leftPane.current.files).not.toContainEqual(fileData);
   });
 
-  test('should not fail when trying to open a reference that does not exist', () => {
+  it('should not fail when trying to open a reference that does not exist', () => {
     const store = createStore();
     const openReference = runSetAtomHook(openReferenceAtom, store);
     const rightPane = runGetAtomHook(rightPaneAtom, store);
@@ -201,7 +201,7 @@ describe('fileActions', () => {
     expect(rightPane.current.activeFile).toBeUndefined();
   });
 
-  test('should close all opened files with closeAllFilesAtom', () => {
+  it('should close all opened files with closeAllFilesAtom', () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
     const closeAllFiles = runSetAtomHook(closeAllFilesAtom, store);
@@ -226,7 +226,7 @@ describe('fileActions', () => {
     expect(totalOpenedFiles).toBe(0);
   });
 
-  test('should split (move) file from one tab to the other', () => {
+  it('should split (move) file from one tab to the other', () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
     const leftPane = runGetAtomHook(leftPaneAtom, store);
@@ -250,7 +250,7 @@ describe('fileActions', () => {
     expect(rightPane.current.files).toContainEqual(fileData);
   });
 
-  test('should split (move) file from one tab to same tab', () => {
+  it('should split (move) file from one tab to same tab', () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
     const leftPane = runGetAtomHook(leftPaneAtom, store);
@@ -274,7 +274,7 @@ describe('fileActions', () => {
     expect(rightPane.current.files).not.toContainEqual(fileData);
   });
 
-  test('should NOT split (move) file if file is NOT opened', () => {
+  it('should NOT split (move) file if file is NOT opened', () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
     const leftPane = runGetAtomHook(leftPaneAtom, store);
@@ -298,7 +298,7 @@ describe('fileActions', () => {
     expect(rightPane.current.files).not.toContainEqual(fileData);
   });
 
-  test('should make another file active, in same pane, after closing the active', () => {
+  it('should make another file active, in same pane, after closing the active', () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
     const closeFileFromPane = runSetAtomHook(closeFileFromPaneAtom, store);
@@ -323,7 +323,7 @@ describe('fileActions', () => {
     expect(leftPane.current.activeFile).toEqual(fileBData.fileId);
   });
 
-  test('should not make another file active, in same pane, after closing other than the active', () => {
+  it('should not make another file active, in same pane, after closing other than the active', () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
     const closeFileFromPane = runSetAtomHook(closeFileFromPaneAtom, store);
@@ -348,7 +348,7 @@ describe('fileActions', () => {
     expect(leftPane.current.activeFile).toEqual(fileCData.fileId);
   });
 
-  test('should not open folder entries', () => {
+  it('should not open folder entries', () => {
     const store = createStore();
     const openFileResult = runSetAtomHook(openFileAtom, store);
     const leftPane = runGetAtomHook(leftPaneAtom, store);
@@ -363,7 +363,7 @@ describe('fileActions', () => {
     expect(rightPane.current.files.length).toBe(0);
   });
 
-  test('should focus panel to make active', () => {
+  it('should focus panel to make active', () => {
     const store = createStore();
     const activePane = runGetAtomHook(activePaneAtom, store);
     const focusPanel = runSetAtomHook(focusPaneAtom, store);
@@ -377,7 +377,7 @@ describe('fileActions', () => {
     expect(activePane.current.id).toBe(paneToFocus);
   });
 
-  test('should read file content on openFile', async () => {
+  it('should read file content on openFile', async () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
     const leftPane = runGetAtomHook(leftPaneAtom, store);

--- a/src/atoms/fileActions.test.ts
+++ b/src/atoms/fileActions.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { createStore, useAtomValue } from 'jotai';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { readFileContent } from '../filesystem';
 import { ReferenceItem } from '../types/ReferenceItem';

--- a/src/atoms/selectionState.test.ts
+++ b/src/atoms/selectionState.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test } from 'vitest';
 import { selectionAtom } from './selectionState';
 
 describe('selectionState', () => {
-  test('should be empty by default', () => {
+  it('should be empty by default', () => {
     // Note: We need to use `renderHook` to test atoms outside of react/provider
     // https://github.com/pmndrs/jotai/blob/main/docs/guides/testing.mdx#custom-hooks
     const { result } = renderHook(() => useAtom(selectionAtom));
@@ -13,7 +13,7 @@ describe('selectionState', () => {
     expect(selection).toBe('');
   });
 
-  test('should change to string value', () => {
+  it('should change to string value', () => {
     const { result } = renderHook(() => useAtom(selectionAtom));
     const [selection, setSelection] = result.current;
     expect(selection).toBe('');

--- a/src/atoms/selectionState.test.ts
+++ b/src/atoms/selectionState.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { useAtom } from 'jotai';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { selectionAtom } from './selectionState';
 

--- a/src/components/FileEntryTree.test.tsx
+++ b/src/components/FileEntryTree.test.tsx
@@ -8,13 +8,13 @@ describe('FileEntryTree component', () => {
     vi.clearAllMocks();
   });
 
-  test('should render a file', () => {
+  it('should render a file', () => {
     const { fileEntry } = makeFile('File 1.pdf');
     render(<FileEntryTree files={[fileEntry]} root selectedFiles={[]} onClick={noop} />);
     expect(screen.getByText(fileEntry.name)).toBeInTheDocument();
   });
 
-  test('should call onClick with file path', async () => {
+  it('should call onClick with file path', async () => {
     const { fileEntry } = makeFile('File 1.pdf');
     const onClick = vi.fn();
     const { user } = setup(<FileEntryTree files={[fileEntry]} root selectedFiles={[]} onClick={onClick} />);
@@ -25,7 +25,7 @@ describe('FileEntryTree component', () => {
     expect(onClick).toHaveBeenCalledWith(fileEntry.path);
   });
 
-  test('should render a folder and its children', () => {
+  it('should render a folder and its children', () => {
     const { fileEntry } = makeFile('File 1.pdf');
     const folderEntry = makeFolder('Folder 1', [fileEntry]);
     render(<FileEntryTree files={[folderEntry]} root selectedFiles={[]} onClick={noop} />);
@@ -33,7 +33,7 @@ describe('FileEntryTree component', () => {
     expect(screen.getByText(folderEntry.name)).toBeInTheDocument();
   });
 
-  test('should render a right action', () => {
+  it('should render a right action', () => {
     const { fileEntry } = makeFile('File 1.pdf');
     const rightActionMock = vi.fn().mockReturnValue(<div>Right action</div>);
     render(<FileEntryTree files={[fileEntry]} rightAction={rightActionMock} root selectedFiles={[]} onClick={noop} />);
@@ -43,7 +43,7 @@ describe('FileEntryTree component', () => {
     expect(screen.getByText('Right action')).toBeInTheDocument();
   });
 
-  test('should not render dotfiles', () => {
+  it('should not render dotfiles', () => {
     const { fileEntry } = makeFile('File 1.pdf');
     const { fileEntry: dotfileFileEntry } = makeFile('.file2');
     render(<FileEntryTree files={[fileEntry, dotfileFileEntry]} root selectedFiles={[]} onClick={noop} />);

--- a/src/components/PrimarySideBar.test.tsx
+++ b/src/components/PrimarySideBar.test.tsx
@@ -3,26 +3,26 @@ import { render, screen, userEvent } from '../utils/test-utils';
 import { PrimarySideBar } from './PrimarySideBar';
 
 describe('PrimarySideBar', () => {
-  test('should display Explorer and References icons', () => {
+  it('should display Explorer and References icons', () => {
     render(<PrimarySideBar activePane="Explorer" onClick={noop} onSettingsClick={noop} />);
     expect(screen.getByRole('menubar')).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Explorer' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'References' })).toBeInTheDocument();
   });
 
-  test('should display active icon with 100% opacity ', () => {
+  it('should display active icon with 100% opacity', () => {
     render(<PrimarySideBar activePane="References" onClick={noop} onSettingsClick={noop} />);
     expect(screen.getByRole('menubar')).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'References' })).toHaveClass('opacity-100');
   });
 
-  test('should display inactive icon with 50% opacity ', () => {
+  it('should display inactive icon with 50% opacity', () => {
     render(<PrimarySideBar activePane="References" onClick={noop} onSettingsClick={noop} />);
     expect(screen.getByRole('menubar')).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Explorer' })).toHaveClass('opacity-50');
   });
 
-  test('should call onClick with pane name', async () => {
+  it('should call onClick with pane name', async () => {
     const fn = vi.fn();
     render(<PrimarySideBar activePane="References" onClick={fn} onSettingsClick={noop} />);
     await userEvent.setup().click(screen.getByRole('menuitem', { name: 'Explorer' }));
@@ -30,7 +30,7 @@ describe('PrimarySideBar', () => {
     expect(fn).toBeCalledWith('Explorer');
   });
 
-  test('should call onSettingsClick with click in the settings icon', async () => {
+  it('should call onSettingsClick with click in the settings icon', async () => {
     const settingsFn = vi.fn();
     render(<PrimarySideBar activePane="References" onClick={noop} onSettingsClick={settingsFn} />);
     await userEvent.setup().click(screen.getByRole('menuitem', { name: 'Settings' }));

--- a/src/components/TabPane.test.tsx
+++ b/src/components/TabPane.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, userEvent, within } from './../utils/test-utils';
 import { TabPane } from './TabPane';
 
 describe('TabPane component', () => {
-  test('should render the one tab', () => {
+  it('should render the one tab', () => {
     render(
       <TabPane
         items={[{ key: 'k1', value: '1', text: 'File 1.txt' }]}
@@ -14,7 +14,7 @@ describe('TabPane component', () => {
     expect(screen.getByText('File 1.txt')).toBeInTheDocument();
   });
 
-  test('should render the two tabs', () => {
+  it('should render the two tabs', () => {
     render(
       <TabPane
         items={[
@@ -30,7 +30,7 @@ describe('TabPane component', () => {
     expect(screen.getByText('File 2.txt')).toBeInTheDocument();
   });
 
-  test('should render aria tablist with two aria tabs, one selected', () => {
+  it('should render aria tablist with two aria tabs, one selected', () => {
     render(
       <TabPane
         items={[
@@ -47,7 +47,7 @@ describe('TabPane component', () => {
     expect(screen.getByRole('tab', { selected: true, name: 'File 1.txt' })).toBeInTheDocument();
   });
 
-  test('should call onClick when clicked', async () => {
+  it('should call onClick when clicked', async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();
 
@@ -71,7 +71,7 @@ describe('TabPane component', () => {
     expect(onClick).toBeCalled();
   });
 
-  test('should call onCloseClick when X is clicked (and no call to onClick)', async () => {
+  it('should call onCloseClick when X is clicked (and no call to onClick)', async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();
     const onCloseClick = vi.fn();

--- a/src/editor/TipTapEditor.tsx
+++ b/src/editor/TipTapEditor.tsx
@@ -20,7 +20,7 @@ export function TipTapEditor({ editorContent }: EditorProps) {
     const newEditor = new Editor({
       extensions: EDITOR_EXTENSIONS,
       content: editorContent ?? INITIAL_CONTENT,
-      onSelectionUpdate(update) {
+      onSelectionUpdate: (update) => {
         const updatedEditor = update.editor;
         const { from, to } = updatedEditor.view.state.selection;
         const text = updatedEditor.view.state.doc.textBetween(from, to);

--- a/src/editor/nodes/collapsibleBlock/CollapsibleBlock.test.tsx
+++ b/src/editor/nodes/collapsibleBlock/CollapsibleBlock.test.tsx
@@ -10,7 +10,7 @@ describe('CollapsibleBlock', () => {
     extensions: EDITOR_EXTENSIONS,
   });
 
-  test('should collapse block when clicking on the arrow', async () => {
+  it('should collapse block when clicking on the arrow', async () => {
     editor.commands.setContent(defaultUncollapsedCollapsibleBlock);
     const { user } = setup(<EditorContent editor={editor} />);
 
@@ -27,7 +27,7 @@ describe('CollapsibleBlock', () => {
     expect(collapsibleBlock.attrs.folded).toBe(true);
   });
 
-  test('should uncollapse block when clicking on the arrow', async () => {
+  it('should uncollapse block when clicking on the arrow', async () => {
     editor.commands.setContent(defaultCollapsibleBlock);
     const { user } = setup(<EditorContent editor={editor} />);
 

--- a/src/editor/nodes/collapsibleBlock/helpers/changeCollapsibleBlockToParagraphs.test.ts
+++ b/src/editor/nodes/collapsibleBlock/helpers/changeCollapsibleBlockToParagraphs.test.ts
@@ -15,7 +15,7 @@ describe('changeCollapsibleBlockToParagraph', () => {
     editor.commands.setContent(defaultCollapsibleBlock);
   });
 
-  test('should transform collapsible block into paragraphs', () => {
+  it('should transform collapsible block into paragraphs', () => {
     const { from } = TextSelection.near(editor.state.doc.resolve(0));
 
     expect(editor.state.doc.childCount).toBe(1);
@@ -39,7 +39,7 @@ describe('changeCollapsibleBlockToParagraph', () => {
     expect(getText(doc.child(2))).toEqual(getText(initialContent[1]));
   });
 
-  test('should not do anything if pos does not belong to a collapsibleBlock', () => {
+  it('should not do anything if pos does not belong to a collapsibleBlock', () => {
     const initialDoc = editor.state.doc;
 
     editor.commands.command(({ tr }) => {
@@ -50,7 +50,7 @@ describe('changeCollapsibleBlockToParagraph', () => {
     expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
   });
 
-  test('should not do anything if there is no collapsibleBlock in the document', () => {
+  it('should not do anything if there is no collapsibleBlock in the document', () => {
     editor.commands.setContent('<p></p>');
     expect(findNodesByNodeType(editor.state.doc, 'collapsibleBlock')).toHaveLength(0);
 

--- a/src/editor/nodes/collapsibleBlock/helpers/unsetPartiallySelectedCollapsibleBlocks.test.ts
+++ b/src/editor/nodes/collapsibleBlock/helpers/unsetPartiallySelectedCollapsibleBlocks.test.ts
@@ -15,7 +15,7 @@ describe('unsetPartiallySelectedCollapsibleBlocks', () => {
     editor.commands.setContent('<p>First paragraph</p>' + defaultCollapsibleBlock + '<p>Last paragraph</p>');
   });
 
-  test('should unset the collapsible block when it is partially selected', () => {
+  it('should unset the collapsible block when it is partially selected', () => {
     const selection = TextSelection.between(editor.state.doc.resolve(0), editor.state.doc.resolve(30));
     expect(editor.state.doc.childCount).toBe(3);
     const [collapsibleBlock] = findNodesByNodeType(editor.state.doc, 'collapsibleBlock');
@@ -46,7 +46,7 @@ describe('unsetPartiallySelectedCollapsibleBlocks', () => {
     expect(doc.child(4).toJSON()).toEqual(lastParagraph.toJSON());
   });
 
-  test('should not do anything if the collapsible block is completely selected', () => {
+  it('should not do anything if the collapsible block is completely selected', () => {
     const initialDoc = editor.state.doc;
 
     const commandResult = editor.chain().selectAll().command(unsetPartiallySelectedCollapsibleBlocks).run();
@@ -54,7 +54,7 @@ describe('unsetPartiallySelectedCollapsibleBlocks', () => {
     expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
   });
 
-  test('should not do anything if the selection head is inside the collapsible block', () => {
+  it('should not do anything if the selection head is inside the collapsible block', () => {
     const firstParagraph = editor.state.doc.child(0);
     const selection = TextSelection.between(
       // + 6 is to position the caret in the middle of the collapsible summary

--- a/src/editor/nodes/collapsibleBlock/helpers/unsetPartiallySelectedCollapsibleBlocks.ts
+++ b/src/editor/nodes/collapsibleBlock/helpers/unsetPartiallySelectedCollapsibleBlocks.ts
@@ -7,7 +7,7 @@ import { changeCollapsibleBlockToParagraphs } from './changeCollapsibleBlockToPa
  * Command that unsets any collapsible block that is partially selected,
  * ie. part of the node is selected but not the whole node
  */
-export const unsetPartiallySelectedCollapsibleBlocks: Command = function ({ dispatch, editor, tr }) {
+export const unsetPartiallySelectedCollapsibleBlocks: Command = ({ dispatch, editor, tr }) => {
   const { from, to } = tr.selection;
   let unsetNodes = 0;
 

--- a/src/editor/nodes/collapsibleBlock/inputRuleHandlers/chevronHandler.test.ts
+++ b/src/editor/nodes/collapsibleBlock/inputRuleHandlers/chevronHandler.test.ts
@@ -8,7 +8,7 @@ describe('Chevron input rule handler', () => {
   const editor = new Editor({
     extensions: EDITOR_EXTENSIONS,
   });
-  test('should remove "> " and turn paragraph into an uncollapsed and focused collapsible block', () => {
+  it('should remove "> " and turn paragraph into an uncollapsed and focused collapsible block', () => {
     editor.chain().setContent('<p>> Some content</p>').setTextSelection(4).run();
 
     chevronHandler({ can: () => editor.can(), chain: () => editor.chain(), range: { from: 2, to: 4 } });
@@ -19,7 +19,7 @@ describe('Chevron input rule handler', () => {
     expect(collapsibleBlocks).toHaveLength(1);
 
     const [collapsibleBlock] = collapsibleBlocks;
-    expect(getText(collapsibleBlock)).toEqual('Some content');
+    expect(getText(collapsibleBlock)).toBe('Some content');
 
     expect(collapsibleBlock.attrs.folded).toBe(false);
 
@@ -27,11 +27,11 @@ describe('Chevron input rule handler', () => {
     const { $from } = editor.state.selection;
 
     // The selection should point to the start of the text
-    expect(editor.state.doc.nodeAt($from.pos)?.type.name).toEqual('text');
+    expect(editor.state.doc.nodeAt($from.pos)?.type.name).toBe('text');
     expect($from.sameParent(editor.state.doc.resolve($from.pos - 1))).toBe(false);
   });
 
-  test('should do nothing when the block cannot be turned into a collapsible block', () => {
+  it('should do nothing when the block cannot be turned into a collapsible block', () => {
     editor.chain().setContent('<h1>> Some content</h1>').setTextSelection(4).run();
     const initialDoc = editor.state.doc;
 

--- a/src/editor/nodes/collapsibleBlock/keyboardShortcutCommands/backspace.test.ts
+++ b/src/editor/nodes/collapsibleBlock/keyboardShortcutCommands/backspace.test.ts
@@ -10,7 +10,7 @@ describe('Backspace keyboard shortcut command', () => {
     extensions: EDITOR_EXTENSIONS,
   });
 
-  test('should turn collapsible block back into paragraphs when selection is at the beginning of the summary', () => {
+  it('should turn collapsible block back into paragraphs when selection is at the beginning of the summary', () => {
     // 3 is to position the caret at the beginning of the summary
     editor.chain().setContent(defaultCollapsibleBlock).setTextSelection(3).run();
     expect(editor.state.doc.childCount).toBe(1);
@@ -22,12 +22,12 @@ describe('Backspace keyboard shortcut command', () => {
     // A new collapsible should have been added
     expect(doc.childCount).toBe(3);
 
-    expect(getText(doc.child(0))).toEqual('Header');
-    expect(getText(doc.child(1))).toEqual('Content Line 1');
-    expect(getText(doc.child(2))).toEqual('Content Line 2');
+    expect(getText(doc.child(0))).toBe('Header');
+    expect(getText(doc.child(1))).toBe('Content Line 1');
+    expect(getText(doc.child(2))).toBe('Content Line 2');
   });
 
-  test('should remove content and collapse block when removing the only remaining content block of collapsible block', () => {
+  it('should remove content and collapse block when removing the only remaining content block of collapsible block', () => {
     // 7 is to position the caret in the content
     editor.chain().setContent(uncollapsedCollapsibleBlockWithEmptyContent).setTextSelection(7).run();
 
@@ -50,7 +50,7 @@ describe('Backspace keyboard shortcut command', () => {
     expect(getText(collapsibleBlock)).toEqual(initialSummary);
   });
 
-  test('should not do anything when the selection is not at the beginning of the summary', () => {
+  it('should not do anything when the selection is not at the beginning of the summary', () => {
     editor.chain().setContent(defaultCollapsibleBlock).setTextSelection(4).run();
     const initialDoc = editor.state.doc;
 
@@ -59,7 +59,7 @@ describe('Backspace keyboard shortcut command', () => {
     expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
   });
 
-  test('should not do anything when removing a content block that has siblings', () => {
+  it('should not do anything when removing a content block that has siblings', () => {
     const content = `
     <collapsible-block folded='false'>
       <collapsible-summary></collapsible-summary>
@@ -76,7 +76,7 @@ describe('Backspace keyboard shortcut command', () => {
     expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
   });
 
-  test('should not do anything when the selection is not in a collapsible block', () => {
+  it('should not do anything when the selection is not in a collapsible block', () => {
     editor
       .chain()
       .setContent('<p>Some content</p>' + defaultCollapsibleBlock)
@@ -89,7 +89,7 @@ describe('Backspace keyboard shortcut command', () => {
     expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
   });
 
-  test('should not do anything when the selection is not empty', () => {
+  it('should not do anything when the selection is not empty', () => {
     editor.chain().setContent(defaultCollapsibleBlock).selectAll().run();
     const initialDoc = editor.state.doc;
 

--- a/src/editor/nodes/collapsibleBlock/keyboardShortcutCommands/backspace.ts
+++ b/src/editor/nodes/collapsibleBlock/keyboardShortcutCommands/backspace.ts
@@ -1,6 +1,6 @@
 import { KeyboardShortcutCommand } from '@tiptap/react';
 
-export const backspace: KeyboardShortcutCommand = function ({ editor }) {
+export const backspace: KeyboardShortcutCommand = ({ editor }) => {
   const { selection } = editor.state;
   if (!selection.empty) {
     return false;

--- a/src/editor/nodes/collapsibleBlock/keyboardShortcutCommands/enter.test.ts
+++ b/src/editor/nodes/collapsibleBlock/keyboardShortcutCommands/enter.test.ts
@@ -10,7 +10,7 @@ describe('Enter keyboard shortcut command', () => {
     extensions: EDITOR_EXTENSIONS,
   });
 
-  test('should split a collapsed collapsible block', () => {
+  it('should split a collapsed collapsible block', () => {
     // 6 is to position the caret in the middle of 'Header'
     editor.chain().setContent(defaultCollapsibleBlock).setTextSelection(6).run();
     expect(editor.state.doc.childCount).toBe(1);
@@ -24,20 +24,20 @@ describe('Enter keyboard shortcut command', () => {
     const [firstNode, secondNode] = findNodesByNodeType(editor.state.doc, 'collapsibleBlock');
     // The first collapsible block should contain the content of the initial block
     expect(firstNode.childCount).toBe(2);
-    expect(getText(firstNode.child(0))).toEqual('Hea');
+    expect(getText(firstNode.child(0))).toBe('Hea');
     expect(firstNode.attrs.folded).toBe(true);
     const content = firstNode.child(1);
     expect(content.childCount).toBe(2);
-    expect(getText(content.child(0))).toEqual('Content Line 1');
-    expect(getText(content.child(1))).toEqual('Content Line 2');
+    expect(getText(content.child(0))).toBe('Content Line 1');
+    expect(getText(content.child(1))).toBe('Content Line 2');
 
     // The second collapsible block should not have content
     expect(secondNode.childCount).toBe(1);
-    expect(getText(secondNode.child(0))).toEqual('der');
+    expect(getText(secondNode.child(0))).toBe('der');
     expect(secondNode.attrs.folded).toBe(true);
   });
 
-  test('should add a new content line to an uncollapsed collapsible block', () => {
+  it('should add a new content line to an uncollapsed collapsible block', () => {
     // 6 is to position the caret in the middle of 'Header'
     editor.chain().setContent(defaultUncollapsedCollapsibleBlock).setTextSelection(6).run();
     expect(editor.state.doc.childCount).toBe(1);
@@ -50,38 +50,16 @@ describe('Enter keyboard shortcut command', () => {
     const [collapsibleBlock] = findNodesByNodeType(editor.state.doc, 'collapsibleBlock');
     expect(collapsibleBlock).toBeDefined();
     expect(collapsibleBlock.childCount).toBe(2);
-    expect(getText(collapsibleBlock.child(0))).toEqual('Hea');
+    expect(getText(collapsibleBlock.child(0))).toBe('Hea');
 
     const content = collapsibleBlock.child(1);
     expect(content.childCount).toBe(3);
-    expect(getText(content.child(0))).toEqual('der');
-    expect(getText(content.child(1))).toEqual('Content Line 1');
-    expect(getText(content.child(2))).toEqual('Content Line 2');
+    expect(getText(content.child(0))).toBe('der');
+    expect(getText(content.child(1))).toBe('Content Line 1');
+    expect(getText(content.child(2))).toBe('Content Line 2');
   });
 
-  test('should add a new content line to an uncollapsed collapsible block', () => {
-    // 6 is to position the caret in the middle of 'Header'
-    editor.chain().setContent(defaultUncollapsedCollapsibleBlock).setTextSelection(6).run();
-    expect(editor.state.doc.childCount).toBe(1);
-
-    const commandResult = enter({ editor });
-    expect(commandResult).toBe(true);
-
-    expect(editor.state.doc.childCount).toBe(1);
-
-    const [collapsibleBlock] = findNodesByNodeType(editor.state.doc, 'collapsibleBlock');
-    expect(collapsibleBlock).toBeDefined();
-    expect(collapsibleBlock.childCount).toBe(2);
-    expect(getText(collapsibleBlock.child(0))).toEqual('Hea');
-
-    const content = collapsibleBlock.child(1);
-    expect(content.childCount).toBe(3);
-    expect(getText(content.child(0))).toEqual('der');
-    expect(getText(content.child(1))).toEqual('Content Line 1');
-    expect(getText(content.child(2))).toEqual('Content Line 2');
-  });
-
-  test('should not do anything when the selection is not in a collapsible block', () => {
+  it('should not do anything when the selection is not in a collapsible block', () => {
     editor
       .chain()
       .setContent('<p>Some content</p>' + defaultCollapsibleBlock)
@@ -94,7 +72,7 @@ describe('Enter keyboard shortcut command', () => {
     expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
   });
 
-  test('should not do anything when the selection is not empty', () => {
+  it('should not do anything when the selection is not empty', () => {
     editor.chain().setContent(defaultCollapsibleBlock).selectAll().run();
     const initialDoc = editor.state.doc;
 

--- a/src/editor/nodes/collapsibleBlock/keyboardShortcutCommands/enter.ts
+++ b/src/editor/nodes/collapsibleBlock/keyboardShortcutCommands/enter.ts
@@ -1,7 +1,7 @@
 import { TextSelection } from '@tiptap/pm/state';
 import { KeyboardShortcutCommand } from '@tiptap/react';
 
-export const enter: KeyboardShortcutCommand = function ({ editor }) {
+export const enter: KeyboardShortcutCommand = ({ editor }) => {
   const { selection } = editor.state;
   if (!selection.empty) {
     return false;

--- a/src/editor/nodes/collapsibleBlock/keyboardShortcutCommands/modEnter.test.ts
+++ b/src/editor/nodes/collapsibleBlock/keyboardShortcutCommands/modEnter.test.ts
@@ -10,7 +10,7 @@ describe('Mod-Enter keyboard shortcut command', () => {
     extensions: EDITOR_EXTENSIONS,
   });
 
-  test('should collapse collapsible block', () => {
+  it('should collapse collapsible block', () => {
     editor.chain().setContent(defaultUncollapsedCollapsibleBlock).setTextSelection(0).run();
 
     let [collapsibleBlock] = findNodesByNodeType(editor.state.doc, 'collapsibleBlock');
@@ -25,7 +25,7 @@ describe('Mod-Enter keyboard shortcut command', () => {
     expect(collapsibleBlock.attrs.folded).toBe(true);
   });
 
-  test('should uncollapse collapsible block', () => {
+  it('should uncollapse collapsible block', () => {
     editor.chain().setContent(defaultCollapsibleBlock).setTextSelection(0).run();
 
     let [collapsibleBlock] = findNodesByNodeType(editor.state.doc, 'collapsibleBlock');
@@ -40,7 +40,7 @@ describe('Mod-Enter keyboard shortcut command', () => {
     expect(collapsibleBlock.attrs.folded).toBe(false);
   });
 
-  test('should not do anything when the selection is in the content of the collapsible block', () => {
+  it('should not do anything when the selection is in the content of the collapsible block', () => {
     editor.chain().setContent(defaultCollapsibleBlock).setTextSelection(15).run();
     const initialDoc = editor.state.doc;
 
@@ -49,7 +49,7 @@ describe('Mod-Enter keyboard shortcut command', () => {
     expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
   });
 
-  test('should not do anything when the selection is not in a collapsible block', () => {
+  it('should not do anything when the selection is not in a collapsible block', () => {
     editor
       .chain()
       .setContent('<p>Some content</p>' + defaultCollapsibleBlock)
@@ -62,7 +62,7 @@ describe('Mod-Enter keyboard shortcut command', () => {
     expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
   });
 
-  test('should not do anything when the selection is not empty', () => {
+  it('should not do anything when the selection is not empty', () => {
     editor.chain().setContent(defaultCollapsibleBlock).selectAll().run();
     const initialDoc = editor.state.doc;
 

--- a/src/editor/nodes/collapsibleBlock/keyboardShortcutCommands/modEnter.ts
+++ b/src/editor/nodes/collapsibleBlock/keyboardShortcutCommands/modEnter.ts
@@ -1,6 +1,6 @@
 import { KeyboardShortcutCommand } from '@tiptap/react';
 
-export const modEnter: KeyboardShortcutCommand = function ({ editor }) {
+export const modEnter: KeyboardShortcutCommand = ({ editor }) => {
   if (!editor.state.selection.empty) {
     return false;
   }

--- a/src/editor/nodes/collapsibleBlock/nodes/CollapsibleBlockContent.ts
+++ b/src/editor/nodes/collapsibleBlock/nodes/CollapsibleBlockContent.ts
@@ -7,15 +7,11 @@ export const CollapsibleBlockContentNode = Node.create({
   defining: true,
   selectable: false,
 
-  parseHTML() {
-    return [
-      {
-        tag: 'collapsible-content',
-      },
-    ];
-  },
+  parseHTML: () => [
+    {
+      tag: 'collapsible-content',
+    },
+  ],
 
-  renderHTML({ HTMLAttributes }) {
-    return ['collapsible-content', mergeAttributes(HTMLAttributes), 0];
-  },
+  renderHTML: ({ HTMLAttributes }) => ['collapsible-content', mergeAttributes(HTMLAttributes), 0],
 });

--- a/src/editor/nodes/collapsibleBlock/nodes/CollapsibleBlockNode.test.ts
+++ b/src/editor/nodes/collapsibleBlock/nodes/CollapsibleBlockNode.test.ts
@@ -21,7 +21,7 @@ describe('CollapsibleBlockNode commands', () => {
       editor.commands.setContent(defaultCollapsibleBlock);
     });
 
-    test('should uncollapse with command', () => {
+    it('should uncollapse with command', () => {
       const { from } = TextSelection.near(editor.state.doc.resolve(0));
 
       // The node is collapsed by default
@@ -42,7 +42,7 @@ describe('CollapsibleBlockNode commands', () => {
       expect(collapsibleBlock.attrs.folded).toBe(false);
     });
 
-    test('should collapse with command', () => {
+    it('should collapse with command', () => {
       editor.commands.setContent(defaultUncollapsedCollapsibleBlock);
       const { from } = TextSelection.near(editor.state.doc.resolve(0));
 
@@ -64,7 +64,7 @@ describe('CollapsibleBlockNode commands', () => {
       expect(collapsibleBlock.attrs.folded).toBe(true);
     });
 
-    test('should add empty content when uncollapsing', () => {
+    it('should add empty content when uncollapsing', () => {
       editor.commands.setContent(collapsedEmptyCollapsibleBlock);
       const { from } = TextSelection.near(editor.state.doc.resolve(0));
 
@@ -78,7 +78,7 @@ describe('CollapsibleBlockNode commands', () => {
       expect(collapsibleContents).toHaveLength(1);
     });
 
-    test('should remove empty content when collapsing', () => {
+    it('should remove empty content when collapsing', () => {
       editor.commands.setContent(uncollapsedCollapsibleBlockWithEmptyContent);
       const { from } = TextSelection.near(editor.state.doc.resolve(0));
 
@@ -92,7 +92,7 @@ describe('CollapsibleBlockNode commands', () => {
       expect(collapsibleContents).toHaveLength(0);
     });
 
-    test('should not do anything if run from a paragraph', () => {
+    it('should not do anything if run from a paragraph', () => {
       editor.commands.setContent('<p></p>');
       const initialDoc = editor.state.doc;
 
@@ -105,7 +105,7 @@ describe('CollapsibleBlockNode commands', () => {
   });
 
   describe('setCollapsibleBlock command', () => {
-    test('should wrap paragraph in a collapsible block', () => {
+    it('should wrap paragraph in a collapsible block', () => {
       editor.commands.setContent('<p></p>');
 
       let collapsibleBlocks = findNodesByNodeType(editor.state.doc, 'collapsibleBlock');
@@ -118,7 +118,7 @@ describe('CollapsibleBlockNode commands', () => {
       expect(collapsibleBlocks).toHaveLength(1);
     });
 
-    test('should not do anything if content is already in a collapsible block', () => {
+    it('should not do anything if content is already in a collapsible block', () => {
       editor.commands.setContent(defaultCollapsibleBlock);
       const initialDoc = editor.state.doc;
 
@@ -127,7 +127,7 @@ describe('CollapsibleBlockNode commands', () => {
       expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
     });
 
-    test('should not do anything if block cannot be turned into collapsible block', () => {
+    it('should not do anything if block cannot be turned into collapsible block', () => {
       editor.commands.setContent('<h1>Some content</h1>');
       const initialDoc = editor.state.doc;
 
@@ -136,7 +136,7 @@ describe('CollapsibleBlockNode commands', () => {
       expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
     });
 
-    test('should not do anything if selection is not empty', () => {
+    it('should not do anything if selection is not empty', () => {
       editor.commands.setContent('<p>Some text</p>');
       const initialDoc = editor.state.doc;
 
@@ -149,34 +149,34 @@ describe('CollapsibleBlockNode commands', () => {
   });
 
   describe('unsetCollapsibleBlock command', () => {
-    test('should unwrap block and add all its content blocks to the document', () => {
+    it('should unwrap block and add all its content blocks to the document', () => {
       editor.commands.setContent(defaultCollapsibleBlock);
 
-      expect(editor.state.doc.childCount).toEqual(1);
+      expect(editor.state.doc.childCount).toBe(1);
 
       const commandResult = editor.chain().setTextSelection(0).unsetCollapsibleBlock().run();
       expect(commandResult).toBe(true);
 
-      expect(editor.state.doc.childCount).toEqual(3);
-      expect(getText(editor.state.doc.child(0))).toEqual('Header');
-      expect(getText(editor.state.doc.child(1))).toEqual('Content Line 1');
-      expect(getText(editor.state.doc.child(2))).toEqual('Content Line 2');
+      expect(editor.state.doc.childCount).toBe(3);
+      expect(getText(editor.state.doc.child(0))).toBe('Header');
+      expect(getText(editor.state.doc.child(1))).toBe('Content Line 1');
+      expect(getText(editor.state.doc.child(2))).toBe('Content Line 2');
     });
 
-    test('should unwrap block and add its content block to the document', () => {
+    it('should unwrap block and add its content block to the document', () => {
       editor.commands.setContent(oneLineCollapsibleBlock);
 
-      expect(editor.state.doc.childCount).toEqual(1);
+      expect(editor.state.doc.childCount).toBe(1);
 
       const commandResult = editor.chain().setTextSelection(0).unsetCollapsibleBlock().run();
       expect(commandResult).toBe(true);
 
-      expect(editor.state.doc.childCount).toEqual(2);
-      expect(getText(editor.state.doc.child(0))).toEqual('Header');
-      expect(getText(editor.state.doc.child(1))).toEqual('Content Line');
+      expect(editor.state.doc.childCount).toBe(2);
+      expect(getText(editor.state.doc.child(0))).toBe('Header');
+      expect(getText(editor.state.doc.child(1))).toBe('Content Line');
     });
 
-    test('should not do anything if content is not in a collapsible block', () => {
+    it('should not do anything if content is not in a collapsible block', () => {
       editor.commands.setContent('<p></p>');
       const initialDoc = editor.state.doc;
 
@@ -185,7 +185,7 @@ describe('CollapsibleBlockNode commands', () => {
       expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
     });
 
-    test('should not do anything if the selection is not empty', () => {
+    it('should not do anything if the selection is not empty', () => {
       editor.commands.setContent(defaultCollapsibleBlock);
       const initialDoc = editor.state.doc;
 
@@ -202,7 +202,7 @@ describe('CollapsibleBlockNode commands', () => {
       editor.commands.setContent(defaultCollapsibleBlock);
     });
 
-    test('should split collapsible block into 2 collapsible blocks', () => {
+    it('should split collapsible block into 2 collapsible blocks', () => {
       expect(findNodesByNodeType(editor.state.doc, 'collapsibleBlock')).toHaveLength(1);
       const [initialContent] = findNodesByNodeType(editor.state.doc, 'collapsibleContent');
       expect(initialContent).toBeDefined();
@@ -219,9 +219,9 @@ describe('CollapsibleBlockNode commands', () => {
         findNodesByNodeType(collapsibleBlock, 'collapsibleSummary'),
       );
       expect(firstSummaries).toHaveLength(1);
-      expect(getText(firstSummaries[0])).toEqual('Hea');
+      expect(getText(firstSummaries[0])).toBe('Hea');
       expect(secondSummaries).toHaveLength(1);
-      expect(getText(secondSummaries[0])).toEqual('der');
+      expect(getText(secondSummaries[0])).toBe('der');
 
       // The content should still be in the first collapsible block
       const [firstCollapsibleBlock, secondCollapsibleBlock] = collapsibleBlocks;
@@ -233,7 +233,7 @@ describe('CollapsibleBlockNode commands', () => {
       expect(findNodesByNodeType(secondCollapsibleBlock, 'collapsibleContent')).toHaveLength(0);
     });
 
-    test('should split collapsed collapsible block with no content into 2 collapsible blocks', () => {
+    it('should split collapsed collapsible block with no content into 2 collapsible blocks', () => {
       editor.commands.setContent(collapsedEmptyCollapsibleBlock);
 
       expect(findNodesByNodeType(editor.state.doc, 'collapsibleBlock')).toHaveLength(1);
@@ -247,7 +247,7 @@ describe('CollapsibleBlockNode commands', () => {
       expect(findNodesByNodeType(editor.state.doc, 'collapsibleContent')).toHaveLength(0);
     });
 
-    test('should not do anything if the selection is not empty', () => {
+    it('should not do anything if the selection is not empty', () => {
       // 6 corresponds to the carret being in the middle of the word 'Header'
       const selection = TextSelection.between(editor.state.doc.resolve(6), editor.state.doc.resolve(7));
       const initialDoc = editor.state.doc;
@@ -257,7 +257,7 @@ describe('CollapsibleBlockNode commands', () => {
       expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
     });
 
-    test('should not do anything if the block is not a collapsibleBlock', () => {
+    it('should not do anything if the block is not a collapsibleBlock', () => {
       editor.commands.setContent('<p></p>');
       const initialDoc = editor.state.doc;
 

--- a/src/editor/nodes/collapsibleBlock/nodes/CollapsibleBlockNode.ts
+++ b/src/editor/nodes/collapsibleBlock/nodes/CollapsibleBlockNode.ts
@@ -38,33 +38,25 @@ export const CollapsibleBlockNode = Node.create({
   defining: true,
   selectable: false,
 
-  parseHTML() {
-    return [
-      {
-        tag: 'collapsible-block',
-      },
-    ];
-  },
+  parseHTML: () => [
+    {
+      tag: 'collapsible-block',
+    },
+  ],
 
-  renderHTML({ HTMLAttributes }) {
-    return ['collapsible-block', HTMLAttributes, 0];
-  },
+  renderHTML: ({ HTMLAttributes }) => ['collapsible-block', HTMLAttributes, 0],
 
-  addAttributes(): {
+  addAttributes: (): {
     [K in keyof CollapsibleBlockNodeAttributes]: {
       default: CollapsibleBlockNodeAttributes[K];
     };
-  } {
-    return {
-      folded: {
-        default: true,
-      },
-    };
-  },
+  } => ({
+    folded: {
+      default: true,
+    },
+  }),
 
-  addNodeView() {
-    return ReactNodeViewRenderer(CollapsibleBlock);
-  },
+  addNodeView: () => ReactNodeViewRenderer(CollapsibleBlock),
 
   addCommands() {
     return {
@@ -102,7 +94,7 @@ export const CollapsibleBlockNode = Node.create({
           }
           return true;
         },
-      /* 
+      /*
         Splits a collapsible block from the summary:
          - removes text after the caret from the first collapsible block
          - creates a new collapsible block with text after the caret as summary and empty content
@@ -268,20 +260,16 @@ export const CollapsibleBlockNode = Node.create({
     };
   },
 
-  addKeyboardShortcuts() {
-    return {
-      Backspace: backspace,
-      Enter: enter,
-      'Mod-Enter': modEnter,
-    };
-  },
+  addKeyboardShortcuts: () => ({
+    Backspace: backspace,
+    Enter: enter,
+    'Mod-Enter': modEnter,
+  }),
 
-  addInputRules() {
-    return [
-      new InputRule({
-        find: inputRegex,
-        handler: chevronHandler,
-      }),
-    ];
-  },
+  addInputRules: () => [
+    new InputRule({
+      find: inputRegex,
+      handler: chevronHandler,
+    }),
+  ],
 });

--- a/src/editor/nodes/collapsibleBlock/nodes/CollapsibleBlockSummary.ts
+++ b/src/editor/nodes/collapsibleBlock/nodes/CollapsibleBlockSummary.ts
@@ -8,15 +8,11 @@ export const CollapsibleBlockSummaryNode = Node.create({
   content: 'text*',
   selectable: false,
 
-  parseHTML() {
-    return [
-      {
-        tag: 'collapsible-summary',
-      },
-    ];
-  },
+  parseHTML: () => [
+    {
+      tag: 'collapsible-summary',
+    },
+  ],
 
-  renderHTML({ HTMLAttributes }) {
-    return ['collapsible-summary', mergeAttributes(HTMLAttributes), 0];
-  },
+  renderHTML: ({ HTMLAttributes }) => ['collapsible-summary', mergeAttributes(HTMLAttributes), 0],
 });

--- a/src/editor/nodes/draggableBlock/DraggableBlockNode.ts
+++ b/src/editor/nodes/draggableBlock/DraggableBlockNode.ts
@@ -23,21 +23,15 @@ export const DraggableBlockNode = Node.create({
   draggable: true,
   selectable: true,
 
-  parseHTML() {
-    return [
-      {
-        tag: 'draggable-block',
-      },
-    ];
-  },
+  parseHTML: () => [
+    {
+      tag: 'draggable-block',
+    },
+  ],
 
-  renderHTML({ HTMLAttributes }) {
-    return ['draggable-block', HTMLAttributes, 0];
-  },
+  renderHTML: ({ HTMLAttributes }) => ['draggable-block', HTMLAttributes, 0],
 
-  addNodeView() {
-    return ReactNodeViewRenderer(DraggableBlock);
-  },
+  addNodeView: () => ReactNodeViewRenderer(DraggableBlock),
 
   addCommands() {
     return {
@@ -105,10 +99,7 @@ export const DraggableBlockNode = Node.create({
     };
   },
 
-  addKeyboardShortcuts() {
-    return {
-      Enter: ({ editor }) =>
-        editor.chain().command(unsetPartiallySelectedCollapsibleBlocks).splitDraggableBlock().run(),
-    };
-  },
+  addKeyboardShortcuts: () => ({
+    Enter: ({ editor }) => editor.chain().command(unsetPartiallySelectedCollapsibleBlocks).splitDraggableBlock().run(),
+  }),
 });

--- a/src/editor/nodes/refStudioDocument/RefStudioDocument.ts
+++ b/src/editor/nodes/refStudioDocument/RefStudioDocument.ts
@@ -14,16 +14,16 @@ declare module '@tiptap/core' {
 export const RefStudioDocument = Document.extend({
   content: 'draggableBlock* | codeBlock',
   addKeyboardShortcuts: () => ({
-      Backspace: backspace,
-    }),
+    Backspace: backspace,
+  }),
   addCommands: () => ({
-      deleteNonEmptySelection: () => (props) => {
-        const { dispatch, tr } = props;
-        if (dispatch) {
-          unsetPartiallySelectedCollapsibleBlocks(props);
-          tr.deleteSelection();
-        }
-        return true;
-      },
-    }),
+    deleteNonEmptySelection: () => (props) => {
+      const { dispatch, tr } = props;
+      if (dispatch) {
+        unsetPartiallySelectedCollapsibleBlocks(props);
+        tr.deleteSelection();
+      }
+      return true;
+    },
+  }),
 });

--- a/src/editor/nodes/refStudioDocument/RefStudioDocument.ts
+++ b/src/editor/nodes/refStudioDocument/RefStudioDocument.ts
@@ -13,13 +13,10 @@ declare module '@tiptap/core' {
 
 export const RefStudioDocument = Document.extend({
   content: 'draggableBlock* | codeBlock',
-  addKeyboardShortcuts() {
-    return {
+  addKeyboardShortcuts: () => ({
       Backspace: backspace,
-    };
-  },
-  addCommands() {
-    return {
+    }),
+  addCommands: () => ({
       deleteNonEmptySelection: () => (props) => {
         const { dispatch, tr } = props;
         if (dispatch) {
@@ -28,6 +25,5 @@ export const RefStudioDocument = Document.extend({
         }
         return true;
       },
-    };
-  },
+    }),
 });

--- a/src/editor/nodes/refStudioDocument/keyboardShortcutCommands/backspace.test.ts
+++ b/src/editor/nodes/refStudioDocument/keyboardShortcutCommands/backspace.test.ts
@@ -10,7 +10,7 @@ describe('Backspace keyboard shortcut command', () => {
     extensions: EDITOR_EXTENSIONS,
   });
 
-  test('should turn collapsible block back into paragraphs when selection is at the beginning of the summary', () => {
+  it('should turn collapsible block back into paragraphs when selection is at the beginning of the summary', () => {
     editor
       .chain()
       .setContent(defaultParagraph + defaultParagraph)
@@ -25,10 +25,10 @@ describe('Backspace keyboard shortcut command', () => {
     // Paragraphs should have been merged together
     expect(editor.state.doc.childCount).toBe(1);
 
-    expect(getText(editor.state.doc)).toEqual('Some contentSome content');
+    expect(getText(editor.state.doc)).toBe('Some contentSome content');
   });
 
-  test('should unset partially selected collapsible blocks before deleting content', () => {
+  it('should unset partially selected collapsible blocks before deleting content', () => {
     editor
       .chain()
       .setContent(defaultParagraph + defaultCollapsibleBlock + defaultCollapsibleBlock)
@@ -45,7 +45,7 @@ describe('Backspace keyboard shortcut command', () => {
     expect(editor.state.doc.childCount).toBe(3);
   });
 
-  test('should not do anything when the selection is empty and not a the beginning of a block', () => {
+  it('should not do anything when the selection is empty and not a the beginning of a block', () => {
     editor
       .chain()
       .setContent(defaultParagraph + defaultParagraph)
@@ -59,7 +59,7 @@ describe('Backspace keyboard shortcut command', () => {
     expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
   });
 
-  test('should not do anything when the selection is a node selection', () => {
+  it('should not do anything when the selection is a node selection', () => {
     editor
       .chain()
       .setContent(defaultParagraph + defaultParagraph)

--- a/src/editor/nodes/refStudioDocument/keyboardShortcutCommands/backspace.ts
+++ b/src/editor/nodes/refStudioDocument/keyboardShortcutCommands/backspace.ts
@@ -1,7 +1,7 @@
 import { TextSelection } from '@tiptap/pm/state';
 import { isNodeSelection, KeyboardShortcutCommand } from '@tiptap/react';
 
-export const backspace: KeyboardShortcutCommand = function ({ editor }) {
+export const backspace: KeyboardShortcutCommand = ({ editor }) => {
   if (editor.state.selection.empty && editor.state.selection.$from.parentOffset === 0) {
     // Removes the content item and moves the selection to the previous content item or the header
     return editor.commands.command(({ tr, dispatch }) => {

--- a/src/editor/nodes/referenceNode/ReferenceNode.ts
+++ b/src/editor/nodes/referenceNode/ReferenceNode.ts
@@ -5,9 +5,7 @@ import { SuggestionKeyDownProps } from '@tiptap/suggestion';
 import { ReferenceListProps, ReferencesList } from './ReferencesList';
 
 export const ReferenceNode = Mention.configure({
-  renderLabel({ node }) {
-    return (node.attrs.label as string | undefined) ?? '[INVALID_REF]';
-  },
+  renderLabel: ({ node }) => (node.attrs.label as string | undefined) ?? '[INVALID_REF]',
   suggestion: {
     allowSpaces: true,
     char: '[',
@@ -26,11 +24,11 @@ export const ReferenceNode = Mention.configure({
           );
         },
 
-        onUpdate(props) {
+        onUpdate: (props) => {
           reactRenderer.updateProps(props);
         },
 
-        onKeyDown(props) {
+        onKeyDown: (props) => {
           if (props.event.key === 'Escape') {
             reactRenderer.destroy();
             return true;
@@ -39,7 +37,7 @@ export const ReferenceNode = Mention.configure({
           return reactRenderer.ref?.onKeyDown(props) ?? false;
         },
 
-        onExit() {
+        onExit: () => {
           reactRenderer.destroy();
         },
       };

--- a/src/hooks/useAsyncEffect.ts
+++ b/src/hooks/useAsyncEffect.ts
@@ -27,7 +27,7 @@ export function useAsyncEffect<V, E>(
       .then((_effectResult) => (effectResult = _effectResult))
       .catch((err: E) => onError?.(err));
 
-    return function () {
+    return () => {
       mounted = false;
 
       if (hasDestroy) {

--- a/src/lib/isNonNullish.test.ts
+++ b/src/lib/isNonNullish.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { isNonNullish } from './isNonNullish';
 

--- a/src/lib/isNonNullish.test.ts
+++ b/src/lib/isNonNullish.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, test } from 'vitest';
 import { isNonNullish } from './isNonNullish';
 
 describe('isNonNullish', () => {
-  test('should filter null values', () => {
+  it('should filter null values', () => {
     const out = [1, 2, null, 3].filter(isNonNullish);
     expect(out.length).toBe(3);
   });
 
-  test('should filter undefined values', () => {
+  it('should filter undefined values', () => {
     const out = [1, 2, null, 3, undefined, 4].filter(isNonNullish);
     expect(out.length).toBe(4);
   });

--- a/src/panels/ai/ChatPanelSection.test.tsx
+++ b/src/panels/ai/ChatPanelSection.test.tsx
@@ -11,13 +11,13 @@ describe('ChatPanelSection component', () => {
     vi.clearAllMocks();
   });
 
-  test('should render the panel without history content and a textbox', () => {
+  it('should render the panel without history content and a textbox', () => {
     render(<ChatPanelSection />);
     expect(screen.getByText(/your chat history will be shown here\./i)).toBeInTheDocument();
     expect(screen.getByRole('textbox')).toBeInTheDocument();
   });
 
-  test('should call api if textbox has text', async () => {
+  it('should call api if textbox has text', async () => {
     const chatWithAiMock = vi.mocked(chatWithAI).mockResolvedValue([]);
     const user = userEvent.setup();
     render(<ChatPanelSection />);
@@ -26,7 +26,7 @@ describe('ChatPanelSection component', () => {
     expect(chatWithAiMock.mock.calls.length).toBe(1);
   });
 
-  test('should NOT call api if textbox has empty text', async () => {
+  it('should NOT call api if textbox has empty text', async () => {
     const chatWithAiMock = vi.mocked(chatWithAI).mockResolvedValue([]);
     const user = userEvent.setup();
     render(<ChatPanelSection />);
@@ -35,7 +35,7 @@ describe('ChatPanelSection component', () => {
   });
 
   // https://testing-library.com/docs/user-event/keyboard/
-  test('should call api on ENTER in the textbox', async () => {
+  it('should call api on ENTER in the textbox', async () => {
     const chatWithAiMock = vi.mocked(chatWithAI).mockResolvedValue([]);
     const user = userEvent.setup();
     render(<ChatPanelSection />);
@@ -45,7 +45,7 @@ describe('ChatPanelSection component', () => {
   });
 
   // https://testing-library.com/docs/user-event/keyboard/
-  test('should display ERROR if chatWithAI throw exception', async () => {
+  it('should display ERROR if chatWithAI throw exception', async () => {
     const chatWithAiMock = vi.mocked(chatWithAI).mockRejectedValue('Error message.');
     const user = userEvent.setup();
     render(<ChatPanelSection />);
@@ -55,7 +55,7 @@ describe('ChatPanelSection component', () => {
     expect(screen.getByText('ERROR: Error message.')).toBeInTheDocument();
   });
 
-  test('should NOT call api on SHIFT+ENTER in the textbox', async () => {
+  it('should NOT call api on SHIFT+ENTER in the textbox', async () => {
     const chatWithAiMock = vi.mocked(chatWithAI).mockResolvedValue([]);
     const user = userEvent.setup();
     render(<ChatPanelSection />);
@@ -64,7 +64,7 @@ describe('ChatPanelSection component', () => {
     expect(chatWithAiMock.mock.calls.length).toBe(0);
   });
 
-  test('should render question and reply in the screen', async () => {
+  it('should render question and reply in the screen', async () => {
     const chatWithAiMock = vi.mocked(chatWithAI).mockResolvedValue(['Sure!']);
     const user = userEvent.setup();
     render(<ChatPanelSection />);
@@ -75,7 +75,7 @@ describe('ChatPanelSection component', () => {
     expect(screen.getByText('Sure!')).toBeInTheDocument();
   });
 
-  test('should render ... while waiting for reply', async () => {
+  it('should render ... while waiting for reply', async () => {
     // Note: this is a promise that _don't resolve_ so that we can test the "..." below.
     vi.mocked(chatWithAI).mockImplementation(async () => new Promise<string[]>(() => ['---']));
     const user = userEvent.setup();
@@ -88,7 +88,7 @@ describe('ChatPanelSection component', () => {
     expect(screen.getByText('...')).toBeInTheDocument();
   });
 
-  test('should render ... and then the ### reply text', async () => {
+  it('should render ... and then the ### reply text', async () => {
     let resolveFn: () => void = vi.fn();
     vi.mocked(chatWithAI).mockImplementation(async () => {
       await new Promise<void>((resolve) => {

--- a/src/panels/ai/ChatPanelSection.tsx
+++ b/src/panels/ai/ChatPanelSection.tsx
@@ -31,15 +31,15 @@ export function ChatPanelSection() {
   ]);
   const [currentChatThreadItem, setCurrentChatThreadItem] = useState<ChatThreadItem | null>(null);
 
-  function handleKeyDown(evt: React.KeyboardEvent<HTMLTextAreaElement>): void {
+  const handleKeyDown = (evt: React.KeyboardEvent<HTMLTextAreaElement>): void => {
     if (!evt.shiftKey && evt.code === 'Enter') {
       evt.preventDefault();
       handleChat(text);
       return;
     }
-  }
+  };
 
-  function handleChat(question: string) {
+  const handleChat = (question: string) => {
     if (!question || currentChatThreadItem) {
       return;
     }
@@ -58,7 +58,7 @@ export function ChatPanelSection() {
         ]);
         setCurrentChatThreadItem(null);
       });
-  }
+  };
 
   return (
     <PanelSection grow title="Chat">

--- a/src/panels/references/PdfInputFileUpload.test.tsx
+++ b/src/panels/references/PdfInputFileUpload.test.tsx
@@ -3,13 +3,13 @@ import { render, screen, setup } from '../../utils/test-utils';
 import { PdfInputFileUpload } from './PdfInputFileUpload';
 
 describe('PdfInputFileUpload', () => {
-  test('should display guidance TIP text for upload', () => {
+  it('should display guidance TIP text for upload', () => {
     render(<PdfInputFileUpload onUpload={noop} />);
     expect(screen.getByText(/click.*here/i)).toBeInTheDocument();
     expect(screen.getByText(/drag.drop PDF files here for upload/i)).toBeInTheDocument();
   });
 
-  test('should upload file on click', async () => {
+  it('should upload file on click', async () => {
     const handler = vi.fn();
     const { user } = setup(<PdfInputFileUpload onUpload={handler} />);
     const input = screen.getByRole<HTMLInputElement>('form');
@@ -29,7 +29,7 @@ describe('PdfInputFileUpload', () => {
     expect(handlerParameters[0].item(0)).toBe(file);
   });
 
-  test('should upload multiple files on click', async () => {
+  it('should upload multiple files on click', async () => {
     const handler = vi.fn();
     const { user } = setup(<PdfInputFileUpload onUpload={handler} />);
     const input = screen.getByRole<HTMLInputElement>('form');

--- a/src/panels/references/ReferencesList.test.tsx
+++ b/src/panels/references/ReferencesList.test.tsx
@@ -3,12 +3,12 @@ import { render, screen, setup } from '../../utils/test-utils';
 import { ReferencesList } from './ReferencesList';
 
 describe('ReferencesList', () => {
-  test('should display empty list if for empty array', () => {
+  it('should display empty list if for empty array', () => {
     render(<ReferencesList references={[]} onRefClicked={noop} />);
     expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
   });
 
-  test('should display one reference item with title', () => {
+  it('should display one reference item with title', () => {
     render(
       <ReferencesList
         references={[
@@ -29,7 +29,7 @@ describe('ReferencesList', () => {
     expect(screen.getByText('title')).toBeInTheDocument();
   });
 
-  test('should display multiple reference items with title', () => {
+  it('should display multiple reference items with title', () => {
     render(
       <ReferencesList
         references={[
@@ -61,7 +61,7 @@ describe('ReferencesList', () => {
     expect(screen.getByText('title-2')).toBeInTheDocument();
   });
 
-  test('should display one reference item with authors', () => {
+  it('should display one reference item with authors', () => {
     render(
       <ReferencesList
         references={[
@@ -83,7 +83,7 @@ describe('ReferencesList', () => {
     expect(screen.getByText(/Maria Ana/i)).toBeInTheDocument();
   });
 
-  test('should trigger onRefClicked on ref item click', async () => {
+  it('should trigger onRefClicked on ref item click', async () => {
     const handler = vi.fn();
     const { user } = setup(
       <ReferencesList

--- a/src/panels/references/ReferencesPanel.test.tsx
+++ b/src/panels/references/ReferencesPanel.test.tsx
@@ -7,7 +7,7 @@ import { act, render, screen } from '../../utils/test-utils';
 import { ReferencesPanel } from './ReferencesPanel';
 
 describe('ReferencesPanel', () => {
-  test('should display welcome message with empty references', () => {
+  it('should display welcome message with empty references', () => {
     render(
       <Provider>
         <ReferencesPanel onRefClicked={noop} />
@@ -17,7 +17,7 @@ describe('ReferencesPanel', () => {
     expect(screen.getByText(/welcome to your refstudio references library/i)).toBeInTheDocument();
   });
 
-  test('should display references list with non-empty references', () => {
+  it('should display references list with non-empty references', () => {
     const store = createStore();
     render(
       <Provider store={store}>

--- a/src/panels/references/ReferencesPanel.tsx
+++ b/src/panels/references/ReferencesPanel.tsx
@@ -20,7 +20,7 @@ export function ReferencesPanel({ onRefClicked }: ReferencesPanelProps) {
 
   const [syncInProgress, setSyncInProgress] = useAtom(referencesSyncInProgressAtom);
 
-  async function handleChange(uploadedFiles: FileList) {
+  const handleChange = async (uploadedFiles: FileList) => {
     try {
       await uploadFiles(uploadedFiles);
       emitEvent(RefStudioEvents.references.ingestion.run);
@@ -29,7 +29,7 @@ export function ReferencesPanel({ onRefClicked }: ReferencesPanelProps) {
     } finally {
       setSyncInProgress(false);
     }
-  }
+  };
 
   return (
     <PanelWrapper title="References">

--- a/src/settings/DebugSettingsPane.test.tsx
+++ b/src/settings/DebugSettingsPane.test.tsx
@@ -48,17 +48,17 @@ describe('DebugSettingsPane component', () => {
     vi.clearAllMocks();
   });
 
-  test('should render the component', () => {
+  it('should render the component', () => {
     render(<DebugSettingsPane config={panelConfig} />);
     expect(screen.getByTestId(panelConfig.id)).toBeInTheDocument();
   });
 
-  test('should render default settings component', () => {
+  it('should render default settings component', () => {
     render(<DebugSettingsPane config={panelConfig} />);
     expect(screen.getByText(/default settings/i)).toBeInTheDocument();
   });
 
-  test('should render current settings component', () => {
+  it('should render current settings component', () => {
     render(<DebugSettingsPane config={panelConfig} />);
     expect(screen.getByText(/current settings/i)).toBeInTheDocument();
   });

--- a/src/settings/GeneralSettingsPane.test.tsx
+++ b/src/settings/GeneralSettingsPane.test.tsx
@@ -48,12 +48,12 @@ describe('GeneralSettingsPane component', () => {
     vi.clearAllMocks();
   });
 
-  test('should render the component', () => {
+  it('should render the component', () => {
     render(<GeneralSettingsPane config={panelConfig} />);
     expect(screen.getByTestId(panelConfig.id)).toBeInTheDocument();
   });
 
-  test('should render existing settings value', () => {
+  it('should render existing settings value', () => {
     const getCachedSettingMock = vi.mocked(getCachedSetting);
     render(<GeneralSettingsPane config={panelConfig} />);
 
@@ -63,7 +63,7 @@ describe('GeneralSettingsPane component', () => {
     expect(screen.getByLabelText('Path')).toHaveValue(mockSettings.sidecar.logging.path);
   });
 
-  test('should save (setCached, flush) with edited values on save', async () => {
+  it('should save (setCached, flush) with edited values on save', async () => {
     const user = userEvent.setup();
     render(<GeneralSettingsPane config={panelConfig} />);
 

--- a/src/settings/GeneralSettingsPane.tsx
+++ b/src/settings/GeneralSettingsPane.tsx
@@ -17,10 +17,10 @@ export function GeneralSettingsPane({ config }: SettingsPaneProps) {
     },
   });
 
-  function handleSaveSettings(evt: React.FormEvent<HTMLFormElement>) {
+  const handleSaveSettings = (evt: React.FormEvent<HTMLFormElement>) => {
     evt.preventDefault();
     saveMutation.mutate({ general: generalSettings, sidecarLogging: sidecarLoggingSettings });
-  }
+  };
 
   const isDirty =
     JSON.stringify(generalSettings) !== JSON.stringify(getCachedSetting('general')) ||

--- a/src/settings/OpenAiSettingsPane.test.tsx
+++ b/src/settings/OpenAiSettingsPane.test.tsx
@@ -34,12 +34,12 @@ describe('OpenAiSettingsPane component', () => {
     vi.clearAllMocks();
   });
 
-  test('should render the component', () => {
+  it('should render the component', () => {
     render(<OpenAiSettingsPane config={panelConfig} />);
     expect(screen.getByTestId(panelConfig.id)).toBeInTheDocument();
   });
 
-  test('should render existing settings value', () => {
+  it('should render existing settings value', () => {
     render(<OpenAiSettingsPane config={panelConfig} />);
 
     expect(vi.mocked(getCachedSetting).mock.calls.length).toBeGreaterThan(0);
@@ -48,7 +48,7 @@ describe('OpenAiSettingsPane component', () => {
     expect(screen.getByLabelText('Complete Model')).toHaveValue(mockSettings.openAI.completeModel);
   });
 
-  test('should save (setCached, flush) with edited values on save', async () => {
+  it('should save (setCached, flush) with edited values on save', async () => {
     const user = userEvent.setup();
     render(<OpenAiSettingsPane config={panelConfig} />);
 

--- a/src/settings/OpenAiSettingsPane.tsx
+++ b/src/settings/OpenAiSettingsPane.tsx
@@ -16,10 +16,10 @@ export function OpenAiSettingsPane({ config }: SettingsPaneProps) {
     },
   });
 
-  function handleSaveSettings(evt: React.FormEvent<HTMLFormElement>) {
+  const handleSaveSettings = (evt: React.FormEvent<HTMLFormElement>) => {
     evt.preventDefault();
     saveMutation.mutate(paneSettings);
-  }
+  };
 
   const isDirty = JSON.stringify(paneSettings) !== JSON.stringify(getCachedSetting('openAI'));
 

--- a/src/settings/SettingsModal.test.tsx
+++ b/src/settings/SettingsModal.test.tsx
@@ -20,19 +20,19 @@ describe('SettingsModal component', () => {
     vi.clearAllMocks();
   });
 
-  test('should render the modal CLOSED (empty)', () => {
+  it('should render the modal CLOSED (empty)', () => {
     const { container } = render(<SettingsModal open={false} onCloseClick={noop} />);
     expect(container).toBeEmptyDOMElement();
   });
 
-  test('should render 3 settings panels with open={true}', () => {
+  it('should render 3 settings panels with open={true}', () => {
     render(<SettingsModal open onCloseClick={noop} />);
     expect(screen.getByRole('menuitem', { name: 'General' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Open AI' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Config' })).toBeInTheDocument();
   });
 
-  test.skip('should close Modal on X click', async () => {
+  it.skip('should close Modal on X click', async () => {
     const user = userEvent.setup();
     const spyClose = vi.fn();
     render(<SettingsModal open onCloseClick={spyClose} />);
@@ -41,12 +41,12 @@ describe('SettingsModal component', () => {
     expect(spyClose).toBeCalled();
   });
 
-  test('should render General panel by default', () => {
+  it('should render General panel by default', () => {
     render(<SettingsModal open onCloseClick={noop} />);
     expect(screen.getByTestId('project-general' as SettingsPaneId)).toBeInTheDocument();
   });
 
-  test('should toggle to "Open AI" panel from sidebar', async () => {
+  it('should toggle to "Open AI" panel from sidebar', async () => {
     const user = userEvent.setup();
     render(<SettingsModal open onCloseClick={noop} />);
     await user.click(screen.getByText('Open AI'));

--- a/src/settings/SettingsModalOpener.test.tsx
+++ b/src/settings/SettingsModalOpener.test.tsx
@@ -22,12 +22,12 @@ describe('SettingsModalOpener component', () => {
     vi.clearAllMocks();
   });
 
-  test('should render the modal CLOSED (empty) by default', () => {
+  it('should render the modal CLOSED (empty) by default', () => {
     const { container } = render(<SettingsModalOpener />);
     expect(container).toBeEmptyDOMElement();
   });
 
-  test('should open the Settings model on SETTING menu event', () => {
+  it('should open the Settings model on SETTING menu event', () => {
     let settingEvtHandler: undefined | RefStudioEventCallback;
     let eventName = '';
     vi.mocked(listenEvent).mockImplementation(async (event: string, handler: RefStudioEventCallback) => {
@@ -53,7 +53,7 @@ describe('SettingsModalOpener component', () => {
     expect(screen.getByRole('menuitem', { name: 'Config' })).toBeInTheDocument();
   });
 
-  test('should toggle the Settings model on SETTING menu event', () => {
+  it('should toggle the Settings model on SETTING menu event', () => {
     let settingEvtHandler: undefined | RefStudioEventCallback;
     let eventName = '';
     vi.mocked(listenEvent).mockImplementation(async (event: string, handler: RefStudioEventCallback) => {

--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -22,6 +22,7 @@ describe('settings', () => {
     vi.resetAllMocks();
   });
 
+  // eslint-disable-next-line vitest/expect-expect
   it('should throw when using getSettings before initialization', () => {
     try {
       getSettings();

--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -22,7 +22,7 @@ describe('settings', () => {
     vi.resetAllMocks();
   });
 
-  test('should throw when using getSettings before initialization', () => {
+  it('should throw when using getSettings before initialization', () => {
     try {
       getSettings();
       fail();
@@ -31,7 +31,7 @@ describe('settings', () => {
     }
   });
 
-  test('should getSettings manager after call to initSettings', async () => {
+  it('should getSettings manager after call to initSettings', async () => {
     const fn = vi.fn();
     vi.mocked(SettingsManager<SettingsSchema>).mockImplementation(
       (defaultSettings) =>
@@ -44,7 +44,7 @@ describe('settings', () => {
     expect(fn).toBeCalled();
   });
 
-  test('should read settings from env', async () => {
+  it('should read settings from env', async () => {
     vi.mocked(readEnv).mockResolvedValue('some value');
     const fn = vi.fn();
     vi.mocked(SettingsManager<SettingsSchema>).mockImplementation(
@@ -59,7 +59,7 @@ describe('settings', () => {
     expect(getSettings()).toBeDefined();
   });
 
-  test('should read default value from env', async () => {
+  it('should read default value from env', async () => {
     vi.mocked(readEnv).mockResolvedValue('OPENAI_COMPLETE_MODEL-value');
     const fn = vi.fn();
     vi.mocked(SettingsManager<SettingsSchema>).mockImplementation(
@@ -73,7 +73,7 @@ describe('settings', () => {
     expect(getSettings().default.openAI.chatModel).toBe('OPENAI_COMPLETE_MODEL-value');
   });
 
-  test('should call settingsManager via getCachedSetting and setCachedSetting', async () => {
+  it('should call settingsManager via getCachedSetting and setCachedSetting', async () => {
     const getCachedFn = vi.fn();
     const setCachedFn = vi.fn();
     vi.mocked(SettingsManager<SettingsSchema>).mockImplementation(
@@ -96,7 +96,7 @@ describe('settings', () => {
     expect(setCachedFn).toBeCalledWith('openAI.chatModel', 'value');
   });
 
-  test('should call settingsManager.syncCache via saveCachedSettings', async () => {
+  it('should call settingsManager.syncCache via saveCachedSettings', async () => {
     const syncCacheFn = vi.fn();
     vi.mocked(SettingsManager<SettingsSchema>).mockImplementation(
       (defaultSettings, options) =>

--- a/src/utils/readEnv.test.ts
+++ b/src/utils/readEnv.test.ts
@@ -5,19 +5,19 @@ import { readEnv } from './readEnv';
 vi.mock('@tauri-apps/api');
 
 describe('readEnv', () => {
-  test('should return env value from tauri', async () => {
+  it('should return env value from tauri', async () => {
     vi.mocked(invoke).mockResolvedValue('TAURI ENV VALUE');
     const value = await readEnv('KEY', 'unused');
     expect(value).toBe('TAURI ENV VALUE');
   });
 
-  test('should fallback if env value is empty', async () => {
+  it('should fallback if env value is empty', async () => {
     vi.mocked(invoke).mockResolvedValue('');
     const value = await readEnv('KEY', 'FALLBACK');
     expect(value).toBe('FALLBACK');
   });
 
-  test('should fallback if throw', async () => {
+  it('should fallback if throw', async () => {
     vi.mocked(invoke).mockRejectedValue('some error');
     const value = await readEnv('KEY', 'FALLBACK');
     expect(value).toBe('FALLBACK');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,7 +1736,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.60.0, @typescript-eslint/utils@npm:^5.58.0":
+"@typescript-eslint/utils@npm:5.60.0, @typescript-eslint/utils@npm:^5.58.0, @typescript-eslint/utils@npm:^5.59.9":
   version: 5.60.0
   resolution: "@typescript-eslint/utils@npm:5.60.0"
   dependencies:
@@ -3303,6 +3303,17 @@ __metadata:
   peerDependencies:
     eslint: ^7.5.0 || ^8.0.0
   checksum: 7f19d3dedd7788b411ca3d9045de682feb26025b9c26d97d4e2f0bf62f5eaa276147d946bd5d0cd967b822e546a954330fdb7ef80485301264f646143f011a02
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-vitest@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "eslint-plugin-vitest@npm:0.2.6"
+  dependencies:
+    "@typescript-eslint/utils": ^5.59.9
+  peerDependencies:
+    eslint: ">=8.0.0"
+  checksum: 09bb95262dc39b05546eb704b60440bce03bc68f4d563b3bcb4b25774624b3758db76bfa3702b8b0d45313246b6a6d57729ecc027f64ad840b234b94ca6aa233
   languageName: node
   linkType: hard
 
@@ -6201,6 +6212,7 @@ __metadata:
     eslint-plugin-react-hooks: ^4.6.0
     eslint-plugin-simple-import-sort: ^10.0.0
     eslint-plugin-testing-library: ^5.11.0
+    eslint-plugin-vitest: ^0.2.6
     fuse.js: ^6.6.2
     husky: ^8.0.0
     jotai: ^2.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3243,6 +3243,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-prefer-arrow@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "eslint-plugin-prefer-arrow@npm:1.2.3"
+  peerDependencies:
+    eslint: ">=2.0.0"
+  checksum: 3cdae574121c4a683d77e329ee193103b2bf418d7a8c85831b274000ae4aba64cb4d302fe69a44ae4d729b90f5130c968e4a9e43852a5de940d00283e61f92fc
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-react-hooks@npm:^4.6.0":
   version: 4.6.0
   resolution: "eslint-plugin-react-hooks@npm:4.6.0"
@@ -6187,6 +6196,7 @@ __metadata:
     eslint-plugin-import: ^2.27.5
     eslint-plugin-jest-dom: ^5.0.1
     eslint-plugin-jsdoc: ^46.2.6
+    eslint-plugin-prefer-arrow: ^1.2.3
     eslint-plugin-react: ^7.32.2
     eslint-plugin-react-hooks: ^4.6.0
     eslint-plugin-simple-import-sort: ^10.0.0


### PR DESCRIPTION
This adds two new eslint plugins:

- [eslint-plugin-vitest](https://yarnpkg.com/package/eslint-plugin-vitest)
- [eslint-plugin-prefer-arrow](https://yarnpkg.com/package/eslint-plugin-prefer-arrow)

This was prompted by discovering two tests with the same name in #186.