### PR TITLE
fix: always keep a file as active file when possible

### DIFF
--- a/src/atoms/core/paneGroup.ts
+++ b/src/atoms/core/paneGroup.ts
@@ -70,10 +70,17 @@ export const removeFileFromPane = atom(null, (get, set, { fileId, paneId }: Pane
   }
 
   const updatedOpenFiles = panes[paneId].openFiles.filter((_fileId) => _fileId !== fileId);
+
+  // If the active file was the file being removed, make the last file of the pane the active one
+  let updatedActiveFile = panes[paneId].activeFile;
+  if (updatedActiveFile === fileId) {
+    updatedActiveFile = updatedOpenFiles.length > 0 ? updatedOpenFiles[updatedOpenFiles.length - 1] : undefined;
+  }
+
   set(updatePaneGroup, {
     paneId,
     openFiles: updatedOpenFiles,
-    activeFile: updatedOpenFiles.includes(fileId) ? fileId : undefined,
+    activeFile: updatedActiveFile,
   });
 });
 

--- a/src/atoms/fileActions.test.ts
+++ b/src/atoms/fileActions.test.ts
@@ -274,6 +274,37 @@ describe('fileActions', () => {
     expect(rightPane.current.files).not.toContainEqual(fileData);
   });
 
+  it('should make remaining file active when splitting (moving) file from one pane to another', () => {
+    const store = createStore();
+    const openFile = runSetAtomHook(openFileAtom, store);
+    const leftPane = runGetAtomHook(leftPaneAtom, store);
+    const rightPane = runGetAtomHook(rightPaneAtom, store);
+    const activePane = runGetAtomHook(activePaneAtom, store);
+    const splitFileToPane = runSetAtomHook(splitFileToPaneAtom, store);
+
+    const { fileEntry: fileA, fileData: fileAData } = makeFile('file1.txt');
+    const { fileEntry: fileB, fileData: fileBData } = makeFile('file2.txt');
+
+    act(() => {
+      openFile.current(fileA);
+      openFile.current(fileB);
+    });
+
+    expect(activePane.current.id).toBe('LEFT');
+    expect(leftPane.current.activeFile).toBe(fileBData.fileId);
+
+    act(() => {
+      splitFileToPane.current({ fileId: fileBData.fileId, fromPaneId: 'LEFT', toPaneId: 'RIGHT' });
+    });
+
+    expect(activePane.current.id).toBe('RIGHT');
+
+    expect(leftPane.current.files).toContainEqual(fileAData);
+    expect(leftPane.current.activeFile).toBe(fileAData.fileId);
+    expect(rightPane.current.files).toContainEqual(fileBData);
+    expect(rightPane.current.activeFile).toBe(fileBData.fileId);
+  });
+
   it('should NOT split (move) file if file is NOT opened', () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
@@ -348,7 +379,7 @@ describe('fileActions', () => {
     expect(leftPane.current.activeFile).toEqual(fileCData.fileId);
   });
 
-  it('should make active file undefined if is the last one closed in same pane', () => {
+  it('should make active file undefined if it is the last one closed in the pane', () => {
     const store = createStore();
     const openFile = runSetAtomHook(openFileAtom, store);
     const closeFileFromPane = runSetAtomHook(closeFileFromPaneAtom, store);


### PR DESCRIPTION
Fixes #205 

Removing the active file from a pane now updates the active file of the pane:
 - makes the last file of the pane the new active file
 - updates the field to `undefined` if there are no files left in the pane