### PR TITLE
feat: use only relative paths in the app

### DIFF
--- a/src/atoms/__tests__/fileEntryActions.test.ts
+++ b/src/atoms/__tests__/fileEntryActions.test.ts
@@ -1,52 +1,51 @@
-import { exists } from '@tauri-apps/api/fs';
 import { createStore } from 'jotai';
 
-import { getBaseDir } from '../../io/filesystem';
+import { readAllProjectFiles } from '../../io/filesystem';
 import { act } from '../../test/test-utils';
 import { createFileAtom } from '../fileEntryActions';
+import { refreshFileTreeAtom } from '../fileExplorerActions';
 import { activePaneContentAtom } from '../paneActions';
 import { PaneId } from '../types/PaneGroup';
+import { makeFile } from './test-fixtures';
 import { runSetAtomHook } from './test-utils';
 
 vi.mock('../../io/filesystem');
-vi.mock('@tauri-apps/api/fs');
 
 describe('fileEntryActions', () => {
   let store: ReturnType<typeof createStore>;
 
   beforeEach(() => {
     store = createStore();
-    vi.mocked(getBaseDir).mockResolvedValue('/baseDir');
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should create a file and open it in the LEFT pane', async () => {
-    vi.mocked(exists).mockResolvedValueOnce(false);
+  it('should create a file and open it in the LEFT pane', () => {
     const createFile = runSetAtomHook(createFileAtom, store);
 
-    await act(() => createFile.current());
+    act(() => createFile.current());
 
     const paneContent = store.get(activePaneContentAtom);
     expect(paneContent.id).toBe<PaneId>('LEFT');
     expect(paneContent.activeEditor).toBeDefined();
-    expect(paneContent.activeEditor!.id).toMatchInlineSnapshot('"refstudio://text//baseDir/Untitled-1"');
+    expect(paneContent.activeEditor!.id).toMatchInlineSnapshot('"refstudio://text//Untitled-1"');
   });
 
   it('should create a file with the first available name', async () => {
-    vi.mocked(exists).mockImplementation((path) => Promise.resolve(path === '/baseDir/Untitled-1'));
     const createFile = runSetAtomHook(createFileAtom, store);
+    vi.mocked(readAllProjectFiles).mockResolvedValueOnce([makeFile('Untitled-1')]);
+    await store.set(refreshFileTreeAtom);
 
-    await act(async () => {
-      await createFile.current();
-      await createFile.current();
+    act(() => {
+      createFile.current();
+      createFile.current();
     });
 
     const paneContent = store.get(activePaneContentAtom);
     expect(paneContent.id).toBe<PaneId>('LEFT');
     expect(paneContent.activeEditor).toBeDefined();
-    expect(paneContent.activeEditor!.id).toMatchInlineSnapshot('"refstudio://text//baseDir/Untitled-3"');
+    expect(paneContent.activeEditor!.id).toMatchInlineSnapshot('"refstudio://text//Untitled-3"');
   });
 });

--- a/src/atoms/fileEntryActions.ts
+++ b/src/atoms/fileEntryActions.ts
@@ -1,9 +1,8 @@
-import { exists } from '@tauri-apps/api/fs';
 import { atom } from 'jotai';
 
-import { getBaseDir } from '../io/filesystem';
 import { editorsContentStateAtom, loadEditorContent, loadFileEntry } from './core/editorContent';
 import { addEditorData, editorsDataAtom, setEditorDataIsDirtyAtom } from './core/editorData';
+import { fileExplorerEntriesAtom } from './core/fileExplorerEntry';
 import { addEditorToPane, selectEditorInPaneAtom } from './core/paneGroup';
 import { targetPaneIdFor } from './editorActions';
 import { buildEditorId } from './types/EditorData';
@@ -47,11 +46,14 @@ export const openFilePathAtom = atom(null, (get, set, filePath: string) => {
   set(openFileEntryAtom, fileEntry);
 });
 
-/** Create a new file and open it in the LEFT pane */
-export const createFileAtom = atom(null, async (get, set) => {
+/** Create a new file in the root of the project directory and open it in the LEFT pane */
+export const createFileAtom = atom(null, (get, set) => {
+  const fileExplorerEntries = get(fileExplorerEntriesAtom);
+  const rootFileNames = get(fileExplorerEntries.childrenAtom).map(({ name }) => name);
   const openEditorNames = [...get(editorsDataAtom).values()].map(({ title }) => title);
-  const fileName = await generateFileName(openEditorNames);
-  const filePath = `${await getBaseDir()}/${fileName}`;
+
+  const fileName = generateFileName(new Set([...rootFileNames, ...openEditorNames]));
+  const filePath = `/${fileName}`;
   const editorId = buildEditorId('text', filePath);
 
   // Load editor in memory
@@ -69,15 +71,11 @@ export const createFileAtom = atom(null, async (get, set) => {
   set(selectEditorInPaneAtom, { editorId, paneId });
 });
 
-async function generateFileName(openEditorNames: string[]) {
+function generateFileName(existingFileNames: Set<string>) {
   const nameFromIndex = (index: number) => `Untitled-${index}`;
   let i = 1;
-  while (!(await isValidName(nameFromIndex(i), openEditorNames))) {
+  while (existingFileNames.has(nameFromIndex(i))) {
     i++;
   }
   return nameFromIndex(i);
-}
-
-async function isValidName(name: string, openEditorNames: string[]) {
-  return !openEditorNames.includes(name) && !(await exists(`${await getBaseDir()}/${name}`));
 }

--- a/src/io/filesystem.ts
+++ b/src/io/filesystem.ts
@@ -58,8 +58,6 @@ export async function ensureProjectFileStructure() {
     await ensureFile(baseDir, 'file 3.refstudio', FILE3_CONTENT);
 
     console.log('Project structure created with success. Folder: ', baseDir);
-
-    return baseDir;
   } catch (err) {
     console.error('ERROR', err);
     throw new Error('Error ensuring file struture');
@@ -74,13 +72,14 @@ async function ensureFile(baseDir: string, fileName: string, content: string) {
 }
 
 export async function readAllProjectFiles() {
-  const entries = await readDir(await getBaseDir(), { recursive: true });
-  const fileEntries = entries.map(convertTauriFileEntryToFileEntry);
-  return sortedFileEntries(fileEntries);
+  const baseDir = await getBaseDir();
+  const entries = await readDir(baseDir, { recursive: true });
+  return entries.map((entry) => convertTauriFileEntryToFileEntry(entry, baseDir));
 }
 
-export async function writeFileContent(path: string, textContent: string) {
+export async function writeFileContent(relativePath: string, textContent: string) {
   try {
+    const path = (await getBaseDir()) + relativePath;
     await writeTextFile(path, textContent);
     return true;
   } catch (err) {
@@ -101,73 +100,53 @@ export async function uploadFiles(files: File[]) {
 }
 
 export async function readFileContent(file: FileFileEntry): Promise<EditorContent> {
+  const path = (await getBaseDir()) + file.path;
   switch (file.fileExtension) {
     case 'xml': {
-      const textContent = await readTextFile(file.path);
+      const textContent = await readTextFile(path);
       return { type: 'xml', textContent };
     }
     case 'json': {
-      const textContent = await readTextFile(file.path);
+      const textContent = await readTextFile(path);
       return { type: 'json', textContent };
     }
     case 'pdf': {
-      const binaryContent = await readBinaryFile(file.path);
+      const binaryContent = await readBinaryFile(path);
       return { type: 'pdf', binaryContent };
     }
     default: {
-      const textContent = await readTextFile(file.path);
+      const textContent = await readTextFile(path);
       return { type: 'text', textContent };
     }
   }
 }
 
-function convertTauriFileEntryToFileEntry(entry: TauriFileEntry): FileEntry {
+function convertTauriFileEntryToFileEntry(entry: TauriFileEntry, baseDir: string): FileEntry {
   const isFolder = !!entry.children;
 
   const name = entry.name ?? '';
   const isDotfile = name.startsWith('.');
 
+  const relativePath = entry.path.replace(new RegExp(`^${baseDir}`), '');
+
   if (isFolder) {
     return {
       name,
-      path: entry.path,
+      path: relativePath,
       isFolder,
       isFile: !isFolder,
       isDotfile,
-      children: entry.children!.map(convertTauriFileEntryToFileEntry),
+      children: entry.children!.map((child) => convertTauriFileEntryToFileEntry(child, baseDir)),
     };
   } else {
     const fileExtension = name.split('.').pop()?.toLowerCase() ?? '';
     return {
       name,
-      path: entry.path,
+      path: relativePath,
       fileExtension,
       isFolder,
       isDotfile,
       isFile: !isFolder,
     };
   }
-}
-
-function sortedFileEntries(entries: FileEntry[]): FileEntry[] {
-  return entries
-    .sort((fileA, fileB) => {
-      if (fileA.isFile) {
-        return -1;
-      }
-      if (fileB.isFile) {
-        return 1;
-      }
-      return fileA.name.localeCompare(fileB.name);
-    })
-    .map((entry) => {
-      if (entry.isFile) {
-        return entry;
-      } else {
-        return {
-          ...entry,
-          children: sortedFileEntries(entry.children),
-        };
-      }
-    });
 }

--- a/src/io/filesystem.ts
+++ b/src/io/filesystem.ts
@@ -40,7 +40,7 @@ export async function getAppDataDir() {
   return appDataDir();
 }
 
-export async function getBaseDir() {
+async function getBaseDir() {
   return join(await appDataDir(), PROJECT_NAME);
 }
 export async function getUploadsDir() {

--- a/src/wrappers/EventsListener.tsx
+++ b/src/wrappers/EventsListener.tsx
@@ -32,7 +32,7 @@ function useSaveActiveFile() {
 function useCreateFile() {
   const createFile = useSetAtom(createFileAtom);
 
-  return () => void createFile();
+  return () => createFile();
 }
 
 function useCloseActiveEditor() {

--- a/src/wrappers/__tests__/EventsListener.newFile.test.tsx
+++ b/src/wrappers/__tests__/EventsListener.newFile.test.tsx
@@ -1,24 +1,19 @@
-import { exists } from '@tauri-apps/api/fs';
 import { createStore } from 'jotai';
 
 import { runGetAtomHook } from '../../atoms/__tests__/test-utils';
 import { activePaneContentAtom } from '../../atoms/paneActions';
 import { RefStudioEventName } from '../../events';
-import { getBaseDir } from '../../io/filesystem';
 import { act, mockListenEvent, setupWithJotaiProvider, waitFor } from '../../test/test-utils';
 import { EventsListener } from '../EventsListener';
 
 vi.mock('../../events');
 vi.mock('../../io/filesystem');
-vi.mock('@tauri-apps/api/fs');
 
 describe('EventsListener.close', () => {
   let store: ReturnType<typeof createStore>;
 
   beforeEach(() => {
     store = createStore();
-    vi.mocked(exists).mockResolvedValue(false);
-    vi.mocked(getBaseDir).mockResolvedValue('/root');
   });
 
   afterEach(() => {

--- a/src/wrappers/__tests__/EventsListener.newFile.test.tsx
+++ b/src/wrappers/__tests__/EventsListener.newFile.test.tsx
@@ -7,7 +7,6 @@ import { act, mockListenEvent, setupWithJotaiProvider, waitFor } from '../../tes
 import { EventsListener } from '../EventsListener';
 
 vi.mock('../../events');
-vi.mock('../../io/filesystem');
 
 describe('EventsListener.close', () => {
   let store: ReturnType<typeof createStore>;


### PR DESCRIPTION
We are currently using absolute paths everywhere, but should not be aware of this absolute path.
This also leads to issues, like being forced to make functions async only to get the base directory, like the atom to create a new file.
This PR fixes the issue by only using relative path: `filesystem` functions strip out the base directory from returned path, and add it back when trying to read or write files