### PR TITLE
fix: remove footer border

### DIFF
--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -114,7 +114,7 @@ function RightPanelWrapper() {
       <Panel collapsible order={3} ref={panelRef} onCollapse={setClosed}>
         <AIPanel onCloseClick={() => setClosed(true)} />
         {closed && (
-          <div className="absolute bottom-0 right-0 flex border border-slate-300 bg-slate-100 px-4 py-2">
+          <div className="absolute bottom-0 right-0 flex border border-b-0 border-slate-300 bg-slate-100 px-4 py-2">
             <div
               className="flex w-60 cursor-pointer select-none items-center justify-between"
               onClick={() => setClosed(false)}

--- a/src/components/PrimarySideBar.tsx
+++ b/src/components/PrimarySideBar.tsx
@@ -19,7 +19,7 @@ export function PrimarySideBar({
     { pane: 'References', Icon: VscLibrary },
   ];
   return (
-    <div className="flex select-none flex-col gap-1 bg-black text-white" role="menubar">
+    <div className="flex select-none flex-col gap-1 bg-slate-800 text-white" role="menubar">
       {panes.map(({ pane, Icon }) => (
         <Icon
           aria-label={pane}

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -2,7 +2,7 @@ import { ReferencesFooterItems } from '../../features/references/footer/Referenc
 
 export function Footer() {
   return (
-    <div className="flex items-center justify-end gap-2 border-t border-t-slate-100 bg-black px-2 text-white">
+    <div className="flex items-center justify-end gap-2 bg-black px-2 text-white">
       <ReferencesFooterItems />
     </div>
   );


### PR DESCRIPTION
This removes the top border of the footer and the bottom border of the collapsed AI panel

Before:
<img width="1512" alt="image" src="https://github.com/refstudio/refstudio/assets/58954208/c2da4048-cf01-4a75-8da7-eadffeeb936e">

After:
<img width="1512" alt="image" src="https://github.com/refstudio/refstudio/assets/58954208/aa2d34e8-c490-4fac-a83e-dfdc34d4dc36">
