### PR TITLE
feat: improve file tree

### DIFF
--- a/src/atoms/core/paneGroup.ts
+++ b/src/atoms/core/paneGroup.ts
@@ -73,6 +73,7 @@ export const removeFileFromPane = atom(null, (get, set, { fileId, paneId }: Pane
   set(updatePaneGroup, {
     paneId,
     openFiles: updatedOpenFiles,
+    activeFile: updatedOpenFiles.includes(fileId) ? fileId : undefined,
   });
 });
 

--- a/src/atoms/fileActions.test.ts
+++ b/src/atoms/fileActions.test.ts
@@ -348,6 +348,30 @@ describe('fileActions', () => {
     expect(leftPane.current.activeFile).toEqual(fileCData.fileId);
   });
 
+  it('should make active file undefined if is the last one closed in same pane', () => {
+    const store = createStore();
+    const openFile = runSetAtomHook(openFileAtom, store);
+    const closeFileFromPane = runSetAtomHook(closeFileFromPaneAtom, store);
+    const leftPane = runGetAtomHook(leftPaneAtom, store);
+
+    const { fileEntry: fileA } = makeFile('fileA.txt');
+    const { fileEntry: fileB, fileData: fileBData } = makeFile('fileB.txt');
+
+    act(() => {
+      openFile.current(fileA);
+      openFile.current(fileB);
+    });
+
+    expect(leftPane.current.activeFile).toEqual(fileBData.fileId);
+
+    act(() => {
+      closeFileFromPane.current({ paneId: leftPane.current.id, fileId: fileB.path });
+      closeFileFromPane.current({ paneId: leftPane.current.id, fileId: fileA.path });
+    });
+
+    expect(leftPane.current.activeFile).toBeUndefined();
+  });
+
   it('should not open folder entries', () => {
     const store = createStore();
     const openFileResult = runSetAtomHook(openFileAtom, store);

--- a/src/components/FileEntryTree.test.tsx
+++ b/src/components/FileEntryTree.test.tsx
@@ -10,14 +10,14 @@ describe('FileEntryTree component', () => {
 
   it('should render a file', () => {
     const { fileEntry } = makeFile('File 1.pdf');
-    render(<FileEntryTree files={[fileEntry]} root selectedFiles={[]} onClick={noop} />);
+    render(<FileEntryTree files={[fileEntry]} root selectedFiles={[]} onFileClick={noop} />);
     expect(screen.getByText(fileEntry.name)).toBeInTheDocument();
   });
 
-  it('should call onClick with file path', async () => {
+  it('should call onFileClick with file path', async () => {
     const { fileEntry } = makeFile('File 1.pdf');
     const onClick = vi.fn();
-    const { user } = setup(<FileEntryTree files={[fileEntry]} root selectedFiles={[]} onClick={onClick} />);
+    const { user } = setup(<FileEntryTree files={[fileEntry]} root selectedFiles={[]} onFileClick={onClick} />);
 
     await user.click(screen.getByText(fileEntry.name));
 
@@ -28,25 +28,15 @@ describe('FileEntryTree component', () => {
   it('should render a folder and its children', () => {
     const { fileEntry } = makeFile('File 1.pdf');
     const folderEntry = makeFolder('Folder 1', [fileEntry]);
-    render(<FileEntryTree files={[folderEntry]} root selectedFiles={[]} onClick={noop} />);
+    render(<FileEntryTree files={[folderEntry]} root selectedFiles={[]} onFileClick={noop} />);
     expect(screen.getByText(fileEntry.name)).toBeInTheDocument();
     expect(screen.getByText(folderEntry.name)).toBeInTheDocument();
-  });
-
-  it('should render a right action', () => {
-    const { fileEntry } = makeFile('File 1.pdf');
-    const rightActionMock = vi.fn().mockReturnValue(<div>Right action</div>);
-    render(<FileEntryTree files={[fileEntry]} rightAction={rightActionMock} root selectedFiles={[]} onClick={noop} />);
-
-    expect(rightActionMock).toHaveBeenCalledTimes(1);
-    expect(rightActionMock).toHaveBeenCalledWith(fileEntry.path);
-    expect(screen.getByText('Right action')).toBeInTheDocument();
   });
 
   it('should not render dotfiles', () => {
     const { fileEntry } = makeFile('File 1.pdf');
     const { fileEntry: dotfileFileEntry } = makeFile('.file2');
-    render(<FileEntryTree files={[fileEntry, dotfileFileEntry]} root selectedFiles={[]} onClick={noop} />);
+    render(<FileEntryTree files={[fileEntry, dotfileFileEntry]} root selectedFiles={[]} onFileClick={noop} />);
     expect(screen.getByText(fileEntry.name)).toBeInTheDocument();
     expect(screen.queryByText(dotfileFileEntry.name)).not.toBeInTheDocument();
   });

--- a/src/components/FileEntryTree.tsx
+++ b/src/components/FileEntryTree.tsx
@@ -1,76 +1,73 @@
-import React from 'react';
-import { VscFile, VscFolder } from 'react-icons/vsc';
+import { useState } from 'react';
+import { VscChevronDown, VscChevronRight, VscFile } from 'react-icons/vsc';
 
 import { FileId } from '../atoms/types/FileData';
-import { FileEntry } from '../atoms/types/FileEntry';
-import { cx } from '../cx';
+import { FileEntry, FolderFileEntry } from '../atoms/types/FileEntry';
+import { FileNode } from './FileNode';
 
-interface FileEntryTreeProps {
+interface FileEntryTreePropsBase {
   files: FileEntry[];
-  onClick: (fileId: FileId) => void;
-  rightAction?: (file: FileId) => React.ReactNode;
-  root?: boolean;
+  onFileClick: (fileId: FileId) => void;
   selectedFiles: FileId[];
+  paddingLeft?: string;
 }
 
-interface FileTreeNodeProps {
-  fileName: string;
-  isFolder?: boolean;
-  onClick?: () => void;
-  rightAction?: React.ReactNode;
-  selected?: boolean;
+interface RootFileEntryTreeProps extends FileEntryTreePropsBase {
+  root: true;
 }
+
+interface NonRootFileEntryTreeProps extends FileEntryTreePropsBase {
+  root?: false;
+  folderName: string;
+}
+
+type FileEntryTreeProps = RootFileEntryTreeProps | NonRootFileEntryTreeProps;
 
 export function FileEntryTree(props: FileEntryTreeProps) {
-  const { files, root, onClick, rightAction, selectedFiles } = props;
+  const { files, onFileClick, paddingLeft = '0', root, selectedFiles } = props;
+  const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <div>
-      <ul className={root ? 'ml-4' : 'ml-6'}>
-        <li>
+    <div className="flex w-full flex-col">
+      {!root && (
+        <FileNode
+          VscIcon={collapsed ? VscChevronRight : VscChevronDown}
+          bold
+          fileName={props.folderName}
+          paddingLeft={`calc(${paddingLeft} - 1rem)`}
+          onClick={() => setCollapsed((currentState) => !currentState)}
+        />
+      )}
+      {(root || !collapsed) && (
+        <>
           {files
-            // Hide DOTFILES
             .filter((file) => !file.isDotfile)
-            .map((file) =>
-              file.isFolder ? (
-                <React.Fragment key={file.path}>
-                  <FileTreeNode fileName={file.name} isFolder />
-                  <FileEntryTree {...props} files={file.children} root={false} />
-                </React.Fragment>
-              ) : (
-                <FileTreeNode
-                  fileName={file.name}
-                  key={file.path}
-                  rightAction={rightAction ? rightAction(file.path) : undefined}
-                  selected={selectedFiles.includes(file.path)}
-                  onClick={() => onClick(file.path)}
-                />
-              ),
-            )}
-        </li>
-      </ul>
-    </div>
-  );
-}
-export function FileTreeNode({ fileName, isFolder, onClick, rightAction, selected }: FileTreeNodeProps) {
-  return (
-    <div
-      className={cx('mb-1 py-1', 'flex flex-row items-center gap-1', 'group', {
-        'bg-slate-100': selected,
-        'cursor-pointer hover:bg-slate-100': !!onClick,
-      })}
-      title={fileName}
-      onClick={onClick}
-    >
-      {isFolder ? <VscFolder className="shrink-0" /> : <VscFile className="shrink-0" />}
-      <span
-        className={cx('flex-1 truncate', {
-          'font-bold': isFolder,
-        })}
-      >
-        {fileName}
-      </span>
-      {rightAction && <div className="mr-2 hidden p-0.5 hover:bg-gray-200 group-hover:block">{rightAction}</div>}
+            .filter((file): file is FolderFileEntry => file.isFolder)
+            .map((folder) => (
+              <FileEntryTree
+                {...props}
+                files={folder.children}
+                folderName={folder.name}
+                key={folder.path}
+                paddingLeft={`calc(${paddingLeft} + 1rem)`}
+                root={false}
+              />
+            ))}
+          {files
+            .filter((file) => !file.isDotfile)
+            .filter((file) => file.isFile)
+            .map((file) => (
+              <FileNode
+                VscIcon={VscFile}
+                fileName={file.name}
+                key={file.path}
+                paddingLeft={paddingLeft}
+                selected={selectedFiles.includes(file.path)}
+                onClick={() => onFileClick(file.path)}
+              />
+            ))}
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/FileNode.tsx
+++ b/src/components/FileNode.tsx
@@ -21,8 +21,8 @@ interface FileNodeProps {
 export function FileNode({ bold, fileName, onClick, paddingLeft, rightAction, selected, VscIcon }: FileNodeProps) {
   return (
     <div
-      className={cx('cursor-pointer select-none', 'flex flex-row items-center gap-1', 'group', {
-        'bg-slate-200': selected,
+      className={cx('cursor-pointer select-none', 'flex flex-row items-center gap-1 py-1', 'group', {
+        'bg-slate-100': selected,
         'hover:bg-slate-100': !selected,
       })}
       style={{ paddingLeft }}

--- a/src/components/FileNode.tsx
+++ b/src/components/FileNode.tsx
@@ -40,6 +40,7 @@ export function FileNode({ bold, fileName, onClick, paddingLeft, rightAction, se
         {rightAction && (
           <div
             className="mr-2 hidden rounded-md p-0.5 hover:bg-gray-300 group-hover:block"
+            role="button"
             title={rightAction.title}
             onClick={rightAction.onClick}
           >

--- a/src/components/FileNode.tsx
+++ b/src/components/FileNode.tsx
@@ -1,0 +1,52 @@
+import { IconType } from 'react-icons';
+
+import { cx } from '../cx';
+
+export interface RightAction {
+  title?: string;
+  onClick: (evt: React.MouseEvent) => void;
+  VscIcon: IconType;
+}
+
+interface FileNodeProps {
+  bold?: boolean;
+  fileName: string;
+  onClick: () => void;
+  paddingLeft: string;
+  rightAction?: RightAction;
+  selected?: boolean;
+  VscIcon: IconType;
+}
+
+export function FileNode({ bold, fileName, onClick, paddingLeft, rightAction, selected, VscIcon }: FileNodeProps) {
+  return (
+    <div
+      className={cx('cursor-pointer select-none', 'flex flex-row items-center gap-1', 'group', {
+        'bg-slate-200': selected,
+        'hover:bg-slate-100': !selected,
+      })}
+      style={{ paddingLeft }}
+      onClick={onClick}
+    >
+      <div className="flex h-full w-full items-center gap-1">
+        <VscIcon />
+        <div
+          className={cx('flex-1 truncate', {
+            'font-semibold': bold,
+          })}
+        >
+          {fileName}
+        </div>
+        {rightAction && (
+          <div
+            className="mr-2 hidden rounded-md p-0.5 hover:bg-gray-300 group-hover:block"
+            title={rightAction.title}
+            onClick={rightAction.onClick}
+          >
+            <rightAction.VscIcon />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/FileNode.tsx
+++ b/src/components/FileNode.tsx
@@ -23,7 +23,7 @@ export function FileNode({ bold, fileName, onClick, paddingLeft, rightAction, se
     <div
       className={cx('cursor-pointer select-none', 'flex flex-row items-center gap-1 py-1', 'group', {
         'bg-slate-100': selected,
-        'hover:bg-slate-100': !selected,
+        'hover:bg-slate-200': !selected,
       })}
       style={{ paddingLeft }}
       onClick={onClick}

--- a/src/components/FilesList.test.tsx
+++ b/src/components/FilesList.test.tsx
@@ -1,0 +1,50 @@
+import { VscFile } from 'react-icons/vsc';
+
+import { makeFile } from '../atoms/test-fixtures';
+import { noop } from '../utils/noop';
+import { render, screen, setup } from '../utils/test-utils';
+import { RightAction } from './FileNode';
+import { FilesList } from './FilesList';
+
+describe('FilesList component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render a file', () => {
+    const { fileData } = makeFile('File 1.pdf');
+    render(<FilesList files={[fileData]} selectedFiles={[]} onClick={noop} />);
+    expect(screen.getByText(fileData.fileName)).toBeInTheDocument();
+  });
+
+  it('should call onClick with file id', async () => {
+    const { fileData } = makeFile('File 1.pdf');
+    const onClick = vi.fn();
+    const { user } = setup(<FilesList files={[fileData]} selectedFiles={[]} onClick={onClick} />);
+
+    await user.click(screen.getByText(fileData.fileName));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledWith(fileData.fileId);
+  });
+
+  it('should render several files', () => {
+    const { fileData: fileData1 } = makeFile('File 1.pdf');
+    const { fileData: fileData2 } = makeFile('File 2.pdf');
+    render(<FilesList files={[fileData1, fileData2]} selectedFiles={[]} onClick={noop} />);
+    expect(screen.getByText(fileData1.fileName)).toBeInTheDocument();
+    expect(screen.getByText(fileData2.fileName)).toBeInTheDocument();
+  });
+
+  it('should call rightAction with file id', () => {
+    const { fileData } = makeFile('File 1.pdf');
+    const rightActionMock = vi.fn<[], RightAction>().mockReturnValue({ onClick: vi.fn(), VscIcon: VscFile });
+
+    render(<FilesList files={[fileData]} rightAction={rightActionMock} selectedFiles={[]} onClick={noop} />);
+
+    expect(rightActionMock).toHaveBeenCalledTimes(1);
+    expect(rightActionMock).toHaveBeenCalledWith(fileData.fileId);
+
+    expect(screen.getByRole('button', { hidden: true })).toBeInTheDocument();
+  });
+});

--- a/src/components/FilesList.tsx
+++ b/src/components/FilesList.tsx
@@ -6,12 +6,12 @@ import { FileNode, RightAction } from './FileNode';
 interface FilesListProps {
   files: FileData[];
   onClick: (fileId: FileId) => void;
-  paddingLeft: string;
+  paddingLeft?: string;
   rightAction?: (file: FileId) => RightAction;
   selectedFiles: FileId[];
 }
 
-export function FilesList({ files, onClick, paddingLeft, rightAction, selectedFiles }: FilesListProps) {
+export function FilesList({ files, onClick, paddingLeft = '0', rightAction, selectedFiles }: FilesListProps) {
   return (
     <>
       {files.map((file) => (

--- a/src/components/FilesList.tsx
+++ b/src/components/FilesList.tsx
@@ -1,0 +1,30 @@
+import { VscFile } from 'react-icons/vsc';
+
+import { FileData, FileId } from '../atoms/types/FileData';
+import { FileNode, RightAction } from './FileNode';
+
+interface FilesListProps {
+  files: FileData[];
+  onClick: (fileId: FileId) => void;
+  paddingLeft: string;
+  rightAction?: (file: FileId) => RightAction;
+  selectedFiles: FileId[];
+}
+
+export function FilesList({ files, onClick, paddingLeft, rightAction, selectedFiles }: FilesListProps) {
+  return (
+    <>
+      {files.map((file) => (
+        <FileNode
+          VscIcon={VscFile}
+          fileName={file.fileName}
+          key={file.fileId}
+          paddingLeft={paddingLeft}
+          rightAction={rightAction?.(file.fileId)}
+          selected={selectedFiles.includes(file.fileId)}
+          onClick={() => onClick(file.fileId)}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/components/PanelSection.tsx
+++ b/src/components/PanelSection.tsx
@@ -19,7 +19,7 @@ export function PanelSection({
 
   return (
     <div
-      className={cx('flex flex-col px-2', {
+      className={cx('flex flex-col', {
         'flex-shrink-0': !grow, // Take the component's height without shrinking
         'flex-grow overflow-hidden': grow, // Can grow
       })}
@@ -28,7 +28,7 @@ export function PanelSection({
         className={cx(
           'group/header',
           'flex flex-row items-center gap-1', //
-          'mb-2 cursor-pointer text-sm',
+          'mb-1 cursor-pointer pl-1 text-sm',
         )}
         onClick={() => setExpanded(!expanded)}
       >

--- a/src/panels/ExplorerPanel.tsx
+++ b/src/panels/ExplorerPanel.tsx
@@ -71,7 +71,7 @@ export function ExplorerPanel() {
         rightIcons={[{ key: 'closeAll', Icon: VscCloseAll, title: 'Close All Open Files', onClick: closeAllFiles }]}
         title="Open Files"
       >
-        {hasLeftAndRightPanelsFiles && <div className="font-bold ml-4 text-xs">LEFT</div>}
+        {hasLeftAndRightPanelsFiles && <div className="ml-4 text-xs font-bold">LEFT</div>}
         {left.files.length > 0 && (
           <FilesList
             files={left.files}
@@ -85,7 +85,7 @@ export function ExplorerPanel() {
             onClick={(fileId) => selectFileInPane({ paneId: left.id, fileId })}
           />
         )}
-        {hasLeftAndRightPanelsFiles && <div className="font-bold ml-4 text-xs">RIGHT</div>}
+        {hasLeftAndRightPanelsFiles && <div className="ml-4 text-xs font-bold">RIGHT</div>}
         {right.files.length > 0 && (
           <FilesList
             files={right.files}

--- a/src/panels/ExplorerPanel.tsx
+++ b/src/panels/ExplorerPanel.tsx
@@ -14,25 +14,12 @@ import {
 import { FileId } from '../atoms/types/FileData';
 import { FileEntry, FileFileEntry } from '../atoms/types/FileEntry';
 import { PaneId } from '../atoms/types/PaneGroup';
-import { FileEntryTree, FileTreeNode } from '../components/FileEntryTree';
+import { FileEntryTree } from '../components/FileEntryTree';
+import { FilesList } from '../components/FilesList';
 import { PanelSection } from '../components/PanelSection';
 import { PanelWrapper } from '../components/PanelWrapper';
 import { readAllProjectFiles } from '../filesystem';
 import { isNonNullish } from '../lib/isNonNullish';
-
-function SplitPaneButton({ fromPaneId, toPaneId, fileId }: { fromPaneId: PaneId; toPaneId: PaneId; fileId: FileId }) {
-  const splitFileToPane = useSetAtom(splitFileToPaneAtom);
-
-  return (
-    <VscSplitHorizontal
-      title={`Move to ${fromPaneId} split pane`}
-      onClick={(evt) => {
-        evt.stopPropagation();
-        splitFileToPane({ fileId, fromPaneId, toPaneId });
-      }}
-    />
-  );
-}
 
 export function ExplorerPanel() {
   const left = useAtomValue(leftPaneAtom);
@@ -40,6 +27,7 @@ export function ExplorerPanel() {
   const selectFileInPane = useSetAtom(selectFileInPaneAtom);
   const openFile = useSetAtom(openFileAtom);
   const closeAllFiles = useSetAtom(closeAllFilesAtom);
+  const splitFileToPane = useSetAtom(splitFileToPaneAtom);
 
   const { data: allFiles } = useQuery({
     queryKey: ['allFiles'],
@@ -66,7 +54,16 @@ export function ExplorerPanel() {
     [flattenedFiles, openFile],
   );
 
-  const hasRightPanelFiles = right.files.length > 0;
+  const handleSplitFile = useCallback(
+    ({ fileId, fromPaneId, toPaneId }: { fileId: FileId; fromPaneId: PaneId; toPaneId: PaneId }) =>
+      (evt: React.MouseEvent) => {
+        evt.stopPropagation();
+        splitFileToPane({ fileId, fromPaneId, toPaneId });
+      },
+    [splitFileToPane],
+  );
+
+  const hasLeftAndRightPanelsFiles = left.files.length > 0 && right.files.length > 0;
 
   return (
     <PanelWrapper title="Explorer">
@@ -74,41 +71,42 @@ export function ExplorerPanel() {
         rightIcons={[{ key: 'closeAll', Icon: VscCloseAll, title: 'Close All Open Files', onClick: closeAllFiles }]}
         title="Open Files"
       >
-        {hasRightPanelFiles && <div className="ml-4 text-xs font-bold">LEFT</div>}
+        {hasLeftAndRightPanelsFiles && <div className="font-bold ml-4 text-xs">LEFT</div>}
         {left.files.length > 0 && (
-          <div className="ml-4">
-            {left.files.map(({ fileId, fileName }) => (
-              <FileTreeNode
-                fileName={fileName}
-                key={fileId}
-                rightAction={<SplitPaneButton fileId={fileId} fromPaneId={left.id} toPaneId={right.id} />}
-                selected={fileId === left.activeFile}
-                onClick={() => selectFileInPane({ paneId: left.id, fileId })}
-              />
-            ))}
-          </div>
+          <FilesList
+            files={left.files}
+            paddingLeft="1.5rem"
+            rightAction={(fileId) => ({
+              onClick: handleSplitFile({ fileId, fromPaneId: left.id, toPaneId: right.id }),
+              VscIcon: VscSplitHorizontal,
+              title: `Move to ${right.id} split pane`,
+            })}
+            selectedFiles={left.activeFile ? [left.activeFile] : []}
+            onClick={(fileId) => selectFileInPane({ paneId: left.id, fileId })}
+          />
         )}
-        {hasRightPanelFiles && <div className="ml-4 text-xs font-bold">RIGHT</div>}
-        {hasRightPanelFiles && (
-          <div className="ml-4">
-            {right.files.map(({ fileId, fileName }) => (
-              <FileTreeNode
-                fileName={fileName}
-                key={fileId}
-                rightAction={<SplitPaneButton fileId={fileId} fromPaneId={right.id} toPaneId={left.id} />}
-                selected={fileId === left.activeFile}
-                onClick={() => selectFileInPane({ paneId: right.id, fileId })}
-              />
-            ))}
-          </div>
+        {hasLeftAndRightPanelsFiles && <div className="font-bold ml-4 text-xs">RIGHT</div>}
+        {right.files.length > 0 && (
+          <FilesList
+            files={right.files}
+            paddingLeft="1.5rem"
+            rightAction={(fileId) => ({
+              onClick: handleSplitFile({ fileId, fromPaneId: right.id, toPaneId: left.id }),
+              VscIcon: VscSplitHorizontal,
+              title: `Move to ${right.id} split pane`,
+            })}
+            selectedFiles={right.activeFile ? [right.activeFile] : []}
+            onClick={(fileId) => selectFileInPane({ paneId: right.id, fileId })}
+          />
         )}
       </PanelSection>
       <PanelSection grow title="Project X">
         <FileEntryTree
           files={allFiles}
+          paddingLeft="1.25rem"
           root
           selectedFiles={[left.activeFile, right.activeFile].filter(isNonNullish)}
-          onClick={handleOpenFile}
+          onFileClick={handleOpenFile}
         />
       </PanelSection>
     </PanelWrapper>

--- a/src/panels/MainPanel.tsx
+++ b/src/panels/MainPanel.tsx
@@ -48,13 +48,11 @@ export function MainPanel(props: MainPanelProps) {
             <MainPanelPane pane={left} {...props} />
           </Panel>
         )}
+        {showLeft && showRight && <VerticalResizeHandle />}
         {showRight && (
-          <>
-            <VerticalResizeHandle />
-            <Panel order={2}>
-              <MainPanelPane pane={right} {...props} />
-            </Panel>
-          </>
+          <Panel order={2}>
+            <MainPanelPane pane={right} {...props} />
+          </Panel>
         )}
       </PanelGroup>
     </>


### PR DESCRIPTION
This improves the File Tree component:
 - Hover and selected effects now take the whole width of pane
 - Open files use a FilesList component instead of FileTree
 - Directories are collapsible

Closes #195 