### PR TITLE
fix: citation keys should not update on key collision with newly uploaded references

### DIFF
--- a/python/sidecar/ingest.py
+++ b/python/sidecar/ingest.py
@@ -349,62 +349,86 @@ class PDFIngestion:
             )
         return references
     
-    def _add_citation_keys(self, references: list[Reference]) -> list[Reference]:
+    def _add_citation_keys(self, new_references: list[Reference]) -> list[Reference]:
         """
         Adds unique citation keys for a list of Reference objects based on Pandoc
         citation key formatting rules.
 
-        Because citation keys are unique, we need to create them after all References
-        have been created. This is because the citation key is based on the Reference's
-        author surname and published date. If two References have the same author surname
-        and published date, then the citation key is appended with a, b, c, etc.
+        A citation key is based on the Reference's first author surname
+        and published date.
 
-        If a Reference does not have an author surname or published date, then the citation
-        key becomes "untitled" and is appended with 1, 2, 3, etc.
+        If two References have the same author surname and published date, 
+        then the citation key is appended with a, b, c, etc.
+
+        If a Reference does not have an author surname or published date,
+        then the citation key becomes "untitled" and is appended with 1, 2, 3, etc.
+
+        If a Reference already has a citation key, then it is not modified.
 
         https://quarto.org/docs/authoring/footnotes-and-citations.html#sec-citations
 
         Parameters
         ----------
-        references : list[References]
+        new_references : list[References]
+            List of newly uploaded References that need citation keys
 
         Returns
         -------
         references : list[Reference]
             List of References, each with a unique `citation_key` field
-        
-        Notes
-        -----
-        1. Two References with different author surnames and different published year:
-            - (Smith, 2018) and (Jones, 2020) => citation keys: smith2018 and jones2020
-        2. Two References with different author surnames and no published year:
-            - (Smith, None) and (Jones, None) => citation keys: smith and jones
-        3. Two References with the same author surname but different published years:
-            - (Smith, 2020) and (Smith, 2021) => citation keys: smith2020 and smith2021
-        4. Two References with the same author surname and published year:
-            - (Smith, 2020) and (Smith, 2020) => citation keys: smith2020a and smith2020b
-        5. Two References with the same author surname and no published year:
-            - (Smith, None) and (Smith, None) => citation keys: smitha and smithb 
-        6. Two References with no author surname and different published years:
-            - (None, 2020) and (None, 2021) => citation keys: untitled2020 and untitled2021
-        7. Two References with no author surname and no published year:
-            - (None, None) and (None, None) => citation keys: untitled1 and untitled2
         """
-        ref_key_groups = defaultdict(list)
-        for ref in references:
+
+        # we must determine the max current "appended" index for key
+        # (e.g. 1, 2, 3, a, b, c, etc.)
+        # this will determine the starting index for new references
+        # 
+        # we do this by incrementing from what the citation key would have 
+        # been in its "unappended" format -- what the key would be if we did not 
+        # have any other references
+        max_existing_index_by_key = {}
+        for ref in self.references:
             key = shared.create_citation_key(ref)
-            ref_key_groups[key].append(ref)
-        
-        for key, refs in ref_key_groups.items():
-            if len(refs) == 1:
-                refs[0].citation_key = key
-            elif key == "untitled":
-                for i, ref in enumerate(refs):
-                    ref.citation_key = f"{key}{i + 1}"
+            if key not in max_existing_index_by_key:
+                max_existing_index_by_key[key] = 1
             else:
-                for i, ref in enumerate(refs):
-                    ref.citation_key = f"{key}{chr(97 + i)}"
-        return references
+                max_existing_index_by_key[key] += 1
+
+        new_ref_key_groups = defaultdict(list)
+        for ref in new_references:
+            key = shared.create_citation_key(ref)
+            new_ref_key_groups[key].append(ref)
+        
+        for key, new_refs_for_key in new_ref_key_groups.items():
+            idx = max_existing_index_by_key.get(key, 0)
+
+            # if no existing references ... 
+            if idx == 0:
+                for i, ref in enumerate(new_refs_for_key):
+                    # first ref always gets the "unappended" key
+                    # this is necessary to maintain consistency upon new uploads
+                    if i == 0:
+                        ref.citation_key = f"{key}"
+                    else:
+                        if key == "untitled":
+                            # untitled refs get numbered 1, 2, 3, etc.
+                            ref.citation_key = f"{key}{i}"
+                        else:
+                            # others get numbered a, b, c, etc.
+                            ref.citation_key = f"{key}{chr(97 + i)}"
+
+            # if existing references, append as necessary starting 
+            # from existing max index for the key
+            if idx > 0:
+                for i, ref in enumerate(new_refs_for_key):
+                    if key == "untitled":
+                        # untitleds start at 1
+                        ref.citation_key = f"{key}{idx + i}"
+                    else:
+                        # others start at a = chr(97)
+                        # so need to subtract 1 since idx >= 1
+                        ref.citation_key = f"{key}{chr(97 + idx - 1 + i)}"
+
+        return new_references
 
     def _create_references(self) -> None:
         """

--- a/python/tests/test_ingest.py
+++ b/python/tests/test_ingest.py
@@ -86,7 +86,7 @@ def test_run_ingest(monkeypatch, tmp_path, capsys):
         assert json.load(f) == output['references']
 
 
-def test_ingest_add_citation_keys(tmp_path):
+def test_ingest_add_citation_keys(monkeypatch, tmp_path):
     ingestion = ingest.PDFIngestion(input_dir=tmp_path)
 
     # set up base reference with required fields
@@ -114,7 +114,8 @@ def test_ingest_add_citation_keys(tmp_path):
     ]
 
 
-    # test - references with unique citation keys should not be modified
+    # test: references with different authors
+    # expect: should have unique citation keys
     refs = []
     for d in fake_data:
         reference = base_reference.copy()
@@ -128,7 +129,8 @@ def test_ingest_add_citation_keys(tmp_path):
         assert ref.citation_key == d["expected_citation_key"]
 
 
-    # test - references with no author and no published year
+    # test: references with no author and no published year
+    # expect: should have citation key "untitled" appeneded with a number
     refs = []
     for i in range(5):
         reference = base_reference.copy()
@@ -137,12 +139,15 @@ def test_ingest_add_citation_keys(tmp_path):
     
     tested = ingestion._add_citation_keys(refs)
 
-    ## should be untitled1, untitled2, untitled3, etc.
     for i, ref in enumerate(tested):
-        assert ref.citation_key == f"untitled{i + 1}"
+        if i == 0:
+            assert ref.citation_key == "untitled"
+        else:
+            assert ref.citation_key == f"untitled{i - 1 + 1}"
     
 
-    # test - references with no author but with published years
+    # test: references with no author but with published years
+    # expect: should have citation key "untitled" appeneded with the year
     refs = []
     for i in range(3):
         reference = base_reference.copy()
@@ -152,12 +157,12 @@ def test_ingest_add_citation_keys(tmp_path):
     
     tested = ingestion._add_citation_keys(refs)
 
-    ## should be untitled2020, untitled2021, untitled2022, etc.
     for i, ref in enumerate(tested):
         assert ref.citation_key == f"untitled{ref.published_date.year}"
 
 
-    # test - references with no author and duplicate published years
+    # test: references with no author and duplicate published years
+    # expect: should have citation key "untitled" appeneded with year and a letter
     refs = []
     for i in range(3):
         reference = base_reference.copy()
@@ -167,12 +172,15 @@ def test_ingest_add_citation_keys(tmp_path):
     
     tested = ingestion._add_citation_keys(refs)
 
-    ## should be untitled2020a, untitled2020b, untitled2021c, etc.
     for i, ref in enumerate(tested):
-        expected = f"untitled{ref.published_date.year}{chr(97 + i)}"
+        if i == 0:
+            expected = f"untitled{ref.published_date.year}"
+        else:
+            expected = f"untitled{ref.published_date.year}{chr(97 + i)}"
         assert ref.citation_key == expected
     
-    # test - references with same author and no published year
+    # test: references with same author last name and no published year
+    # expect: should have citation key of author's last name appended with a letter
     refs = []
     for i in range(3):
         reference = base_reference.copy()
@@ -181,11 +189,14 @@ def test_ingest_add_citation_keys(tmp_path):
 
     tested = ingestion._add_citation_keys(refs)
 
-    ## should be smitha, smithb, smithc
     for i, ref in enumerate(tested):
-        assert ref.citation_key == f"smith{chr(97 + i)}"
+        if i == 0:
+            assert ref.citation_key == f"smith"
+        else:
+            assert ref.citation_key == f"smith{chr(97 + i)}"
 
-    # test - references with same author and same published year
+    # test: references with same author and same published years
+    # expect: should have citation key of author's last name + year + letter
     refs = []
     for i in range(3):
         reference = base_reference.copy()
@@ -197,7 +208,55 @@ def test_ingest_add_citation_keys(tmp_path):
 
     ## should be smith2021a, smith2021b, smith2021c
     for i, ref in enumerate(tested):
-        assert ref.citation_key == f"smith2021{chr(97 + i)}"
+        if i == 0:
+            assert ref.citation_key == f"smith2021"
+        else:
+            assert ref.citation_key == f"smith2021{chr(97 + i)}"
+
+    # test: ingesting new references should not modify existing citation keys
+    # expect: previously created citation keys should be unchanged ...
+    #   ... but new references should have unique citation keys
+    existing_refs = [
+        Reference(
+            source_filename='test.pdf', status=typing.IngestStatus.PROCESSING,
+            authors=[Author(full_name="Kathy Jones")], published_date=date(2021, 1, 1),
+            citation_key='jones2021'
+        ),
+        Reference(
+            source_filename='test.pdf', status=typing.IngestStatus.PROCESSING,
+            authors=[Author(full_name="Kathy Jones")], published_date=date(2021, 1, 1),
+            citation_key='jones2021a'
+        ),
+        Reference(
+            source_filename='test.pdf', status=typing.IngestStatus.PROCESSING,
+            authors=[Author(full_name="John Smith")], citation_key='smith'
+        ),
+        Reference(
+            source_filename='test.pdf', status=typing.IngestStatus.PROCESSING,
+            citation_key='untitled'
+        ),
+        Reference(
+            source_filename='test.pdf', status=typing.IngestStatus.PROCESSING,
+            citation_key='untitled1'
+        ),
+    ]
+    new_refs = [
+        Reference(
+            source_filename='test.pdf', status=typing.IngestStatus.PROCESSING,
+            authors=[Author(full_name="Kathy Jones")], published_date=date(2021, 1, 1)
+        ),
+        Reference(
+            source_filename='test.pdf', status=typing.IngestStatus.PROCESSING,
+            authors=[Author(full_name="John Smith")],
+        ),
+        Reference(source_filename='test.pdf', status=typing.IngestStatus.PROCESSING),
+    ]
+    monkeypatch.setattr(ingestion, 'references', existing_refs)
+
+    tested = ingestion._add_citation_keys(new_refs)
+    new_keys = sorted([ref.citation_key for ref in tested])
+
+    assert new_keys == sorted(['jones2021b', 'smitha', 'untitled2'])
 
 
 def test_ingest_get_statuses(monkeypatch, capsys):

--- a/python/tests/test_ingest.py
+++ b/python/tests/test_ingest.py
@@ -191,7 +191,7 @@ def test_ingest_add_citation_keys(monkeypatch, tmp_path):
 
     for i, ref in enumerate(tested):
         if i == 0:
-            assert ref.citation_key == f"smith"
+            assert ref.citation_key == "smith"
         else:
             assert ref.citation_key == f"smith{chr(97 + i)}"
 
@@ -209,7 +209,7 @@ def test_ingest_add_citation_keys(monkeypatch, tmp_path):
     ## should be smith2021a, smith2021b, smith2021c
     for i, ref in enumerate(tested):
         if i == 0:
-            assert ref.citation_key == f"smith2021"
+            assert ref.citation_key == "smith2021"
         else:
             assert ref.citation_key == f"smith2021{chr(97 + i)}"
 


### PR DESCRIPTION
fixes #222 and related to #112 
________

In addition to fix the bug that resulted in citation keys for existing references being changed upon upload of new, conflicting key references, another change is that a citation key will _always_ begin in its "unappended" form (e.g. reda2023). This is required to maintain consistency in the event of a new upload that conflicts.

Example: Uploading two new references that would have a citation key of `reda2023`.
```
Prior to this PR - `reda2023a`, `reda2023b`
Upon merge - `reda2023`, `reda2023a`
```

