### PR TITLE
159-add-missing-table-row-buttons

### DIFF
--- a/src/features/references/editor/ReferencesTableView.tsx
+++ b/src/features/references/editor/ReferencesTableView.tsx
@@ -12,10 +12,19 @@ import {
   SelectionChangedEvent,
 } from '@ag-grid-community/core';
 import { AgGridReact } from '@ag-grid-community/react';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { VscDesktopDownload, VscKebabVertical, VscNewFile, VscTable, VscTrash } from 'react-icons/vsc';
+import {
+  VscDesktopDownload,
+  VscFile,
+  VscFilePdf,
+  VscKebabVertical,
+  VscNewFile,
+  VscTable,
+  VscTrash,
+} from 'react-icons/vsc';
 
+import { openReferenceAtom, openReferencePdfAtom } from '../../../atoms/editorActions';
 import { getReferencesAtom } from '../../../atoms/referencesState';
 import { emitEvent } from '../../../events';
 import { autoFocusAndSelect } from '../../../lib/autoFocusAndSelect';
@@ -84,7 +93,14 @@ export function ReferencesTableView({ defaultFilter = '' }: { defaultFilter?: st
         onCellValueChanged: handleTitleEdit,
       },
       { field: 'abstract', flex: 2, filter: true, sortable: true },
-      { field: 'publishedDate', filter: true, sortable: true, initialWidth: 140, initialFlex: undefined },
+      {
+        field: 'publishedDate',
+        headerName: 'Published',
+        filter: true,
+        sortable: true,
+        initialWidth: 140,
+        initialFlex: undefined,
+      },
       {
         field: 'authors',
         valueFormatter: authorsFormatter,
@@ -96,6 +112,15 @@ export function ReferencesTableView({ defaultFilter = '' }: { defaultFilter?: st
         sortable: true,
         filter: true,
         cellRenderer: memo(StatusCell),
+      },
+      {
+        field: 'id',
+        colId: 'actions',
+        headerName: '',
+        sortable: false,
+        filter: false,
+        width: 80,
+        cellRenderer: memo(ActionsCell),
       },
     ],
     [handleTitleEdit],
@@ -171,5 +196,30 @@ function StatusCell({ value }: ICellRendererParams<ReferenceItem, ReferenceItemS
     <span className="text-[10px]">
       <ReferencesItemStatusLabel status={value} />
     </span>
+  );
+}
+
+function ActionsCell({ data: reference }: ICellRendererParams<ReferenceItem, ReferenceItemStatus>) {
+  const openReference = useSetAtom(openReferenceAtom);
+  const openReferencePdf = useSetAtom(openReferencePdfAtom);
+
+  if (!reference) {
+    return null;
+  }
+  return (
+    <div className="flex h-full w-full items-center justify-center gap-2">
+      <VscFile
+        className="shrink-0 cursor-pointer"
+        size={20}
+        title="Open Reference Details"
+        onClick={() => openReference(reference.id)}
+      />
+      <VscFilePdf
+        className="shrink-0 cursor-pointer"
+        size={20}
+        title="Open Reference PDF"
+        onClick={() => openReferencePdf(reference.id)}
+      />
+    </div>
   );
 }

--- a/src/features/references/editor/__tests__/ReferencesTableView.test.tsx
+++ b/src/features/references/editor/__tests__/ReferencesTableView.test.tsx
@@ -117,6 +117,6 @@ describe('ReferencesTableView component', () => {
     const active = runGetAtomHook(activePaneContentAtom, store);
 
     expect(active.current.activeEditor?.id).toBeDefined();
-    expect(active.current.activeEditor?.id).toBe(buildEditorId('text', ref1.filepath));
+    expect(active.current.activeEditor?.id).toBe(buildEditorId('pdf', ref1.filepath));
   });
 });

--- a/src/features/references/editor/__tests__/ReferencesTableView.test.tsx
+++ b/src/features/references/editor/__tests__/ReferencesTableView.test.tsx
@@ -1,14 +1,31 @@
-import { runSetAtomHook } from '../../../../atoms/__tests__/test-utils';
+import { createStore } from 'jotai';
+
+import { runGetAtomHook, runSetAtomHook } from '../../../../atoms/__tests__/test-utils';
+import { activePaneContentAtom } from '../../../../atoms/paneActions';
 import { setReferencesAtom } from '../../../../atoms/referencesState';
+import { buildEditorId } from '../../../../atoms/types/EditorData';
 import { emitEvent } from '../../../../events';
-import { act, screen, setupWithJotaiProvider, waitFor, within } from '../../../../test/test-utils';
+import { getAppDataDir } from '../../../../io/filesystem';
+import { screen, setupWithJotaiProvider, waitFor, within } from '../../../../test/test-utils';
 import { REFERENCES } from '../../__tests__/test-fixtures';
 import { UploadTipInstructions } from '../../components/UploadTipInstructions';
 import { ReferencesTableView } from '../ReferencesTableView';
 
 vi.mock('../../../../events');
+vi.mock('../../../../io/filesystem');
+
+vi.mocked(getAppDataDir).mockResolvedValue('/');
 
 describe('ReferencesTableView component', () => {
+  let store: ReturnType<typeof createStore>;
+  const [ref1, ref2] = REFERENCES;
+
+  beforeEach(() => {
+    store = createStore();
+    const setReferences = runSetAtomHook(setReferencesAtom, store);
+    setReferences.current(REFERENCES);
+  });
+
   afterEach(() => {
     vi.resetAllMocks();
   });
@@ -19,38 +36,25 @@ describe('ReferencesTableView component', () => {
   });
 
   it('should render references', () => {
-    const { store } = setupWithJotaiProvider(<ReferencesTableView />);
-
-    const setReferences = runSetAtomHook(setReferencesAtom, store);
-
-    act(() => setReferences.current(REFERENCES));
-
+    setupWithJotaiProvider(<ReferencesTableView />, store);
     expect(screen.getByText(REFERENCES[0].title)).toBeInTheDocument();
     expect(screen.getByText(REFERENCES[1].title)).toBeInTheDocument();
   });
 
   it('should use default filter to filter references', () => {
-    const [ref1] = REFERENCES;
-    setupWithJotaiProvider(<ReferencesTableView defaultFilter={ref1.title} />);
+    setupWithJotaiProvider(<ReferencesTableView defaultFilter={ref1.title} />, store);
     expect(screen.getByPlaceholderText('Search within references...')).toHaveValue(ref1.title);
   });
 
   it('should filter references with default filter', () => {
-    const [ref1, ref2] = REFERENCES;
-    const { store } = setupWithJotaiProvider(<ReferencesTableView defaultFilter={ref1.title} />);
-    const setReferences = runSetAtomHook(setReferencesAtom, store);
-    act(() => setReferences.current(REFERENCES));
-
+    setupWithJotaiProvider(<ReferencesTableView defaultFilter={ref1.title} />, store);
     const grid = screen.getByRole('treegrid');
     expect(within(grid).getByText(ref1.title)).toBeInTheDocument();
     expect(within(grid).queryByText(ref2.title)).not.toBeInTheDocument();
   });
 
   it('should filter references with filter input', async () => {
-    const [ref1, ref2] = REFERENCES;
-    const { store, user } = setupWithJotaiProvider(<ReferencesTableView />);
-    const setReferences = runSetAtomHook(setReferencesAtom, store);
-    act(() => setReferences.current(REFERENCES));
+    const { user } = setupWithJotaiProvider(<ReferencesTableView />, store);
 
     await user.type(screen.getByPlaceholderText('Search within references...'), ref1.title);
 
@@ -60,11 +64,7 @@ describe('ReferencesTableView component', () => {
   });
 
   it('should select references in grid with SPACE', async () => {
-    const [ref1, ref2] = REFERENCES;
-    const { store, user } = setupWithJotaiProvider(<ReferencesTableView />);
-
-    const setReferences = runSetAtomHook(setReferencesAtom, store);
-    act(() => setReferences.current(REFERENCES));
+    const { user } = setupWithJotaiProvider(<ReferencesTableView />, store);
 
     expect(screen.queryByText('(2)')).not.toBeInTheDocument();
 
@@ -74,31 +74,49 @@ describe('ReferencesTableView component', () => {
     expect(screen.getByText('(2)')).toBeInTheDocument();
   });
 
-  it('should render 7 columns', () => {
-    const { store } = setupWithJotaiProvider(<ReferencesTableView />);
-    const setReferences = runSetAtomHook(setReferencesAtom, store);
-    act(() => setReferences.current(REFERENCES));
-
-    expect(screen.getAllByRole('columnheader')).toHaveLength(7);
+  it('should render 8 columns', () => {
+    setupWithJotaiProvider(<ReferencesTableView />, store);
+    expect(screen.getAllByRole('columnheader')).toHaveLength(8);
   });
 
   it('should render title column in 3rd position', () => {
-    const { store } = setupWithJotaiProvider(<ReferencesTableView />);
-    const setReferences = runSetAtomHook(setReferencesAtom, store);
-    act(() => setReferences.current(REFERENCES));
+    setupWithJotaiProvider(<ReferencesTableView />, store);
 
-    const elemDrag = screen.getByRole('columnheader', { name: 'Title' });
-    expect(elemDrag).toBeInTheDocument();
-    expect(elemDrag).toHaveAttribute('aria-colindex', '3');
+    const headerTitle = screen.getByRole('columnheader', { name: 'Title' });
+    expect(headerTitle).toBeInTheDocument();
+    expect(headerTitle).toHaveAttribute('aria-colindex', '3');
   });
 
   it('should emit [refstudio://menu/references/upload] on Add click', async () => {
-    const { user, store } = setupWithJotaiProvider(<ReferencesTableView />);
-    const setReferences = runSetAtomHook(setReferencesAtom, store);
-    act(() => setReferences.current(REFERENCES));
+    const { user } = setupWithJotaiProvider(<ReferencesTableView />, store);
 
     await user.click(screen.getByText('Add'));
-
     expect(vi.mocked(emitEvent)).toHaveBeenCalledWith('refstudio://menu/references/upload');
+  });
+
+  it('should open reference details on click in icon Open Reference Details', async () => {
+    const { user } = setupWithJotaiProvider(<ReferencesTableView />, store);
+
+    const buttons = screen.getAllByText('Open Reference Details');
+    expect(buttons).toHaveLength(REFERENCES.length);
+    await user.click(buttons[0]);
+
+    const active = runGetAtomHook(activePaneContentAtom, store);
+
+    expect(active.current.activeEditor?.id).toBeDefined();
+    expect(active.current.activeEditor?.id).toBe(buildEditorId('reference', ref1.id));
+  });
+
+  it('should open reference PDF details on click in icon Open Reference PDF', async () => {
+    const { user } = setupWithJotaiProvider(<ReferencesTableView />, store);
+
+    const buttons = screen.getAllByText('Open Reference PDF');
+    expect(buttons).toHaveLength(REFERENCES.length);
+    await user.click(buttons[0]);
+
+    const active = runGetAtomHook(activePaneContentAtom, store);
+
+    expect(active.current.activeEditor?.id).toBeDefined();
+    expect(active.current.activeEditor?.id).toBe(buildEditorId('text', ref1.filepath));
   });
 });


### PR DESCRIPTION
This PR adds two new buttons for each references row to open reference details and reference PDF

Related to https://github.com/refstudio/refstudio/issues/159 and https://github.com/refstudio/refstudio/issues/201