### PR TITLE
feat: "Table view" of many references in editor area

### DIFF
--- a/src-tauri/src/core/menu.rs
+++ b/src-tauri/src/core/menu.rs
@@ -2,6 +2,10 @@ use tauri::utils::assets::EmbeddedAssets;
 use tauri::{AboutMetadata, Context, CustomMenuItem, Menu, MenuItem, Submenu, WindowMenuEvent};
 pub struct AppMenu {}
 
+const MENU_SETTINGS: &str = "refstudio://menu/settings";
+const MENU_REFERENCES_OPEN: &str = "refstudio://menu/references/open";
+const MENU_REFERENCES_UPLOAD: &str = "refstudio://menu/references/upload";
+
 impl AppMenu {
     pub fn get_menu(context: &Context<EmbeddedAssets>) -> Menu {
         let name = &context.package_info().name;
@@ -11,10 +15,7 @@ impl AppMenu {
             Menu::new()
                 .add_native_item(MenuItem::About(name.into(), AboutMetadata::new()))
                 .add_native_item(MenuItem::Separator)
-                .add_item(
-                    CustomMenuItem::new("refstudio://menu/settings".to_string(), "Settings")
-                        .accelerator("Cmd+,"),
-                )
+                .add_item(CustomMenuItem::new(MENU_SETTINGS, "Settings").accelerator("Cmd+,"))
                 .add_native_item(MenuItem::Separator)
                 .add_native_item(MenuItem::Services)
                 .add_native_item(MenuItem::Hide)
@@ -44,10 +45,9 @@ impl AppMenu {
 
         let references_menu = Submenu::new(
             "References",
-            Menu::new().add_item(CustomMenuItem::new(
-                "refstudio://menu/references/upload".to_string(),
-                "Upload...",
-            )),
+            Menu::new()
+                .add_item(CustomMenuItem::new(MENU_REFERENCES_OPEN, "Open").accelerator("Cmd+R"))
+                .add_item(CustomMenuItem::new(MENU_REFERENCES_UPLOAD, "Upload...")),
         );
 
         let view_menu = Submenu::new(

--- a/src/atoms/fileActions.ts
+++ b/src/atoms/fileActions.ts
@@ -63,6 +63,24 @@ export const openReferenceAtom = atom(null, (get, set, referenceId: string) => {
   set(selectFileInPaneAtom, { fileId, paneId });
 });
 
+/** Open the references pane in the right pane */
+export const openReferencesAtom = atom(null, (_get, set) => {
+  const fileId = `refstudio://references`;
+
+  // Load in memory
+  set(loadFileSync, { fileId, fileContent: { type: 'references' } });
+
+  // Add to file entries atom
+  set(addFileData, { fileId, fileName: 'RefStudio References' });
+
+  const paneId: PaneId = 'RIGHT';
+  // Add file to panes state
+  set(addFileToPane, { fileId, paneId });
+
+  // Select file in pane
+  set(selectFileInPaneAtom, { fileId, paneId });
+});
+
 /** Removes file from the given pane and unload content from memory if the file is not open in another pane */
 export const closeFileFromPaneAtom = atom(null, (get, set, { fileId, paneId }: PaneFileId) => {
   const panes = get(paneGroupAtom);

--- a/src/atoms/types/FileContent.ts
+++ b/src/atoms/types/FileContent.ts
@@ -18,9 +18,19 @@ export interface JsonFileContent {
   textContent: string;
 }
 
+export interface ReferencesFileContent {
+  type: 'references';
+}
+
 export interface ReferenceFileContent {
   type: 'reference';
   referenceId: string;
 }
 
-export type FileContent = TipTapFileContent | PdfFileContent | XmlFileContent | JsonFileContent | ReferenceFileContent;
+export type FileContent =
+  | TipTapFileContent
+  | PdfFileContent
+  | XmlFileContent
+  | JsonFileContent
+  | ReferencesFileContent
+  | ReferenceFileContent;

--- a/src/components/PanelSection.tsx
+++ b/src/components/PanelSection.tsx
@@ -19,14 +19,13 @@ export function PanelSection({
 
   return (
     <div
-      className={cx('flex flex-col', {
+      className={cx('flex flex-col', 'group/panel-section ', {
         'flex-shrink-0': !grow, // Take the component's height without shrinking
         'flex-grow overflow-hidden': grow, // Can grow
       })}
     >
       <div
         className={cx(
-          'group/header',
           'flex flex-row items-center gap-1', //
           'mb-1 cursor-pointer pl-1 text-sm',
         )}
@@ -34,12 +33,18 @@ export function PanelSection({
       >
         {expanded ? <VscChevronDown /> : <VscChevronRight />}
         <span className="font-bold uppercase">{title}</span>
-        <div className="group/icon invisible ml-auto text-xs group-hover/header:visible">
+        <div
+          className={cx(
+            'ml-auto mr-2 text-xs ', //
+            'flex gap-2',
+            'invisible group-hover/panel-section:visible',
+          )}
+        >
           {rightIcons.map(({ key, Icon, title: iconTitle, onClick }) => (
             <Icon
-              className="cursor-pointer group-hover/icon:bg-slate-200"
+              className="cursor-pointer hover:bg-slate-200"
               key={key}
-              size={16}
+              size={20}
               title={iconTitle}
               onClick={(e) => {
                 e.preventDefault();

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -2,7 +2,7 @@ import { ReferencesFooterItems } from '../../panels/references/ReferencesFooterI
 
 export function Footer() {
   return (
-    <div className="h-10x flex items-center justify-end gap-2 border-t border-t-slate-100 bg-black px-2 text-white">
+    <div className="flex items-center justify-end gap-2 border-t border-t-slate-100 bg-black px-2 text-white">
       <ReferencesFooterItems />
     </div>
   );

--- a/src/components/footer/FooterItem.test.tsx
+++ b/src/components/footer/FooterItem.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '../../utils/test-utils';
+import { render, screen, setup } from '../../utils/test-utils';
 import { FooterItem } from './FooterItem';
 
 describe('FooterItem component', () => {
@@ -6,5 +6,18 @@ describe('FooterItem component', () => {
     render(<FooterItem icon={<span>ICON</span>} text="Some text" />);
     expect(screen.getByText('ICON')).toBeInTheDocument();
     expect(screen.getByText('Some text')).toBeInTheDocument();
+  });
+
+  it('should trigger onClick when cliked', async () => {
+    const fn = vi.fn();
+    const { user } = setup(<FooterItem icon={<span>ICON</span>} text="Some text" onClick={fn} />);
+    await user.click(screen.getByText('Some text'));
+    expect(screen.getByRole('listitem')).toHaveClass('cursor-pointer');
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it('should not be clickable (no cursor-pointer or throw error) if onClick is undefined', () => {
+    render(<FooterItem icon={<span>ICON</span>} text="Some text" onClick={undefined} />);
+    expect(screen.getByRole('listitem')).not.toHaveClass('cursor-pointer');
   });
 });

--- a/src/components/footer/FooterItem.tsx
+++ b/src/components/footer/FooterItem.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 
-export function FooterItem({ icon, text }: { icon: React.ReactNode; text: string }) {
+import { cx } from '../../cx';
+
+export function FooterItem({ icon, text, onClick }: { icon: React.ReactNode; text: string; onClick?: () => void }) {
   return (
-    <span className="flex cursor-pointer items-center gap-2 px-2 py-1 hover:bg-slate-700">
+    <span
+      className={cx('flex select-none items-center gap-2 px-2 py-1', {
+        'cursor-pointer hover:bg-slate-700': onClick,
+      })}
+      onClick={onClick}
+    >
       {icon} <span>{text}</span>
     </span>
   );

--- a/src/components/footer/FooterItem.tsx
+++ b/src/components/footer/FooterItem.tsx
@@ -8,6 +8,7 @@ export function FooterItem({ icon, text, onClick }: { icon: React.ReactNode; tex
       className={cx('flex select-none items-center gap-2 px-2 py-1', {
         'cursor-pointer hover:bg-slate-700': onClick,
       })}
+      role="listitem"
       onClick={onClick}
     >
       {icon} <span>{text}</span>

--- a/src/events.ts
+++ b/src/events.ts
@@ -4,6 +4,7 @@ export const RefStudioEvents = {
   menu: {
     settings: 'refstudio://menu/settings',
     references: {
+      open: 'refstudio://menu/references/open',
       upload: 'refstudio://menu/references/upload',
     },
   },

--- a/src/events.ts
+++ b/src/events.ts
@@ -19,7 +19,7 @@ export function emitEvent<Payload>(event: EventName, payload?: Payload) {
   void emit(event, payload);
 }
 
-export type RefStudioEventCallback<Payload = undefined> = EventCallback<Payload>;
+export type RefStudioEventCallback<Payload> = EventCallback<Payload>;
 
 export async function listenEvent<EventPayload = void>(event: string, fn: RefStudioEventCallback<EventPayload>) {
   return listen<EventPayload>(event, fn);

--- a/src/panels/MainPanel.tsx
+++ b/src/panels/MainPanel.tsx
@@ -77,18 +77,16 @@ export function MainPanelPane({ pane, pdfViewerRef }: MainPanelPaneProps & MainP
   const focusPane = useSetAtom(focusPaneAtom);
 
   return (
-    <div
-      className="h-full grid-cols-1 grid-rows-[auto_1fr]"
-      onClick={() => focusPane(pane.id)}
-      onFocus={() => focusPane(pane.id)}
-    >
-      <TabPane
-        items={items}
-        value={activeFile}
-        onClick={(file) => selectFileInPane({ paneId: pane.id, fileId: file })}
-        onCloseClick={(path) => closeFileInPane({ paneId: pane.id, fileId: path })}
-      />
-      <div className="flex h-full w-full overflow-hidden">
+    <div className="flex h-full flex-col" onClick={() => focusPane(pane.id)} onFocus={() => focusPane(pane.id)}>
+      <div className="grow-0">
+        <TabPane
+          items={items}
+          value={activeFile}
+          onClick={(file) => selectFileInPane({ paneId: pane.id, fileId: file })}
+          onCloseClick={(path) => closeFileInPane({ paneId: pane.id, fileId: path })}
+        />
+      </div>
+      <div className="flex w-full grow overflow-hidden">
         {activeFile && activeFileContent ? (
           <MainPaneViewContent activeFileAtom={activeFileContent} fileId={activeFile} pdfViewerRef={pdfViewerRef} />
         ) : (

--- a/src/panels/MainPanel.tsx
+++ b/src/panels/MainPanel.tsx
@@ -20,6 +20,7 @@ import { PdfViewerAPI } from '../types/PdfViewerAPI';
 import { assertNever } from '../utils/assertNever';
 import { EmptyView } from '../views/EmptyView';
 import { PdfViewer } from '../views/PdfViewer';
+import { ReferencesTableView } from '../views/ReferencesTableView';
 import { ReferenceView } from '../views/ReferenceView';
 import { TextView } from '../views/TextView';
 import { TipTapView } from '../views/TipTapView';
@@ -128,6 +129,8 @@ export function MainPaneViewContent({ activeFileAtom, pdfViewerRef }: MainPaneVi
       return <TipTapView file={data} />;
     case 'reference':
       return <ReferenceView referenceId={data.referenceId} />;
+    case 'references':
+      return <ReferencesTableView />;
     default: {
       assertNever(data);
       return null;

--- a/src/panels/references/FilesDragDropZone.tsx
+++ b/src/panels/references/FilesDragDropZone.tsx
@@ -44,7 +44,6 @@ export function FilesDragDropZone({
       e.stopPropagation();
 
       draggingCountRef.current++;
-      console.log('draggingCountRef.current', draggingCountRef.current);
       if (draggingCountRef.current === 1) {
         onFileDropStarted?.();
       }
@@ -69,7 +68,6 @@ export function FilesDragDropZone({
       e.stopPropagation();
 
       draggingCountRef.current--;
-      console.log('draggingCountRef.current', draggingCountRef.current);
       if (draggingCountRef.current === 0) {
         onFileDropCanceled?.();
       }
@@ -85,7 +83,6 @@ export function FilesDragDropZone({
       e.preventDefault();
       e.stopPropagation();
       draggingCountRef.current = 0;
-      console.log('draggingCountRef.current', draggingCountRef.current);
 
       const eventFiles = e.dataTransfer!.files;
       if (eventFiles.length > 0) {

--- a/src/panels/references/ReferencesFooterItems.test.tsx
+++ b/src/panels/references/ReferencesFooterItems.test.tsx
@@ -1,4 +1,3 @@
-import { waitFor } from '@testing-library/react';
 import { createStore, Provider } from 'jotai';
 
 import { activePaneAtom } from '../../atoms/fileActions';
@@ -86,7 +85,7 @@ describe('ReferencesFooterItems component', () => {
     expect(vi.mocked(emitEvent)).toHaveBeenCalledWith(RefStudioEvents.menu.references.open);
   });
 
-  it('should listen RefStudioEvents.menu.references.open to open references', async () => {
+  it('should listen RefStudioEvents.menu.references.open to open references', () => {
     const mockData = mockListenEvent();
     const store = createStore();
     render(
@@ -95,7 +94,7 @@ describe('ReferencesFooterItems component', () => {
       </Provider>,
     );
 
-    await waitFor(() => expect(mockData.registeredEventName).toBeDefined());
+    expect(mockData.registeredEventName).toBeDefined();
     expect(mockData.registeredEventName).toBe(RefStudioEvents.menu.references.open);
     act(() => mockData.trigger());
 

--- a/src/panels/references/ReferencesFooterItems.tsx
+++ b/src/panels/references/ReferencesFooterItems.tsx
@@ -12,9 +12,7 @@ export function ReferencesFooterItems() {
   const references = useAtomValue(getReferencesAtom);
   const openReferences = useSetAtom(openReferencesAtom);
 
-  useListenEvent(RefStudioEvents.menu.references.open, () => {
-    openReferences();
-  });
+  useListenEvent(RefStudioEvents.menu.references.open, openReferences);
 
   return (
     <>

--- a/src/panels/references/ReferencesFooterItems.tsx
+++ b/src/panels/references/ReferencesFooterItems.tsx
@@ -1,16 +1,29 @@
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { VscLibrary, VscRefresh } from 'react-icons/vsc';
 
+import { openReferencesAtom } from '../../atoms/fileActions';
 import { getReferencesAtom, referencesSyncInProgressAtom } from '../../atoms/referencesState';
 import { FooterItem } from '../../components/footer/FooterItem';
+import { emitEvent, RefStudioEvents } from '../../events';
+import { useListenEvent } from '../../hooks/useListenEvent';
 
 export function ReferencesFooterItems() {
   const syncInProgress = useAtomValue(referencesSyncInProgressAtom);
   const references = useAtomValue(getReferencesAtom);
+  const openReferences = useSetAtom(openReferencesAtom);
+
+  useListenEvent(RefStudioEvents.menu.references.open, () => {
+    openReferences();
+  });
+
   return (
     <>
       {syncInProgress && <FooterItem icon={<VscRefresh className="animate-spin" />} text="References ingestion..." />}
-      <FooterItem icon={<VscLibrary />} text={`References: ${references.length}`} />
+      <FooterItem
+        icon={<VscLibrary />}
+        text={`References: ${references.length}`}
+        onClick={() => emitEvent(RefStudioEvents.menu.references.open)}
+      />
     </>
   );
 }

--- a/src/panels/references/ReferencesList.tsx
+++ b/src/panels/references/ReferencesList.tsx
@@ -8,22 +8,30 @@ export function ReferencesList({
   onRefClicked: (item: ReferenceItem) => void;
 }) {
   return (
-    <ul className="space-y-2" role="list">
-      {references.map((reference) => (
-        <li
-          className="mb-0 cursor-pointer overflow-x-hidden text-ellipsis p-1 hover:bg-slate-200"
-          key={reference.id}
-          role="listitem"
-          onClick={() => onRefClicked(reference)}
-        >
-          <code className="mr-2">[{reference.citationKey}]</code>
-          <strong>{reference.title}</strong>
-          <br />
-          <small>
-            <em className="whitespace-nowrap">{reference.authors.map(({ fullName }) => fullName).join(', ')}</em>
-          </small>
-        </li>
-      ))}
-    </ul>
+    <div className="relative overflow-x-auto">
+      <table className="w-full text-left text-gray-500 ">
+        <thead className="bg-gray-50 text-gray-700 ">
+          <tr>
+            <th scope="col">key</th>
+            <th scope="col">Title</th>
+          </tr>
+        </thead>
+        <tbody>
+          {references.map((reference) => (
+            <tr
+              className="cursor-pointer bg-white even:bg-slate-50 hover:bg-slate-200"
+              key={reference.id}
+              onClick={() => onRefClicked(reference)}
+            >
+              <td className="pr-2">{reference.citationKey}</td>
+              <td className="py-2">
+                <div className="whitespace-nowrap ">{reference.title}</div>
+                <small>{reference.authors.map(({ fullName }) => fullName).join(', ')}</small>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/src/panels/references/ReferencesList.tsx
+++ b/src/panels/references/ReferencesList.tsx
@@ -8,30 +8,20 @@ export function ReferencesList({
   onRefClicked: (item: ReferenceItem) => void;
 }) {
   return (
-    <div className="relative overflow-x-auto">
-      <table className="w-full text-left text-gray-500 ">
-        <thead className="bg-gray-50 text-gray-700 ">
-          <tr>
-            <th scope="col">key</th>
-            <th scope="col">Title</th>
-          </tr>
-        </thead>
-        <tbody>
-          {references.map((reference) => (
-            <tr
-              className="cursor-pointer bg-white even:bg-slate-50 hover:bg-slate-200"
-              key={reference.id}
-              onClick={() => onRefClicked(reference)}
-            >
-              <td className="pr-2">{reference.citationKey}</td>
-              <td className="py-2">
-                <div className="whitespace-nowrap ">{reference.title}</div>
-                <small>{reference.authors.map(({ fullName }) => fullName).join(', ')}</small>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="">
+      <ul className="space-y-4">
+        {references.map((reference) => (
+          <li
+            className="cursor-pointer bg-white p-1 px-4 even:bg-slate-50 hover:bg-slate-200"
+            key={reference.id}
+            onClick={() => onRefClicked(reference)}
+          >
+            <div className="truncate whitespace-nowrap">{reference.title}</div>
+            <div className="text-xs">{reference.authors.map(({ fullName }) => fullName).join(', ')}</div>
+            <div className="text-xs">{reference.citationKey}</div>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/panels/references/ReferencesPanel.test.tsx
+++ b/src/panels/references/ReferencesPanel.test.tsx
@@ -1,6 +1,6 @@
 import { createStore, Provider } from 'jotai';
 
-import { getReferencesAtom, referencesSyncInProgressAtom, setReferencesAtom } from '../../atoms/referencesState';
+import { getReferencesAtom, setReferencesAtom } from '../../atoms/referencesState';
 import { runGetAtomHook, runSetAtomHook } from '../../atoms/test-utils';
 import { emitEvent, RefStudioEvents } from '../../events';
 import { noop } from '../../utils/noop';
@@ -48,41 +48,13 @@ describe('ReferencesPanel', () => {
     expect(screen.getByText(/Reference document title/i)).toBeInTheDocument();
   });
 
-  it('should display tip instructions', () => {
-    const store = createStore();
-    render(
-      <Provider store={store}>
-        <ReferencesPanel onRefClicked={noop} />
-      </Provider>,
-    );
-    expect(screen.getByText(/or drag.drop PDF files for upload/i)).toBeInTheDocument();
-  });
-
-  it('should hide tip instructions during sync', () => {
-    const store = createStore();
-    render(
-      <Provider store={store}>
-        <ReferencesPanel onRefClicked={noop} />
-      </Provider>,
-    );
-
-    const setSync = runSetAtomHook(referencesSyncInProgressAtom, store);
-    act(() => setSync.current(true));
-
-    expect(screen.queryByText(/or drag.drop PDF files for upload/i)).not.toBeInTheDocument();
-  });
-
-  it('should trigger upload event when click in CLICK HERE link', async () => {
-    const store = createStore();
-    const { user } = setup(
-      <Provider store={store}>
-        <ReferencesPanel onRefClicked={noop} />
-      </Provider>,
-    );
-
-    await user.click(screen.getByText(/here/));
-
-    expect(vi.mocked(emitEvent)).toHaveBeenCalledWith(RefStudioEvents.menu.references.upload);
+  it.each([
+    { title: 'Add References', event: RefStudioEvents.menu.references.upload },
+    { title: 'Open References', event: RefStudioEvents.menu.references.open },
+  ])('should trigger $title on click', async ({ title, event }) => {
+    const { user } = setup(<ReferencesPanel onRefClicked={noop} />);
+    await user.click(screen.getByTitle(title));
+    expect(vi.mocked(emitEvent)).toBeCalledWith(event);
   });
 
   it('should reset references when click in reset', async () => {

--- a/src/panels/references/ReferencesPanel.tsx
+++ b/src/panels/references/ReferencesPanel.tsx
@@ -1,12 +1,14 @@
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { VscNewFile, VscOpenPreview } from 'react-icons/vsc';
 
-import { getReferencesAtom, referencesSyncInProgressAtom, setReferencesAtom } from '../../atoms/referencesState';
+import { getReferencesAtom } from '../../atoms/referencesState';
 import { PanelSection } from '../../components/PanelSection';
 import { PanelWrapper } from '../../components/PanelWrapper';
 import { emitEvent, RefStudioEvents } from '../../events';
 import { ReferenceItem } from '../../types/ReferenceItem';
 import { ReferencesList } from './ReferencesList';
+import { ResetReferencesInstructions } from './ResetReferencesInstructions';
+import { UploadTipInstructions } from './UploadTipInstructions';
 
 interface ReferencesPanelProps {
   onRefClicked: (item: ReferenceItem) => void;
@@ -44,46 +46,5 @@ export function ReferencesPanel({ onRefClicked }: ReferencesPanelProps) {
         </div>
       </PanelSection>
     </PanelWrapper>
-  );
-}
-
-function UploadTipInstructions() {
-  const syncInProgress = useAtomValue(referencesSyncInProgressAtom);
-
-  if (syncInProgress) {
-    return null;
-  }
-
-  return (
-    <div className="my-2 bg-yellow-50 p-1 text-sm italic">
-      <strong>TIP:</strong> Click{' '}
-      <span className="cursor-pointer underline" onClick={() => emitEvent(RefStudioEvents.menu.references.upload)}>
-        here
-      </span>{' '}
-      or drag/drop PDF files for upload.
-    </div>
-  );
-}
-
-function ResetReferencesInstructions() {
-  const references = useAtomValue(getReferencesAtom);
-  const setReferences = useSetAtom(setReferencesAtom);
-  const syncInProgress = useAtomValue(referencesSyncInProgressAtom);
-  if (!import.meta.env.DEV) {
-    return null;
-  }
-  if (references.length === 0) {
-    return null;
-  }
-  if (syncInProgress) {
-    return null;
-  }
-
-  return (
-    <div className="mt-10 text-right text-xs ">
-      <button className="text-gray-400 hover:underline" onClick={() => setReferences([])}>
-        DEBUG: reset references store
-      </button>
-    </div>
   );
 }

--- a/src/panels/references/ReferencesPanel.tsx
+++ b/src/panels/references/ReferencesPanel.tsx
@@ -1,7 +1,6 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { VscNewFile, VscOpenPreview } from 'react-icons/vsc';
 
-import { openReferencesAtom } from '../../atoms/fileActions';
 import { getReferencesAtom, referencesSyncInProgressAtom, setReferencesAtom } from '../../atoms/referencesState';
 import { PanelSection } from '../../components/PanelSection';
 import { PanelWrapper } from '../../components/PanelWrapper';
@@ -15,10 +14,13 @@ interface ReferencesPanelProps {
 
 export function ReferencesPanel({ onRefClicked }: ReferencesPanelProps) {
   const references = useAtomValue(getReferencesAtom);
-  const openReferences = useSetAtom(openReferencesAtom);
 
   const handleAddReferences = () => {
     emitEvent(RefStudioEvents.menu.references.upload);
+  };
+
+  const handleOpenReferences = () => {
+    emitEvent(RefStudioEvents.menu.references.open);
   };
 
   return (
@@ -27,7 +29,7 @@ export function ReferencesPanel({ onRefClicked }: ReferencesPanelProps) {
         grow
         rightIcons={[
           { key: 'new', Icon: VscNewFile, title: 'Add References', onClick: handleAddReferences },
-          { key: 'open', Icon: VscOpenPreview, title: 'Open References', onClick: openReferences },
+          { key: 'open', Icon: VscOpenPreview, title: 'Open References', onClick: handleOpenReferences },
         ]}
         title="Library"
       >

--- a/src/panels/references/ReferencesPanel.tsx
+++ b/src/panels/references/ReferencesPanel.tsx
@@ -1,5 +1,7 @@
 import { useAtomValue, useSetAtom } from 'jotai';
+import { VscNewFile, VscOpenPreview } from 'react-icons/vsc';
 
+import { openReferencesAtom } from '../../atoms/fileActions';
 import { getReferencesAtom, referencesSyncInProgressAtom, setReferencesAtom } from '../../atoms/referencesState';
 import { PanelSection } from '../../components/PanelSection';
 import { PanelWrapper } from '../../components/PanelWrapper';
@@ -13,10 +15,22 @@ interface ReferencesPanelProps {
 
 export function ReferencesPanel({ onRefClicked }: ReferencesPanelProps) {
   const references = useAtomValue(getReferencesAtom);
+  const openReferences = useSetAtom(openReferencesAtom);
+
+  const handleAddReferences = () => {
+    emitEvent(RefStudioEvents.menu.references.upload);
+  };
 
   return (
     <PanelWrapper title="References">
-      <PanelSection grow title="Library">
+      <PanelSection
+        grow
+        rightIcons={[
+          { key: 'new', Icon: VscNewFile, title: 'Add References', onClick: handleAddReferences },
+          { key: 'open', Icon: VscOpenPreview, title: 'Open References', onClick: openReferences },
+        ]}
+        title="Library"
+      >
         <div className="min-h-[200px] ">
           {references.length === 0 && (
             <div className="p-2">Welcome to your RefStudio references library. Start by uploading some PDFs.</div>

--- a/src/panels/references/ResetReferencesInstructions.test.tsx
+++ b/src/panels/references/ResetReferencesInstructions.test.tsx
@@ -1,0 +1,42 @@
+import { createStore, Provider } from 'jotai';
+
+import { getReferencesAtom, setReferencesAtom } from '../../atoms/referencesState';
+import { runGetAtomHook, runSetAtomHook } from '../../atoms/test-utils';
+import { act, screen, setup } from '../../utils/test-utils';
+import { ResetReferencesInstructions } from './ResetReferencesInstructions';
+
+vi.mock('../../events');
+
+describe('ResetReferencesInstructions', () => {
+  it('should reset references when click in reset', async () => {
+    const store = createStore();
+    const { user } = setup(
+      <Provider store={store}>
+        <ResetReferencesInstructions />
+      </Provider>,
+    );
+
+    const setReferences = runSetAtomHook(setReferencesAtom, store);
+    const getReferences = runGetAtomHook(getReferencesAtom, store);
+
+    const SAMPLE_REFERENCE = {
+      id: 'ref.id',
+      citationKey: 'citationKey',
+      title: 'Reference document title',
+      abstract: '',
+      authors: [],
+      filename: 'title.pdf',
+      publishedDate: '2023-06-22',
+    };
+
+    act(() => {
+      setReferences.current([SAMPLE_REFERENCE]);
+    });
+
+    expect(getReferences.current).toStrictEqual([SAMPLE_REFERENCE]);
+
+    await user.click(screen.getByText(/reset references store/));
+
+    expect(getReferences.current).toStrictEqual([]);
+  });
+});

--- a/src/panels/references/ResetReferencesInstructions.tsx
+++ b/src/panels/references/ResetReferencesInstructions.tsx
@@ -1,0 +1,26 @@
+import { useAtomValue, useSetAtom } from 'jotai';
+
+import { getReferencesAtom, referencesSyncInProgressAtom, setReferencesAtom } from '../../atoms/referencesState';
+
+export function ResetReferencesInstructions() {
+  const references = useAtomValue(getReferencesAtom);
+  const setReferences = useSetAtom(setReferencesAtom);
+  const syncInProgress = useAtomValue(referencesSyncInProgressAtom);
+  if (!import.meta.env.DEV) {
+    return null;
+  }
+  if (references.length === 0) {
+    return null;
+  }
+  if (syncInProgress) {
+    return null;
+  }
+
+  return (
+    <div className="mt-10 text-right text-xs ">
+      <button className="text-gray-400 hover:underline" onClick={() => setReferences([])}>
+        DEBUG: reset references store
+      </button>
+    </div>
+  );
+}

--- a/src/panels/references/UploadTipInstructions.test.tsx
+++ b/src/panels/references/UploadTipInstructions.test.tsx
@@ -1,0 +1,50 @@
+import { createStore, Provider } from 'jotai';
+
+import { referencesSyncInProgressAtom } from '../../atoms/referencesState';
+import { runSetAtomHook } from '../../atoms/test-utils';
+import { emitEvent, RefStudioEvents } from '../../events';
+import { act, render, screen, setup } from '../../utils/test-utils';
+import { UploadTipInstructions } from './UploadTipInstructions';
+
+vi.mock('../../events');
+
+describe('UploadTipInstructions', () => {
+  it('should display tip instructions', () => {
+    const store = createStore();
+    render(
+      <Provider store={store}>
+        <UploadTipInstructions />
+      </Provider>,
+    );
+    expect(screen.getByText(/TIP/i)).toBeInTheDocument();
+    expect(screen.getByText(/or drag.drop PDF files for upload/i)).toBeInTheDocument();
+  });
+
+  it('should hide tip instructions during sync', () => {
+    const store = createStore();
+    render(
+      <Provider store={store}>
+        <UploadTipInstructions />
+      </Provider>,
+    );
+
+    const setSync = runSetAtomHook(referencesSyncInProgressAtom, store);
+    act(() => setSync.current(true));
+
+    expect(screen.queryByText(/TIP/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/or drag.drop PDF files for upload/i)).not.toBeInTheDocument();
+  });
+
+  it('should trigger upload event when click in CLICK HERE link', async () => {
+    const store = createStore();
+    const { user } = setup(
+      <Provider store={store}>
+        <UploadTipInstructions />
+      </Provider>,
+    );
+
+    await user.click(screen.getByText(/here/));
+
+    expect(vi.mocked(emitEvent)).toHaveBeenCalledWith(RefStudioEvents.menu.references.upload);
+  });
+});

--- a/src/panels/references/UploadTipInstructions.tsx
+++ b/src/panels/references/UploadTipInstructions.tsx
@@ -1,0 +1,22 @@
+import { useAtomValue } from 'jotai';
+
+import { referencesSyncInProgressAtom } from '../../atoms/referencesState';
+import { emitEvent, RefStudioEvents } from '../../events';
+
+export function UploadTipInstructions() {
+  const syncInProgress = useAtomValue(referencesSyncInProgressAtom);
+
+  if (syncInProgress) {
+    return null;
+  }
+
+  return (
+    <div className="my-2 bg-yellow-50 p-1 text-sm italic" data-testid={UploadTipInstructions.name}>
+      <strong>TIP:</strong> Click{' '}
+      <span className="cursor-pointer underline" onClick={() => emitEvent(RefStudioEvents.menu.references.upload)}>
+        here
+      </span>{' '}
+      or drag/drop PDF files for upload.
+    </div>
+  );
+}

--- a/src/settings/SettingsModalOpener.test.tsx
+++ b/src/settings/SettingsModalOpener.test.tsx
@@ -1,8 +1,8 @@
 import { act } from '@testing-library/react';
 
-import { listenEvent, RefStudioEventCallback, RefStudioEvents } from '../events';
+import { RefStudioEvents } from '../events';
 import { noop } from '../utils/noop';
-import { render, screen } from '../utils/test-utils';
+import { mockListenEvent, render, screen } from '../utils/test-utils';
 import { getCachedSetting, initSettings, saveCachedSettings, setCachedSetting } from './settings';
 import { SettingsModalOpener } from './SettingsModalOpener';
 
@@ -28,25 +28,17 @@ describe('SettingsModalOpener component', () => {
   });
 
   it('should open the Settings model on SETTING menu event', () => {
-    let settingEvtHandler: undefined | RefStudioEventCallback;
-    let eventName = '';
-    vi.mocked(listenEvent).mockImplementation(async (event: string, handler: RefStudioEventCallback) => {
-      eventName = event;
-      settingEvtHandler = handler;
-      await Promise.resolve();
-      return noop();
-    });
+    const mockData = mockListenEvent();
 
     render(<SettingsModalOpener />);
     expect(screen.queryByRole('menuitem', { name: 'General' })).not.toBeInTheDocument();
     expect(screen.queryByRole('menuitem', { name: 'Open AI' })).not.toBeInTheDocument();
     expect(screen.queryByRole('menuitem', { name: 'Config' })).not.toBeInTheDocument();
 
-    expect(eventName).toBe(RefStudioEvents.menu.settings);
-    expect(settingEvtHandler).toBeDefined();
+    expect(mockData.registeredEventName).toBe(RefStudioEvents.menu.settings);
 
     // Trigger the settings event to open the modal
-    act(() => settingEvtHandler!({ event: RefStudioEvents.menu.settings, windowLabel: '', id: 1, payload: undefined }));
+    act(() => mockData.trigger());
 
     expect(screen.getByRole('menuitem', { name: 'General' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Open AI' })).toBeInTheDocument();
@@ -54,26 +46,18 @@ describe('SettingsModalOpener component', () => {
   });
 
   it('should toggle the Settings model on SETTING menu event', () => {
-    let settingEvtHandler: undefined | RefStudioEventCallback;
-    let eventName = '';
-    vi.mocked(listenEvent).mockImplementation(async (event: string, handler: RefStudioEventCallback) => {
-      eventName = event;
-      settingEvtHandler = handler;
-      await Promise.resolve();
-      return noop();
-    });
+    const mockData = mockListenEvent();
 
     render(<SettingsModalOpener />);
     expect(screen.queryByRole('menuitem', { name: 'General' })).not.toBeInTheDocument();
-    expect(eventName).toBe(RefStudioEvents.menu.settings);
-    expect(settingEvtHandler).toBeDefined();
+    expect(mockData.registeredEventName).toBe(RefStudioEvents.menu.settings);
 
     // Open
-    act(() => settingEvtHandler!({ event: RefStudioEvents.menu.settings, windowLabel: '', id: 1, payload: undefined }));
+    act(() => mockData.trigger());
     expect(screen.getByRole('menuitem', { name: 'General' })).toBeInTheDocument();
 
     // Close
-    act(() => settingEvtHandler!({ event: RefStudioEvents.menu.settings, windowLabel: '', id: 1, payload: undefined }));
+    act(() => mockData.trigger());
     expect(screen.queryByRole('menuitem', { name: 'General' })).not.toBeInTheDocument();
   });
 });

--- a/src/views/ReferencesTableView.test.tsx
+++ b/src/views/ReferencesTableView.test.tsx
@@ -1,0 +1,57 @@
+import { createStore, Provider } from 'jotai';
+
+import { setReferencesAtom } from '../atoms/referencesState';
+import { runSetAtomHook } from '../atoms/test-utils';
+import { UploadTipInstructions } from '../panels/references/UploadTipInstructions';
+import { act, render, screen } from '../utils/test-utils';
+import { ReferencesTableView } from './ReferencesTableView';
+
+describe('ReferencesTableView component', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should render empty table with upload tips', () => {
+    const store = createStore();
+    render(
+      <Provider store={store}>
+        <ReferencesTableView />
+      </Provider>,
+    );
+    expect(screen.getByTestId(UploadTipInstructions.name)).toBeInTheDocument();
+  });
+
+  it('should render references', () => {
+    const store = createStore();
+    const setReferences = runSetAtomHook(setReferencesAtom, store);
+
+    const REFERENCES = [
+      {
+        id: 'A Few Useful Things to Know about Machine Learning.pdf',
+        filename: 'A Few Useful Things to Know about Machine Learning.pdf',
+        title: 'A Few Useful Things to Know about Machine Learning.pdf',
+        citationKey: 'citationKey',
+        authors: [],
+        abstract: '',
+      },
+      {
+        id: 'Rules of Machine Learning - Best Practices for ML Engineering.pdf',
+        filename: 'Rules of Machine Learning - Best Practices for ML Engineering.pdf',
+        title: 'Rules of Machine Learning - Best Practices for ML Engineering.pdf',
+        citationKey: 'citationKey 2',
+        authors: [],
+        abstract: '',
+      },
+    ];
+
+    act(() => setReferences.current(REFERENCES));
+
+    render(
+      <Provider store={store}>
+        <ReferencesTableView />
+      </Provider>,
+    );
+    expect(screen.getByText(REFERENCES[0].title)).toBeInTheDocument();
+    expect(screen.getByText(REFERENCES[1].title)).toBeInTheDocument();
+  });
+});

--- a/src/views/ReferencesTableView.tsx
+++ b/src/views/ReferencesTableView.tsx
@@ -9,7 +9,7 @@ export function ReferencesTableView() {
   const references = useAtomValue(getReferencesAtom);
 
   return (
-    <div className="w-full p-6">
+    <div className="w-full overflow-y-auto p-6">
       {references.length === 0 && <UploadTipInstructions />}
       <table className="w-full border border-slate-300 text-left text-gray-500 ">
         <thead>

--- a/src/views/ReferencesTableView.tsx
+++ b/src/views/ReferencesTableView.tsx
@@ -3,12 +3,14 @@ import './ReferenceView.css';
 import { useAtomValue } from 'jotai';
 
 import { getReferencesAtom } from '../atoms/referencesState';
+import { UploadTipInstructions } from '../panels/references/UploadTipInstructions';
 
 export function ReferencesTableView() {
   const references = useAtomValue(getReferencesAtom);
 
   return (
-    <div className="debug w-full p-6">
+    <div className="w-full p-6">
+      {references.length === 0 && <UploadTipInstructions />}
       <table className="w-full border border-slate-300 text-left text-gray-500 ">
         <thead>
           <tr className="h-10 bg-slate-300 text-black">
@@ -20,11 +22,7 @@ export function ReferencesTableView() {
         </thead>
         <tbody>
           {references.map((reference) => (
-            <tr
-              className="cursor-pointer bg-white even:bg-slate-50 hover:bg-slate-200"
-              key={reference.id}
-              // onClick={() => onRefClicked(reference)}
-            >
+            <tr className="cursor-pointer bg-white even:bg-slate-50 hover:bg-slate-200" key={reference.id}>
               <td className="px-2">{reference.citationKey}</td>
               <td className="py-2">
                 <div className="whitespace-nowrap ">{reference.title}</div>

--- a/src/views/ReferencesTableView.tsx
+++ b/src/views/ReferencesTableView.tsx
@@ -1,0 +1,46 @@
+import './ReferenceView.css';
+
+import { useAtomValue } from 'jotai';
+
+import { getReferencesAtom } from '../atoms/referencesState';
+
+export function ReferencesTableView() {
+  const references = useAtomValue(getReferencesAtom);
+
+  return (
+    <div className="debug w-full p-6">
+      <table className="w-full border border-slate-300 text-left text-gray-500 ">
+        <thead>
+          <tr className="h-10 bg-slate-300 text-black">
+            <th scope="col">Citation Key</th>
+            <th scope="col">Title</th>
+            <th scope="col">Date</th>
+            <th scope="col">Authors</th>
+          </tr>
+        </thead>
+        <tbody>
+          {references.map((reference) => (
+            <tr
+              className="cursor-pointer bg-white even:bg-slate-50 hover:bg-slate-200"
+              key={reference.id}
+              // onClick={() => onRefClicked(reference)}
+            >
+              <td className="px-2">{reference.citationKey}</td>
+              <td className="py-2">
+                <div className="whitespace-nowrap ">{reference.title}</div>
+              </td>
+              <td>{reference.publishedDate ?? 'N/A'}</td>
+              <td className="py-2 pl-6">
+                <ul className="list-disc">
+                  {reference.authors.map(({ fullName }) => (
+                    <li key={fullName}>{fullName}</li>
+                  ))}
+                </ul>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds table view of references. Check features implemented in #200.

Extra: Also adds the utility test method `mockListenEvent` to simplify tests of components that listen to events.


https://github.com/refstudio/refstudio/assets/174127/887abe32-546f-43af-9097-f6c30f116679



This closes https://github.com/refstudio/refstudio/issues/200