### PR TITLE
Add Rewrite parameters for n_choices and temperature

### DIFF
--- a/python/cli.schema.json
+++ b/python/cli.schema.json
@@ -296,6 +296,14 @@
       "properties": {
         "text": {
           "type": "string"
+        },
+        "n_choices": {
+          "default": 1,
+          "type": "integer"
+        },
+        "temperature": {
+          "default": 0.7,
+          "type": "number"
         }
       },
       "required": [

--- a/python/sidecar/rewrite.py
+++ b/python/sidecar/rewrite.py
@@ -4,7 +4,6 @@ import sys
 
 import openai
 from dotenv import load_dotenv
-
 from sidecar import prompts
 from sidecar.typing import RewriteChoice, RewriteRequest
 
@@ -14,17 +13,17 @@ openai.api_key = os.environ.get("OPENAI_API_KEY")
 
 def summarize(arg: RewriteRequest) -> str:
     text = arg.text
-    n_options = 1
+    n_choices = arg.n_choices
     prompt = prompts.create_prompt_for_summarize(text)
-    chat = Rewriter(prompt, n_options)
+    chat = Rewriter(prompt, n_choices)
     response = chat.get_response()
     sys.stdout.write(json.dumps([r.dict() for r in response]))
 
 
 class Rewriter:
-    def __init__(self, text: str, n_options: int = 1):
+    def __init__(self, text: str, n_choices: int = 1):
         self.text = text
-        self.n_options = int(n_options)
+        self.n_choices = int(n_choices)
 
     def get_response(self):
         messages = self.prepare_messages_for_chat(self.text)
@@ -42,9 +41,9 @@ class Rewriter:
         response = openai.ChatCompletion.create(
             model=os.environ["OPENAI_CHAT_MODEL"],
             messages=messages,
-            n=self.n_options,  # number of completions to generate
-            temperature=0,  # 0 = no randomness, deterministic
-            max_tokens=200,
+            n=self.n_choices,  # number of completions to generate
+            temperature=0.7,
+            # max_tokens=200,
         )
         return response
 

--- a/python/sidecar/rewrite.py
+++ b/python/sidecar/rewrite.py
@@ -14,16 +14,19 @@ openai.api_key = os.environ.get("OPENAI_API_KEY")
 def summarize(arg: RewriteRequest) -> str:
     text = arg.text
     n_choices = arg.n_choices
+    temperature = arg.temperature
+
     prompt = prompts.create_prompt_for_summarize(text)
-    chat = Rewriter(prompt, n_choices)
+    chat = Rewriter(prompt, n_choices, temperature)
     response = chat.get_response()
     sys.stdout.write(json.dumps([r.dict() for r in response]))
 
 
 class Rewriter:
-    def __init__(self, text: str, n_choices: int = 1):
+    def __init__(self, text: str, n_choices: int = 1, temperature: float = 0.7):
         self.text = text
         self.n_choices = int(n_choices)
+        self.temperature = temperature
 
     def get_response(self):
         messages = self.prepare_messages_for_chat(self.text)
@@ -42,8 +45,7 @@ class Rewriter:
             model=os.environ["OPENAI_CHAT_MODEL"],
             messages=messages,
             n=self.n_choices,  # number of completions to generate
-            temperature=0.7,
-            # max_tokens=200,
+            temperature=self.temperature,  # 0 = no randomness, deterministic
         )
         return response
 

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -108,6 +108,7 @@ class DeleteStatusResponse(RefStudioModel):
 class RewriteRequest(RefStudioModel):
     text: str
     n_choices: int = 1
+    temperature: float = 0.7
 
 
 class RewriteChoice(RefStudioModel):

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -107,6 +107,7 @@ class DeleteStatusResponse(RefStudioModel):
 
 class RewriteRequest(RefStudioModel):
     text: str
+    n_choices: int = 1
 
 
 class RewriteChoice(RefStudioModel):

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -94,6 +94,8 @@ export interface ReferenceStatus {
 }
 export interface RewriteRequest {
   text: string;
+  n_choices?: number;
+  temperature?: number;
 }
 export interface RewriteChoice {
   index: number;


### PR DESCRIPTION
Improves on #66 and #60

The current implementation for `rewrite` does not allow the client to request multiple choices to be returned. It also uses a temperature of 0. These two things combined mean:
1. Only one `rewrite` option is ever returned and ...
2. Even if we allow for more than one option, all `N` options will be the same because `temperature` is 0 (deterministic).

This fixes both of those things. I opted for a default temperature of 0.7 based on some playing around, google-fu, and [this post](https://community.openai.com/t/cheat-sheet-mastering-temperature-and-top-p-in-chatgpt-api-a-few-tips-and-tricks-on-controlling-the-creativity-deterministic-output-of-prompt-responses/172683/17). I found that increasing temperature up to 0.9 also led to some interesting but not too crazy results.

I don't expect the client to be messing with the `temperature` parameter much, but did want to allow for that option.
______________

```bash
poetry run python main.py rewrite "{\"text\": \"ML engineering, as a discipline, is highly experimental and itera- tive in nature, especially compared to typical software engineering. Contrary to popular negative sentiment around the large numbers of experiments and models that don’t make it to production, we found that it’s actually okay for experiments and models not to make it to production.\", \"n_choices\": 3, \"temperature\": 0.9}" | jq
[
  {
    "index": 0,
    "text": "ML engineering is experimental and iterative, unlike traditional software engineering. Despite the negative perception of many failed experiments and models not being deployed, it is acceptable for them to not reach production."
  },
  {
    "index": 1,
    "text": "ML engineering is experimental and iterative, unlike traditional software engineering. Despite negativity about experiments and models not making it to production, it is acceptable for them to fail."
  },
  {
    "index": 2,
    "text": "ML engineering is experimental and iterative, differing from typical software engineering. Despite the common perception that many experiments and models don't reach production, it is actually acceptable for them not to."
  }
]
```