### PR TITLE
Remove filename_md5 from backend

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -63,7 +63,6 @@ $ poetry run python main.py ingest --pdf_directory=tests/fixtures/pdf/ | jq
   "references": [
     {
       "source_filename": "test.pdf",
-      "filename_md5": "754dc77d28e62763c4916970d595a10f",
       "title": "A Few Useful Things to Know about Machine Learning",
       "abstract": "... PDF abstract here ...",
       "contents": "... PDF body here ...",
@@ -91,7 +90,6 @@ $ poetry run python main.py ingest --pdf_directory=tests/fixtures/pdf/ | jq
     },
     {
       "source_filename": "grobid-fails.pdf",
-      "filename_md5": "35765b170578ba4bcd412305e78ebf6b",
       "title": null,
       "abstract": null,
       "contents": null,

--- a/python/cli.schema.json
+++ b/python/cli.schema.json
@@ -98,9 +98,6 @@
         "source_filename": {
           "type": "string"
         },
-        "filename_md5": {
-          "type": "string"
-        },
         "status": {
           "$ref": "#/definitions/IngestStatus"
         },
@@ -141,7 +138,6 @@
       },
       "required": [
         "source_filename",
-        "filename_md5",
         "status"
       ]
     },

--- a/python/sidecar/ingest.py
+++ b/python/sidecar/ingest.py
@@ -13,7 +13,7 @@ from grobid_client.grobid_client import (GrobidClient,
 from sidecar import shared, typing
 
 from .settings import REFERENCES_JSON_PATH, UPLOADS_DIR
-from .shared import HiddenPrints, chunk_text, get_filename_md5
+from .shared import HiddenPrints, chunk_text
 from .storage import JsonStorage
 from .typing import Author, IngestResponse, Reference
 
@@ -344,7 +344,6 @@ class PDFIngestion:
                 Reference(
                     source_filename=source_pdf,
                     status=typing.IngestStatus.FAILURE,
-                    filename_md5=get_filename_md5(source_pdf),
                     citation_key="untitled",
                 )
             )
@@ -436,7 +435,6 @@ class PDFIngestion:
 
             ref = Reference(
                 source_filename=source_pdf,
-                filename_md5=get_filename_md5(source_pdf),
                 status=typing.IngestStatus.COMPLETE,
                 title=header.get("title"),
                 authors=header.get("authors"),

--- a/python/sidecar/shared.py
+++ b/python/sidecar/shared.py
@@ -1,4 +1,3 @@
-import hashlib
 import os
 import sys
 from datetime import datetime
@@ -37,15 +36,6 @@ def parse_date(date_str: str) -> datetime:
         return datetime.strptime(date_str, "%Y-%m-%d").date()
     except ValueError:
         return None
-
-
-def get_filename_md5(filename: str) -> str:
-    """
-    Get the MD5 hash of a filename
-    :param filename: str
-    :return: str
-    """
-    return hashlib.md5(filename.encode()).hexdigest()
 
 
 def get_first_author_surname(authors: List[Author]) -> str:

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -31,7 +31,6 @@ class IngestStatus(str, Enum):
 class Reference(RefStudioModel):
     """A reference for an academic paper / PDF"""
     source_filename: str
-    filename_md5: str
     status: IngestStatus
     citation_key: str | None = None
     title: str | None = None

--- a/python/tests/fixtures/data/references.json
+++ b/python/tests/fixtures/data/references.json
@@ -1,7 +1,6 @@
 [
   {
     "source_filename": "some_file.pdf",
-    "filename_md5": "abc123",
     "status": "complete",
     "title": "Some title",
     "abstract": null,
@@ -66,7 +65,6 @@
   },
   {
     "source_filename": "another_file.pdf",
-    "filename_md5": "abcdefg123",
     "status": "complete",
     "title": "Another title",
     "abstract": null,

--- a/python/tests/test_ingest.py
+++ b/python/tests/test_ingest.py
@@ -93,7 +93,6 @@ def test_ingest_add_citation_keys(tmp_path):
     # we'll be copying this reference and modifying it for each test
     base_reference = Reference(
         source_filename="test.pdf",
-        filename_md5="asdf",
         status="complete"
     )
     fake_data = [
@@ -226,12 +225,10 @@ def test_ingest_get_statuses(monkeypatch, capsys):
     mock_references = [
         Reference(
             source_filename="completed.pdf",
-            filename_md5="abcdef123",
             status=typing.IngestStatus.COMPLETE
         ),
         Reference(
             source_filename="failed.pdf",
-            filename_md5="abcdef123",
             status=typing.IngestStatus.FAILURE
         ),
     ]

--- a/python/tests/test_shared.py
+++ b/python/tests/test_shared.py
@@ -15,10 +15,6 @@ def test_parse_date():
     assert shared.parse_date("abc") is None
 
 
-def test_get_filename_md5():
-    assert shared.get_filename_md5("test.pdf") == "754dc77d28e62763c4916970d595a10f"
-
-
 def test_get_first_author_surname():
     a = [
         Author(full_name="Dan Vanderkam", given_name="Dan", surname="Vanderkam"),
@@ -40,7 +36,6 @@ def test_create_citation_key():
     test_data = [
         {
             "source_filename": "abc.pdf",
-            "filename_md5": "some_md5",
             "status": "complete",
             "authors": [
                 Author(full_name="Dan Vanderkam", given_name="Dan", surname="Vanderkam"),
@@ -51,7 +46,6 @@ def test_create_citation_key():
         },
         {
             "source_filename": "abc.pdf",
-            "filename_md5": "some_md5",
             "status": "complete",
             "authors": [
                 Author(full_name="Jeff Hammerbacher", given_name="Jeff", surname="Hammerbacher")
@@ -60,14 +54,12 @@ def test_create_citation_key():
         },
         {
             "source_filename": "abc.pdf",
-            "filename_md5": "some_md5",
             "status": "complete",
             "authors": [],
             "published_date": None,
         },
         {
             "source_filename": "abc.pdf",
-            "filename_md5": "some_md5",
             "status": "complete",
             "authors": [],
             "published_date": date(2020, 1, 1),

--- a/src/api/ingestion.test.ts
+++ b/src/api/ingestion.test.ts
@@ -41,7 +41,6 @@ describe('runPDFIngestion', () => {
       references: [
         {
           source_filename: 'file.pdf',
-          filename_md5: 'md5',
           status: 'complete',
         },
       ],
@@ -49,7 +48,7 @@ describe('runPDFIngestion', () => {
 
     const response = await runPDFIngestion();
     expect(response).toHaveLength(1);
-    expect(response[0].id).toBe('md5');
+    expect(response[0].id).toBe('file.pdf');
     expect(response[0].filename).toBe('file.pdf');
   });
 
@@ -59,7 +58,6 @@ describe('runPDFIngestion', () => {
       references: [
         {
           source_filename: 'file.pdf',
-          filename_md5: 'md5',
           status: 'complete',
           authors: [
             {

--- a/src/api/ingestion.ts
+++ b/src/api/ingestion.ts
@@ -5,7 +5,7 @@ import { IngestResponse } from './types';
 
 function parsePdfIngestionResponse(response: IngestResponse): ReferenceItem[] {
   return response.references.map((reference) => ({
-    id: reference.filename_md5,
+    id: reference.source_filename,
     citationKey: reference.citation_key ?? 'unknown',
     filename: reference.source_filename,
     title: reference.title ?? reference.source_filename.replace('.pdf', ''),

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -31,7 +31,6 @@ export interface IngestResponse {
  */
 export interface Reference {
   source_filename: string;
-  filename_md5: string;
   status: IngestStatus;
   citation_key?: string;
   title?: string;


### PR DESCRIPTION
fixes #190 
____
Discussed this with @cguedes and it makes more sense for us to consider the `source_filename` to be the true unique id of the Reference file, since that implicitly happens on the filesystem anyway.