### PR TITLE
chore: add knip to pre-push hooks

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,6 +2,8 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn check
+yarn knip
 yarn test
+
 
 yarn codegen

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,5 +5,4 @@ yarn check
 yarn knip
 yarn test
 
-
 yarn codegen


### PR DESCRIPTION
This adds `yarn knip` to our pre-push hooks
I made `yarn knip` run before `yarn test` because it runs faster so the pre-push hooks will fail faster in case knip fails

Closes #258 