### PR TITLE
chore: remove duplicated knip check

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,7 +2,6 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn check
-yarn knip
 yarn test
 
 yarn codegen


### PR DESCRIPTION
Now we have added knip to `yarn check` (#268), the pre-push hooks run the script twice, as it runs `yarn check` then `yarn knip`
This simply removes `yarn knip` from the pre-push hooks