### PR TITLE
chore: use setUpEditorWithSelection in all tests

### DIFF
--- a/src/features/textEditor/components/tipTapNodes/collapsibleBlock/helpers/unsetPartiallySelectedCollapsibleBlocks.test.ts
+++ b/src/features/textEditor/components/tipTapNodes/collapsibleBlock/helpers/unsetPartiallySelectedCollapsibleBlocks.test.ts
@@ -1,9 +1,8 @@
-import { TextSelection } from '@tiptap/pm/state';
-import { Editor, getText } from '@tiptap/react';
+import { Editor } from '@tiptap/react';
 
 import { EDITOR_EXTENSIONS } from '../../../tipTapEditorConfigs';
 import { defaultCollapsibleBlock } from '../../test-fixtures';
-import { findNodesByNodeType } from '../../test-utils';
+import { getPrettyHTMLWithSelection, setUpEditorWithSelection } from '../../test-utils';
 import { unsetPartiallySelectedCollapsibleBlocks } from './unsetPartiallySelectedCollapsibleBlocks';
 
 describe('unsetPartiallySelectedCollapsibleBlocks', () => {
@@ -11,63 +10,61 @@ describe('unsetPartiallySelectedCollapsibleBlocks', () => {
     extensions: EDITOR_EXTENSIONS,
   });
 
-  beforeEach(() => {
-    editor.commands.setContent('<p>First paragraph</p>' + defaultCollapsibleBlock + '<p>Last paragraph</p>');
-  });
-
   it('should unset the collapsible block when it is partially selected', () => {
-    const selection = TextSelection.between(editor.state.doc.resolve(0), editor.state.doc.resolve(30));
-    expect(editor.state.doc.childCount).toBe(3);
-    const [collapsibleBlock] = findNodesByNodeType(editor.state.doc, 'collapsibleBlock');
-    expect(collapsibleBlock).toBeDefined();
-    expect(collapsibleBlock.childCount).toBe(2);
-    const firstParagraph = editor.state.doc.child(0);
-    const lastParagraph = editor.state.doc.child(2);
-    const initialSummary = collapsibleBlock.child(0);
-    const contentBlock = collapsibleBlock.child(1);
-    expect(contentBlock.childCount).toBe(2);
-    const initialContent = [contentBlock.child(0), contentBlock.child(1)];
+    setUpEditorWithSelection(
+      editor,
+      `<p>|First paragraph</p>
+      <collapsible-block>
+        <collapsible-summary>Header</collapsible-summary>
+        <collapsible-content>
+          <p>C|ontent Line 1</p>
+          <p>Content Line 2</p>
+        </collapsible-content>
+      </collapsible-block>
+      <p>Last paragraph</p>`,
+    );
 
-    const commandResult = editor
-      .chain()
-      .setTextSelection(selection)
-      .command(unsetPartiallySelectedCollapsibleBlocks)
-      .run();
+    const commandResult = editor.commands.command(unsetPartiallySelectedCollapsibleBlocks);
     expect(commandResult).toBe(true);
 
-    const { doc } = editor.state;
-    expect(doc.childCount).toBe(5);
-    expect(doc.child(0).toJSON()).toEqual(firstParagraph.toJSON());
-    // The collapsible summary is not a block but is transformed into a block when unsetting the collapsing block,
-    // so we can only test that the text has been preserved
-    expect(getText(doc.child(1))).toEqual(getText(initialSummary));
-    expect(doc.child(2).toJSON()).toEqual(initialContent[0].toJSON());
-    expect(doc.child(3).toJSON()).toEqual(initialContent[1].toJSON());
-    expect(doc.child(4).toJSON()).toEqual(lastParagraph.toJSON());
+    expect(getPrettyHTMLWithSelection(editor)).toMatchInlineSnapshot(`
+      "<p>|First paragraph</p>
+      <p>Header</p>
+      <p>C|ontent Line 1</p>
+      <p>Content Line 2</p>
+      <p>Last paragraph</p>"
+    `);
   });
 
   it('should not do anything if the collapsible block is completely selected', () => {
     const initialDoc = editor.state.doc;
 
-    const commandResult = editor.chain().selectAll().command(unsetPartiallySelectedCollapsibleBlocks).run();
+    const commandResult = editor
+      .chain()
+      .setContent('<p>First paragraph</p>' + defaultCollapsibleBlock + '<p>Last paragraph</p>')
+      .selectAll()
+      .command(unsetPartiallySelectedCollapsibleBlocks)
+      .run();
     expect(commandResult).toBe(false);
     expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
   });
 
   it('should not do anything if the selection head is inside the collapsible block', () => {
-    const firstParagraph = editor.state.doc.child(0);
-    const selection = TextSelection.between(
-      // + 6 is to position the caret in the middle of the collapsible summary
-      editor.state.doc.resolve(firstParagraph.nodeSize + 6),
-      editor.state.doc.resolve(30),
+    setUpEditorWithSelection(
+      editor,
+      `<p>First paragraph</p>
+      <collapsible-block>
+        <collapsible-summary>Hea|der</collapsible-summary>
+        <collapsible-content>
+          <p>C|ontent Line 1</p>
+          <p>Content Line 2</p>
+        </collapsible-content>
+      </collapsible-block>
+      <p>Last paragraph</p>`,
     );
     const initialDoc = editor.state.doc;
 
-    const commandResult = editor
-      .chain()
-      .setTextSelection(selection)
-      .command(unsetPartiallySelectedCollapsibleBlocks)
-      .run();
+    const commandResult = editor.commands.command(unsetPartiallySelectedCollapsibleBlocks);
     expect(commandResult).toBe(false);
     expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
   });

--- a/src/features/textEditor/components/tipTapNodes/collapsibleBlock/helpers/unsetPartiallySelectedCollapsibleBlocks.test.ts
+++ b/src/features/textEditor/components/tipTapNodes/collapsibleBlock/helpers/unsetPartiallySelectedCollapsibleBlocks.test.ts
@@ -37,14 +37,11 @@ describe('unsetPartiallySelectedCollapsibleBlocks', () => {
   });
 
   it('should not do anything if the collapsible block is completely selected', () => {
+    setUpEditorWithSelection(editor, '<p>|First paragraph</p>' + defaultCollapsibleBlock + '<p>Last paragraph</p>');
+
     const initialDoc = editor.state.doc;
 
-    const commandResult = editor
-      .chain()
-      .setContent('<p>First paragraph</p>' + defaultCollapsibleBlock + '<p>Last paragraph</p>')
-      .selectAll()
-      .command(unsetPartiallySelectedCollapsibleBlocks)
-      .run();
+    const commandResult = editor.chain().selectAll().command(unsetPartiallySelectedCollapsibleBlocks).run();
     expect(commandResult).toBe(false);
     expect(editor.state.doc.toJSON()).toEqual(initialDoc.toJSON());
   });

--- a/src/features/textEditor/components/tipTapNodes/collapsibleBlock/keyboardShortcutCommands/enter.test.ts
+++ b/src/features/textEditor/components/tipTapNodes/collapsibleBlock/keyboardShortcutCommands/enter.test.ts
@@ -71,11 +71,7 @@ describe('Enter keyboard shortcut command', () => {
   });
 
   it('should not do anything when the selection is not in a collapsible block', () => {
-    editor
-      .chain()
-      .setContent('<p>Some content</p>' + defaultCollapsibleBlock)
-      .setTextSelection(2)
-      .run();
+    setUpEditorWithSelection(editor, '<p>|Some content</p>' + defaultCollapsibleBlock);
     const initialDoc = editor.state.doc;
 
     const commandResult = enter({ editor });

--- a/src/features/textEditor/components/tipTapNodes/collapsibleBlock/keyboardShortcutCommands/modEnter.test.ts
+++ b/src/features/textEditor/components/tipTapNodes/collapsibleBlock/keyboardShortcutCommands/modEnter.test.ts
@@ -2,7 +2,7 @@ import { Editor } from '@tiptap/react';
 
 import { EDITOR_EXTENSIONS } from '../../../tipTapEditorConfigs';
 import { defaultCollapsibleBlock } from '../../test-fixtures';
-import { findNodesByNodeType, getPrettyHTMLWithSelection, setUpEditorWithSelection } from '../../test-utils';
+import { getPrettyHTMLWithSelection, setUpEditorWithSelection } from '../../test-utils';
 import { modEnter } from './modEnter';
 
 describe('Mod-Enter keyboard shortcut command', () => {
@@ -37,22 +37,42 @@ describe('Mod-Enter keyboard shortcut command', () => {
   });
 
   it('should uncollapse collapsible block', () => {
-    editor.chain().setContent(defaultCollapsibleBlock).setTextSelection(0).run();
-
-    let [collapsibleBlock] = findNodesByNodeType(editor.state.doc, 'collapsibleBlock');
-    expect(collapsibleBlock).toBeDefined();
-    expect(collapsibleBlock.attrs.folded).toBe(true);
+    setUpEditorWithSelection(
+      editor,
+      `<collapsible-block folded='true'>
+        <collapsible-summary>|Header</collapsible-summary>
+        <collapsible-content>
+            <p>Content Line 1</p>
+            <p>Content Line 2</p>
+        </collapsible-content>
+      </collapsible-block>`,
+    );
 
     const commandResult = modEnter({ editor });
     expect(commandResult).toBe(true);
 
-    [collapsibleBlock] = findNodesByNodeType(editor.state.doc, 'collapsibleBlock');
-    expect(collapsibleBlock).toBeDefined();
-    expect(collapsibleBlock.attrs.folded).toBe(false);
+    expect(getPrettyHTMLWithSelection(editor)).toMatchInlineSnapshot(`
+      "<collapsible-block folded='false'>
+        <collapsible-summary>|Header</collapsible-summary>
+        <collapsible-content>
+          <p>Content Line 1</p>
+          <p>Content Line 2</p>
+        </collapsible-content>
+      </collapsible-block>"
+    `);
   });
 
   it('should not do anything when the selection is in the content of the collapsible block', () => {
-    editor.chain().setContent(defaultCollapsibleBlock).setTextSelection(15).run();
+    setUpEditorWithSelection(
+      editor,
+      `<collapsible-block folded='true'>
+        <collapsible-summary>Header</collapsible-summary>
+        <collapsible-content>
+            <p>Con|tent Line 1</p>
+            <p>Content Line 2</p>
+        </collapsible-content>
+      </collapsible-block>`,
+    );
     const initialDoc = editor.state.doc;
 
     const commandResult = modEnter({ editor });
@@ -61,11 +81,7 @@ describe('Mod-Enter keyboard shortcut command', () => {
   });
 
   it('should not do anything when the selection is not in a collapsible block', () => {
-    editor
-      .chain()
-      .setContent('<p>Some content</p>' + defaultCollapsibleBlock)
-      .setTextSelection(5)
-      .run();
+    setUpEditorWithSelection(editor, '<p>Som|e content</p>' + defaultCollapsibleBlock);
     const initialDoc = editor.state.doc;
 
     const commandResult = modEnter({ editor });

--- a/src/features/textEditor/components/tipTapNodes/test-fixtures.ts
+++ b/src/features/textEditor/components/tipTapNodes/test-fixtures.ts
@@ -16,26 +16,21 @@ export const defaultUncollapsedCollapsibleBlock = `
     </collapsible-content>
 </collapsible-block>`;
 
+export const defaultCollapsibleBlockWithCursor = `
+<collapsible-block>
+    <collapsible-summary>|Header</collapsible-summary>
+    <collapsible-content>
+        <p>Content Line 1</p>
+        <p>Content Line 2</p>
+    </collapsible-content>
+</collapsible-block>`;
+
 export const defaultParagraph = `<p>Some content</p>`;
 
 export const oneLineCollapsibleBlock = `
 <collapsible-block>
-    <collapsible-summary>Header</collapsible-summary>
+    <collapsible-summary>|Header</collapsible-summary>
     <collapsible-content>
         <p>Content Line</p>
     </collapsible-content>
 </collapsible-block>`;
-
-export const collapsedEmptyCollapsibleBlock = `
-<collapsible-block folded='true'>
-    <collapsible-summary></collapsible-summary>
-</collapsible-block>`;
-
-export const uncollapsedCollapsibleBlockWithEmptyContent = `
-<collapsible-block folded='false'>
-    <collapsible-summary></collapsible-summary>
-    <collapsible-content>
-        <p></p>
-    </collapsible-content>
-</collapsible-block>
-`;


### PR DESCRIPTION
We had to skip a failing test in a previous PR (#215). Debugging the issue was difficult because the test was not using the util function `setUpEditorWithSelection`.

This PR adds the function to all the existing tests, to make the tests more legible