### PR TITLE
feat: Update ingest so uploads are only processed once

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -8,7 +8,7 @@ if __name__ == '__main__':
         print(args)
     
     if args.command == "ingest":
-        ingest.main(args.pdf_directory)
+        ingest.run_ingest(args.pdf_directory)
     
     if args.command == "ingest_status":
         ingest.get_statuses()

--- a/python/sidecar/ingest.py
+++ b/python/sidecar/ingest.py
@@ -1,13 +1,15 @@
 import json
 import logging
 import os
+import shutil
 import sys
 from collections import defaultdict
 from pathlib import Path
 
 import grobid_tei_xml
 from dotenv import load_dotenv
-from grobid_client.grobid_client import GrobidClient
+from grobid_client.grobid_client import (GrobidClient,
+                                         ServerUnavailableException)
 from sidecar import shared, typing
 
 from .settings import REFERENCES_JSON_PATH, UPLOADS_DIR
@@ -34,87 +36,210 @@ logger.addHandler(handler)
 logger.disabled = os.environ.get("SIDECAR_ENABLE_LOGGING", "false").lower() == "true"
 
 GROBID_SERVER_URL = "https://kermitt2-grobid.hf.space"
-GROBID_TIMEOUT = 60 * 5
+
+
+def run_ingest(pdf_directory: str):
+    pdf_directory = Path(pdf_directory)
+    ingest = PDFIngestion(input_dir=pdf_directory)
+    ingest.run()
+
+
+def get_statuses():
+    storage = JsonStorage(REFERENCES_JSON_PATH)
+    status_fetcher = IngestStatusFetcher(storage=storage)
+    status_fetcher.emit_statuses()
 
 
 class PDFIngestion:
+
     def __init__(self, input_dir: Path):
         self.input_dir = input_dir
         self.project_name = input_dir.parent.name
+        self.uploaded_files = list(self.input_dir.glob('*.pdf'))
 
         # directories for storing intermediate files
+        self.staging_dir = input_dir.parent.joinpath('.staging')
         self.grobid_output_dir = input_dir.parent.joinpath('.grobid')
         self.storage_dir = input_dir.parent.joinpath('.storage')
+        self._create_directories()
+
+        self.references = self._load_references()
 
     def run(self):
         logger.info(f"Starting ingestion for project: {self.project_name}")
-        logger.info(f"Input directory: {self.input_dir}")
-        self._create_directories()
-        self.call_grobid_server()
-        self.convert_grobid_xml_to_json()
+
+        self._copy_uploads_to_staging()
+        self._call_grobid_for_staging()
+        self._convert_grobid_xml_to_json()
+
         references = self.create_references()
         self.save_references(references)
+
         response = self.create_response_from_references(references)
         sys.stdout.write(response.json())
+
+        for ref in references:
+            self._remove_temporary_files_for_reference(ref)
+        
         logger.info(f"Finished ingestion for project: {self.project_name}")
-        logger.info(f"Response: {response}")
 
     def _create_directories(self) -> None:
+        if not self.staging_dir.exists():
+            self.staging_dir.mkdir()
+        
         if not self.grobid_output_dir.exists():
             self.grobid_output_dir.mkdir()
 
         if not self.storage_dir.exists():
             self.storage_dir.mkdir()
 
-    def get_files_to_ingest(self) -> list[Path]:
+    def _check_for_uploaded_files(self) -> bool:
         """
-        Determines which files need to be ingested
-        :return: bool
-        """
-        # fp.stem = fp.name without filetype extension
-        pdf_filestems = {fp.stem: fp for fp in self.input_dir.glob("*.pdf")}
-        json_filestems = {fp.stem: fp for fp in self.storage_dir.glob("*.json")}
-        needs_ingestion_filestems = set(pdf_filestems.keys()) - set(json_filestems.keys())
+        Checks for PDF files in the `uploads` directory.
 
-        if not needs_ingestion_filestems:
-            logger.info("All pdf files have already been processed")
+        Returns
+        -------
+        bool
+            True if PDF files are in the `uploads` directory.
+        """
+        if not self.uploaded_files:
+            logger.warning(f"No PDF files found in directory: {self.input_dir}")
+            return False
+        return True
+
+    def _check_for_staging_files(self) -> bool:
+        """
+        Checks for PDF files in the `.staging` directory.
+        Returns
+        -------
+        bool
+            True if PDF files are in the `.staging` directory.
+        """
+        if not list(self.staging_dir.glob("*.pdf")):
+            logger.warning(f"No PDF files found in directory: {self.staging_dir}")
+            return False
+        return True
+
+    def _load_references(self) -> list[Reference]:
+        """
+        Loads existing References list for project. If none exist, this will 
+        be an empty list.
+        References that have been previously processed will not be ingested 
+        again.
+        """
+        filepath = self.storage_dir.joinpath('references.json')
+        if not filepath.exists():
+            logger.warning(f"No previous `references.json` found at {filepath}")
             return []
 
-        filepaths_to_ingest = []
-        for stem in needs_ingestion_filestems:
-            filepaths_to_ingest.append(pdf_filestems[stem])
+        jstore = JsonStorage(filepath)
+        jstore.load()
+        return jstore.references
+
+    def _get_files_to_ingest(self) -> list[Path]:
+        """
+        Determines which files need to be ingested by comparing the list of 
+        already processed References against files found in `uploads`.
+        """
+        if not self._check_for_uploaded_files():
+            logger.info("No files have been uploaded")
+            sys.exit()
+
+        uploaded_filestems = {fp.stem: fp for fp in self.input_dir.glob("*.pdf")}
+        processed_filestems = {
+            Path(ref.source_filename).stem: ref.source_filename for ref in self.references
+        }
+        needs_ingestion_filestems = set(uploaded_filestems.keys()) - set(processed_filestems.keys())
+
+        if not needs_ingestion_filestems:
+            logger.info("All uploaded PDFs have already been processed")
+            sys.exit()
+
+        filepaths_to_ingest = [
+            uploaded_filestems[stem] for stem in needs_ingestion_filestems
+        ]
         return filepaths_to_ingest
 
-    def call_grobid_server(self) -> None:
-        pdf_files = list(self.input_dir.glob("*.pdf"))
+    def _copy_uploads_to_staging(self) -> None:
+        """
+        Copies PDF files in need of ingestion from `self.input_dir` to 
+        `self.staging_dir` so that files in `uploads` are not mutated and are 
+        only processed once.
+        """
+        files_to_ingest = self._get_files_to_ingest()
+        logger.info(f"Found {len(files_to_ingest)} new uploads to ingest")
 
-        # make sure there are PDFs to process
-        if not pdf_files:
-            logger.warning(f"No pdf files found in directory: {self.input_dir}")
-            return
+        for filepath in files_to_ingest:
+            logger.info(f"Copying {filepath.name} to {self.staging_dir}")
+            shutil.copy(filepath, self.staging_dir)
 
-        logger.info(f"Found {len(pdf_files)} pdf files to process")
-        logger.info("Calling Grobid server...")
+    def _remove_temporary_files_for_reference(self, ref: Reference) -> None:
+        """
+        Removes a Reference's temporary files that were created during 
+        various stages of ingestion.
+        """
+        staging_path = self.staging_dir.joinpath(ref.source_filename)
+        shared.remove_file(staging_path)
 
+        # grobid success
+        xml_filename = f"{Path(ref.source_filename).stem}.tei.xml"
+        xml_path = self.grobid_output_dir.joinpath(xml_filename)
+        shared.remove_file(xml_path)
+
+        # grobid failures - there might not be any
+        txt_filename = f"{Path(ref.source_filename).stem}*.txt"
+        matches = list(self.grobid_output_dir.glob(txt_filename))
+
+        if matches:
+            txt_path = matches[0]
+            shared.remove_file(txt_path)
+
+        # json converted from grobid XML
+        json_filename = f"{Path(ref.source_filename).stem}.json"
+        json_path = self.storage_dir.joinpath(json_filename)
+        shared.remove_file(json_path)
+    
+    def _call_grobid_for_staging(self) -> None:
+        """
+        Call Grobid server for all files in `.staging` directory.
+
+        Files that are successfully parsed result in a `{filename}.tei.xml`
+        file being written to `.grobid`. Files that are unable to be parsed
+        are also written to `.grobid`, but their file names are structured 
+        as `{filename}_{errorcode}.txt` (e.g. some-pdf_500.txt)
+        """
+        if not self._check_for_staging_files():
+            logger.info("No staging files found for Grobid processing")
+            sys.exit()
+        
+        num_files = len(list(self.staging_dir.glob("*.pdf")))
+        timeout = 30 * num_files
+
+        logger.info(f"Calling Grobid server for {num_files} files")
+
+        # The Grobid client library we use prints info and error messages to stdout.
+        # This is a problem because the Tauri client <-> sidecar communicate over stdout.
+        # So we need to wrap all Grobid calls inside of `HiddenPrints` to prevent `print`
+        # messages from ending up in stdout (https://stackoverflow.com/a/45669280).
+        # 
+        # Longer-term, we should probably fork the Grobid client and make changes 
+        # to better suit our use-case.
         with HiddenPrints():
-            # Grobid prints a message informing that the server is alive
-            # This is problematic since the sidecar communicates over stdout
-            # thus, HiddenPrint (https://stackoverflow.com/a/45669280)
-            client = GrobidClient(GROBID_SERVER_URL, timeout=GROBID_TIMEOUT)
+            try:
+                client = GrobidClient(GROBID_SERVER_URL, timeout=timeout)
+            except ServerUnavailableException as e:
+                logger.error(e)
 
-            # If an error occurs during processing, the Grobid Server will
-            # print out error messages to stdout, rather than using HTTP status codes
-            # or raising an exception. So this line also needs to be wrapped
-            # in HiddenPrints.
-            # Grobid will still create the output file, even if an error occurs,
-            # however it will be a txt file with a name like {filename}_{errorcode}.txt
             client.process(
                 "processFulltextDocument",
-                input_path=self.input_dir,
+                input_path=self.staging_dir,
                 output=self.grobid_output_dir,
                 force=True
             )
         logger.info("Finished calling Grobid server")
+
+        # statuses aren't needed right now, but calling this method
+        # will write a status message for each file in the logs for us
         _ = self._get_grobid_output_statuses()
 
     def _get_grobid_output_statuses(self) -> dict[Path, str]:
@@ -131,7 +256,7 @@ class PDFIngestion:
         ]
 
         statuses = {}
-        for file in self.input_dir.glob("*.pdf"):
+        for file in self.staging_dir.glob("*.pdf"):
             if file.stem in xml_filestems:
                 logger.info(f"Grobid successfully parsed file: {file.name}")
                 statuses[file.name] = "success"
@@ -143,9 +268,9 @@ class PDFIngestion:
                 statuses[file.name] = "not_found"
         return statuses
 
-    def convert_grobid_xml_to_json(self) -> None:
+    def _convert_grobid_xml_to_json(self) -> None:
         xml_files = list(self.grobid_output_dir.glob("*.xml"))
-        logger.info(f"Found {len(xml_files)} xml files to parse")
+        logger.info(f"Converting {len(xml_files)} Grobid XML files to JSON")
 
         for file in xml_files:
             with open(file, "r") as fin:
@@ -161,9 +286,18 @@ class PDFIngestion:
 
     def _parse_header(self, document: dict) -> dict:
         """
-        Parses the header of a document and returns a dictionary of the header fields
-        :param document: dict
-        :return: Dict[str, str]
+        Parses the `header` elements of a Grobid document and returns a 
+        dictionary of parsed header fields.
+
+        Parameters
+        ----------
+        dict
+            Dictionary of header elements to be parsed
+
+        Returns
+        -------
+        dict
+            Dictionary containing parsed header elements
         """
         header = document.get("header")
         if not header:
@@ -228,7 +362,19 @@ class PDFIngestion:
         If a Reference does not have an author surname or published date, then the citation
         key becomes "untitled" and is appended with 1, 2, 3, etc.
 
-        Examples:
+        https://quarto.org/docs/authoring/footnotes-and-citations.html#sec-citations
+
+        Parameters
+        ----------
+        references : list[References]
+
+        Returns
+        -------
+        references : list[Reference]
+            List of References, each with a unique `citation_key` field
+        
+        Notes
+        -----
         1. Two References with different author surnames and different published year:
             - (Smith, 2018) and (Jones, 2020) => citation keys: smith2018 and jones2020
         2. Two References with different author surnames and no published year:
@@ -243,11 +389,6 @@ class PDFIngestion:
             - (None, 2020) and (None, 2021) => citation keys: untitled2020 and untitled2021
         7. Two References with no author surname and no published year:
             - (None, None) and (None, None) => citation keys: untitled1 and untitled2
-
-        :param ref: List[Reference]
-        :return: str
-
-        https://quarto.org/docs/authoring/footnotes-and-citations.html#sec-citations
         """
         ref_key_groups = defaultdict(list)
         for ref in references:
@@ -279,7 +420,7 @@ class PDFIngestion:
         except ValueError:
             pass
 
-        logger.info(f"Found {len(json_files)} json reference files")
+        logger.info(f"Found {len(json_files)} Grobid JSON files to parse")
 
         references = []
         for file in json_files:
@@ -307,9 +448,10 @@ class PDFIngestion:
             references.append(ref)
 
         failures = self._create_references_for_grobid_failures()
+        num_created = len(references) + len(failures)
 
         msg = (
-            f"Created {len(references)} Reference objects: "
+            f"Created {num_created} Reference objects: "
             f"{len(references)} successful Grobid parses, {len(failures)} Grobid failures"
         )
         logger.info(msg)
@@ -433,14 +575,3 @@ class IngestStatusFetcher:
         )
         return
 
-
-def main(pdf_directory: str):
-    pdf_directory = Path(pdf_directory)
-    ingest = PDFIngestion(input_dir=pdf_directory)
-    ingest.run()
-
-
-def get_statuses():
-    storage = JsonStorage(REFERENCES_JSON_PATH)
-    status_fetcher = IngestStatusFetcher(storage=storage)
-    status_fetcher.emit_statuses()

--- a/python/sidecar/ingest.py
+++ b/python/sidecar/ingest.py
@@ -75,17 +75,12 @@ class PDFIngestion:
         self._create_references()
         self._save_references()
 
-        response = self.create_response_from_references(references)
+        response = self.create_ingest_response()
         sys.stdout.write(response.json())
 
-<<<<<<< Updated upstream
-        for ref in references:
+        for ref in self.references:
             self._remove_temporary_files_for_reference(ref)
         
-=======
-        self._remove_temporary_files()
-
->>>>>>> Stashed changes
         logger.info(f"Finished ingestion for project: {self.project_name}")
 
     def _create_directories(self) -> None:
@@ -177,13 +172,8 @@ class PDFIngestion:
         for filepath in files_to_ingest:
             logger.info(f"Copying {filepath.name} to {self.staging_dir}")
             shutil.copy(filepath, self.staging_dir)
-<<<<<<< Updated upstream
 
     def _remove_temporary_files_for_reference(self, ref: Reference) -> None:
-=======
-    
-    def _remove_temporary_files(self) -> None:
->>>>>>> Stashed changes
         """
         Removes a Reference's temporary files that were created during 
         various stages of ingestion.
@@ -348,6 +338,7 @@ class PDFIngestion:
 
         references = []
         for file in txt_files:
+            logger.info(f"Creating Reference from file: {file.name}")
             source_pdf = f"{file.stem.rpartition('_')[0]}.pdf"
             references.append(
                 Reference(
@@ -466,17 +457,8 @@ class PDFIngestion:
         )
         logger.info(msg)
 
-<<<<<<< Updated upstream
-        references = references + failures
-        self._add_citation_keys(references)
-
-        return references
-=======
         new_references = successes + failures
-
         self._add_citation_keys(new_references)
-        self._add_reference_statuses(new_references)
->>>>>>> Stashed changes
 
         # append new references to any we have previously loaded
         for ref in new_references:
@@ -496,8 +478,10 @@ class PDFIngestion:
     def create_ingest_response(self) -> IngestResponse:
         """
         Creates a Response object from a list of Reference objects
-        :param references: List[Reference]
-        :return: Response
+
+        Returns
+        -------
+        response : IngestResponse
         """
         return IngestResponse(
             project_name=self.project_name,

--- a/python/sidecar/shared.py
+++ b/python/sidecar/shared.py
@@ -11,6 +11,16 @@ def get_word_count(text: str) -> int:
     return len(text.strip().split(" "))
 
 
+def remove_file(filepath: str) -> None:
+    """
+    Removes a file located at `filepath`.
+    """
+    try:
+        os.remove(filepath)
+    except OSError:
+        pass
+
+
 def parse_date(date_str: str) -> datetime:
     """
     Parse a YYYY-mm-dd date string into a datetime object.

--- a/python/tests/test_ingest.py
+++ b/python/tests/test_ingest.py
@@ -1,4 +1,5 @@
 import json
+import os
 from datetime import date
 from pathlib import Path
 
@@ -23,8 +24,9 @@ def _copy_fixture_to_temp_dir(source_path: Path, write_path: Path) -> None:
         f.write(file_bytes)
 
 
-def test_main(monkeypatch, tmp_path, capsys):
+def test_run_ingest(monkeypatch, tmp_path, capsys):
     # directories where ingest will write files
+    staging_dir = tmp_path.joinpath(".staging")
     grobid_output_dir = tmp_path.joinpath(".grobid")
     json_storage_dir = tmp_path.joinpath(".storage")
 
@@ -45,7 +47,7 @@ def test_main(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(ingest.GrobidClient, "process", mock_grobid_client_process)
 
     pdf_directory = tmp_path.joinpath("uploads")
-    ingest.main(pdf_directory)
+    ingest.run_ingest(pdf_directory)
 
     # check that the expected output was printed to stdout
     captured = capsys.readouterr()
@@ -70,14 +72,18 @@ def test_main(monkeypatch, tmp_path, capsys):
     assert references[1]['authors'][0]['full_name'] == "Pedro Domingos"
     assert references[1]['citation_key'] == "domingos"
 
-    # check that the expected directories and files were created
-    # grobid output
-    assert grobid_output_dir.exists()
-    assert grobid_output_dir.joinpath("test.tei.xml").exists()
-    assert grobid_output_dir.joinpath("grobid-fails_500.txt").exists()
-    # json creation and storage - successfully parsed references are stored as json
-    assert json_storage_dir.exists()
-    assert json_storage_dir.joinpath("test.json").exists()
+    # check that all temporary files were cleaned up ...
+    assert len(os.listdir(staging_dir)) == 0
+    assert len(os.listdir(grobid_output_dir)) == 0
+    assert len(os.listdir(json_storage_dir)) == 1
+
+    # ... except for the references.json file
+    references_json_path = json_storage_dir.joinpath("references.json")
+    assert references_json_path.exists()
+
+    # references.json should contain the same references in stdout
+    with open(references_json_path, "r") as f:
+        assert json.load(f) == output['references']
 
 
 def test_ingest_add_citation_keys(tmp_path):

--- a/scripts/reset_uploads.sh
+++ b/scripts/reset_uploads.sh
@@ -3,6 +3,6 @@
 PROJECT_DIR="$HOME/Library/Application Support/com.tauri.dev/project-x"
 
 rm -f "$PROJECT_DIR/uploads/"*.pdf
+rm -rf "$PROJECT_DIR/.staging"
 rm -rf "$PROJECT_DIR/.grobid"
 rm -rf "$PROJECT_DIR/.storage"
-rm -rf "$PROJECT_DIR/.lancedb"


### PR DESCRIPTION
fixes #218 

Note that `IngestResponse` will still contain _all_ References, not just the newly uploaded Reference. Let me know if we want to change this.
______
```bash
$ ls -la $HOME"/Library/Application Support/com.tauri.dev/project-x/uploads"
total 5536
drwxr-xr-x  4 greg  staff      128 Jun 28 21:21 .
drwxr-xr-x  9 greg  staff      288 Jun 28 21:22 ..
-rw-r--r--@ 1 greg  staff   333450 Jun 28 15:24 Machine Learning at Scale.pdf
-rw-r--r--@ 1 greg  staff  2497316 Jun 28 15:36 grobid-fails.pdf

# run ingest
$ poetry run python main.py ingest --pdf_directory=$HOME"/Library/Application Support/com.tauri.dev/project-x/uploads"

# output from /tmp/refstudio-sidecar.log
2023-06-28 21:22:47,767 - sidecar.ingest - INFO - Grobid successfully parsed file: Machine Learning at Scale.pdf
2023-06-28 21:22:47,767 - sidecar.ingest - WARNING - Grobid failed to parse file: grobid-fails.pdf
2023-06-28 21:22:47,767 - sidecar.ingest - INFO - Converting 1 Grobid XML files to JSON
2023-06-28 21:22:47,776 - sidecar.ingest - INFO - Found 1 Grobid JSON files to parse
2023-06-28 21:22:47,776 - sidecar.ingest - INFO - Creating Reference from file: Machine Learning at Scale.json
2023-06-28 21:22:47,780 - sidecar.ingest - INFO - Found 1 txt files from Grobid parsing errors
2023-06-28 21:22:47,780 - sidecar.ingest - INFO - Creating Reference from file: grobid-fails_500.txt
2023-06-28 21:22:47,780 - sidecar.ingest - INFO - Created 2 Reference objects: 1 successful Grobid parses, 1 Grobid failures
2023-06-28 21:22:47,780 - sidecar.ingest - INFO - Saving references to file: /Users/greg/Library/Application Support/com.tauri.dev/project-x/.storage/references.json
2023-06-28 21:22:47,812 - sidecar.ingest - INFO - Finished ingestion for project: project-x


# add a new upload ...
$ cp ~/Downloads/2212.08037v2.pdf uploads/.

# ... and run ingest again
# there are now three uploads - two from above + one new upload
$ poetry run python main.py ingest --pdf_directory=$HOME"/Library/Application Support/com.tauri.dev/project-x/uploads"

# output from logs - note only the new upload is processed
2023-06-28 21:27:17,850 - sidecar.ingest - INFO - Starting ingestion for project: project-x
2023-06-28 21:27:17,850 - sidecar.ingest - INFO - Found 1 new uploads to ingest
2023-06-28 21:27:17,850 - sidecar.ingest - INFO - Copying 2212.08037v2.pdf to /Users/greg/Library/Application Support/com.tauri.dev/project-x/.staging
2023-06-28 21:27:17,851 - sidecar.ingest - INFO - Calling Grobid server for 1 files
2023-06-28 21:27:29,573 - sidecar.ingest - INFO - Finished calling Grobid server
2023-06-28 21:27:29,574 - sidecar.ingest - INFO - Grobid successfully parsed file: 2212.08037v2.pdf
2023-06-28 21:27:29,574 - sidecar.ingest - INFO - Converting 1 Grobid XML files to JSON
2023-06-28 21:27:29,632 - sidecar.ingest - INFO - Found 1 Grobid JSON files to parse
2023-06-28 21:27:29,632 - sidecar.ingest - INFO - Creating Reference from file: 2212.08037v2.json
2023-06-28 21:27:29,634 - sidecar.ingest - INFO - Found 0 txt files from Grobid parsing errors
2023-06-28 21:27:29,634 - sidecar.ingest - INFO - Created 1 Reference objects: 1 successful Grobid parses, 0 Grobid failures
2023-06-28 21:27:29,634 - sidecar.ingest - INFO - Saving references to file: /Users/greg/Library/Application Support/com.tauri.dev/project-x/.storage/references.json
2023-06-28 21:27:29,684 - sidecar.ingest - INFO - Finished ingestion for project: project-x

# check references.json -- should be 3 references
$ cat .storage/references.json | jq '.[] | {"source_filename": .source_filename, "title": .title}'
{
  "source_filename": "Machine Learning at Scale.pdf",
  "title": "Machine Learning at Scale"
}
{
  "source_filename": "grobid-fails.pdf",
  "title": null
}
{
  "source_filename": "2212.08037v2.pdf",
  "title": "Attributed Question Answering: Evaluation and Modeling for Attributed Large Language Models"
}
```