### PR TITLE
fix: open pdf from references with filename

### DIFF
--- a/src/application/sidebar/ExplorerPanel.tsx
+++ b/src/application/sidebar/ExplorerPanel.tsx
@@ -13,7 +13,7 @@ import { PanelSection } from '../../components/PanelSection';
 import { PanelWrapper } from '../../components/PanelWrapper';
 import { useAsyncEffect } from '../../hooks/useAsyncEffect';
 import { isNonNullish } from '../../lib/isNonNullish';
-import { FileEntryTree } from './FileExplorer';
+import { FileExplorer } from './FileExplorer';
 
 export function ExplorerPanel() {
   const left = useAtomValue(leftPaneAtom);
@@ -75,7 +75,7 @@ export function ExplorerPanel() {
         )}
       </PanelSection>
       <PanelSection grow title="Project X">
-        <FileEntryTree
+        <FileExplorer
           fileExplorerEntry={rootFileExplorerEntry}
           paddingLeft="1.25rem"
           selectedFiles={[left.activeEditor?.id, right.activeEditor?.id]

--- a/src/application/sidebar/FileExplorer.tsx
+++ b/src/application/sidebar/FileExplorer.tsx
@@ -4,14 +4,14 @@ import { VscChevronDown, VscChevronRight, VscFile } from 'react-icons/vsc';
 import { FileExplorerFolderEntry } from '../../atoms/types/FileExplorerEntry';
 import { FileNode } from '../../components/FileNode';
 
-interface FileEntryTreeProps {
+interface FileExplorerProps {
   fileExplorerEntry: FileExplorerFolderEntry;
   onFileClick: (filePath: string) => void;
   selectedFiles: string[];
   paddingLeft?: string;
 }
 
-export function FileEntryTree(props: FileEntryTreeProps) {
+export function FileExplorer(props: FileExplorerProps) {
   const { fileExplorerEntry, onFileClick, selectedFiles, paddingLeft = '0' } = props;
   const files = useAtomValue(fileExplorerEntry.childrenAtom);
 
@@ -34,7 +34,7 @@ export function FileEntryTree(props: FileEntryTreeProps) {
         <>
           {files.map((fileEntry) =>
             fileEntry.isFolder ? (
-              <FileEntryTree
+              <FileExplorer
                 {...props}
                 fileExplorerEntry={fileEntry}
                 key={fileEntry.path}

--- a/src/application/sidebar/__tests__/FileExplorer.test.tsx
+++ b/src/application/sidebar/__tests__/FileExplorer.test.tsx
@@ -2,7 +2,7 @@ import { makeFileExplorerFileEntry, makeFileExplorerFolderEntry } from '../../..
 import { FileExplorerFileEntry, FileExplorerFolderEntry } from '../../../atoms/types/FileExplorerEntry';
 import { noop } from '../../../lib/noop';
 import { act, render, screen, setup } from '../../../test/test-utils';
-import { FileEntryTree } from '../FileExplorer';
+import { FileExplorer } from '../FileExplorer';
 
 describe('FileExplorer', () => {
   let fileEntry: FileExplorerFileEntry;
@@ -15,13 +15,13 @@ describe('FileExplorer', () => {
   });
 
   it('should render a file', () => {
-    render(<FileEntryTree fileExplorerEntry={folderEntry} selectedFiles={[]} onFileClick={noop} />);
+    render(<FileExplorer fileExplorerEntry={folderEntry} selectedFiles={[]} onFileClick={noop} />);
     expect(screen.getByText(fileEntry.name)).toBeInTheDocument();
   });
 
   it('should call onFileClick with file path', async () => {
     const onClick = vi.fn();
-    const { user } = setup(<FileEntryTree fileExplorerEntry={folderEntry} selectedFiles={[]} onFileClick={onClick} />);
+    const { user } = setup(<FileExplorer fileExplorerEntry={folderEntry} selectedFiles={[]} onFileClick={onClick} />);
 
     await user.click(screen.getByText(fileEntry.name));
 
@@ -33,7 +33,7 @@ describe('FileExplorer', () => {
     const file = makeFileExplorerFileEntry('File 1.pdf');
     const { folderEntry: folder } = makeFileExplorerFolderEntry('Folder', [file], false);
 
-    const { user } = setup(<FileEntryTree fileExplorerEntry={folder} selectedFiles={[]} onFileClick={noop} />);
+    const { user } = setup(<FileExplorer fileExplorerEntry={folder} selectedFiles={[]} onFileClick={noop} />);
     expect(screen.getByText(folder.name)).toBeInTheDocument();
 
     // Folder is collapsed by default

--- a/src/atoms/editorActions.ts
+++ b/src/atoms/editorActions.ts
@@ -1,8 +1,10 @@
 import { atom } from 'jotai';
 
+import { UPLOADS_DIR } from '../io/filesystem';
 import { editorsContentStateAtom, loadEditorContent, unloadEditorContent } from './core/editorContent';
 import { addEditorData, removeEditorData } from './core/editorData';
 import { addEditorToPane, paneGroupAtom, removeEditorFromPane, selectEditorInPaneAtom } from './core/paneGroup';
+import { openFilePathAtom } from './fileEntryActions';
 import { getDerivedReferenceAtom } from './referencesState';
 import { buildEditorId, EditorId } from './types/EditorData';
 import { FileFileEntry } from './types/FileEntry';
@@ -54,6 +56,18 @@ export const openReferencesAtom = atom(null, (_get, set, filter?: string) => {
 
   // Select editor in pane
   set(selectEditorInPaneAtom, { editorId, paneId });
+});
+
+/** Open the PDF file corresponding to the given reference */
+export const openReferencePdfAtom = atom(null, (get, set, referenceId: string) => {
+  const reference = get(getDerivedReferenceAtom(referenceId));
+
+  if (!reference) {
+    console.warn('Cannot open PDF file for a reference that does not exist: ', referenceId);
+    return;
+  }
+
+  set(openFilePathAtom, `/${UPLOADS_DIR}/${reference.filename}`);
 });
 
 /** Removes editor from the given pane and unload content from memory if the editor is not open in another pane */

--- a/src/atoms/fileEntryActions.ts
+++ b/src/atoms/fileEntryActions.ts
@@ -34,7 +34,7 @@ export const openFileEntryAtom = atom(null, (get, set, file: FileEntry) => {
   set(selectEditorInPaneAtom, { editorId, paneId: targetPaneId });
 });
 
-export const openFilePathAtom = atom(null, (get, set, filePath: string) => {
+export const openFilePathAtom = atom(null, (_get, set, filePath: string) => {
   const fileEntry: FileFileEntry = {
     path: filePath,
     name: filePath.split('/').pop() ?? '',

--- a/src/features/references/__tests__/test-fixtures.ts
+++ b/src/features/references/__tests__/test-fixtures.ts
@@ -1,9 +1,10 @@
+import { UPLOADS_DIR } from '../../../io/filesystem';
 import { ReferenceItem } from '../../../types/ReferenceItem';
 
 export const REFERENCES: ReferenceItem[] = [
   {
     id: 'a_few_useful_things_to_know_about_machine_learning',
-    filepath: '/path/to/A Few Useful Things to Know about Machine Learning.pdf',
+    filepath: `/${UPLOADS_DIR}/A Few Useful Things to Know about Machine Learning.pdf`,
     filename: 'A Few Useful Things to Know about Machine Learning.pdf',
     title: 'REF1 A Few Useful Things to Know about Machine Learning',
     citationKey: 'doe2023',
@@ -12,7 +13,7 @@ export const REFERENCES: ReferenceItem[] = [
   },
   {
     id: 'rules_of_machine_learning_-_best_practices_for_ml_engineering',
-    filepath: '/path/to/Rules of Machine Learning - Best Practices for ML Engineering.pdf',
+    filepath: `/${UPLOADS_DIR}/Rules of Machine Learning - Best Practices for ML Engineering.pdf`,
     filename: 'Rules of Machine Learning - Best Practices for ML Engineering.pdf',
     title: 'REF2 Rules of Machine Learning - Best Practices for ML Engineering',
     citationKey: 'maria',

--- a/src/features/references/sidebar/ReferencesPanel.tsx
+++ b/src/features/references/sidebar/ReferencesPanel.tsx
@@ -2,8 +2,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect, useState } from 'react';
 import { VscDesktopDownload, VscNewFile, VscOpenPreview } from 'react-icons/vsc';
 
-import { openReferenceAtom, openReferencesAtom } from '../../../atoms/editorActions';
-import { openFilePathAtom } from '../../../atoms/fileEntryActions';
+import { openReferenceAtom, openReferencePdfAtom, openReferencesAtom } from '../../../atoms/editorActions';
 import { getReferencesAtom } from '../../../atoms/referencesState';
 import { PanelSection } from '../../../components/PanelSection';
 import { PanelWrapper } from '../../../components/PanelWrapper';
@@ -17,7 +16,7 @@ export function ReferencesPanel() {
   const references = useAtomValue(getReferencesAtom);
   const openReference = useSetAtom(openReferenceAtom);
   const openReferences = useSetAtom(openReferencesAtom);
-  const openFilePath = useSetAtom(openFilePathAtom);
+  const openReferencePdf = useSetAtom(openReferencePdfAtom);
 
   const [visibleReferences, setVisibleReferences] = useState(references);
   useEffect(() => {
@@ -38,7 +37,7 @@ export function ReferencesPanel() {
 
   const handleRefClicked = (reference: ReferenceItem, openPdf?: boolean) => {
     if (openPdf) {
-      openFilePath(reference.filepath);
+      openReferencePdf(reference.id);
     } else {
       openReference(reference.id);
     }

--- a/src/io/filesystem.ts
+++ b/src/io/filesystem.ts
@@ -30,7 +30,7 @@ In the cycling world, power meters are the typical way to objectively measure pe
 `;
 
 const PROJECT_NAME = 'project-x';
-const UPLOADS_DIR = 'uploads';
+export const UPLOADS_DIR = 'uploads';
 
 export async function getConfigDir() {
   return appConfigDir();


### PR DESCRIPTION
Fixes #246 

This creates a new atom to open the PDF file corresponding to a reference. The atom checks that the reference exists and then call the `openFilePathAtom`, assuming that the PDF lives in the uploads directory