### PR TITLE
278 fix reference ingestion

### DIFF
--- a/src/api/__tests__/ingestion.test.ts
+++ b/src/api/__tests__/ingestion.test.ts
@@ -20,7 +20,7 @@ describe('runPDFIngestion', () => {
     await runPDFIngestion();
     expect(vi.mocked(callSidecar).mock.calls).toHaveLength(1);
     const uploadsDir = await getSystemPath(getUploadsDir());
-    expect(vi.mocked(callSidecar).mock.calls[0]).toStrictEqual(['ingest', ['--pdf_directory', uploadsDir]]);
+    expect(vi.mocked(callSidecar).mock.calls[0]).toStrictEqual(['ingest', { pdf_directory: uploadsDir }]);
   });
 
   it('should call sidecar ingest_references with upload dir arg', async () => {
@@ -32,7 +32,7 @@ describe('runPDFIngestion', () => {
     const result = await getIngestedReferences();
     expect(vi.mocked(callSidecar).mock.calls).toHaveLength(1);
     const uploadsDir = await getSystemPath(getUploadsDir());
-    expect(vi.mocked(callSidecar).mock.calls[0]).toStrictEqual(['ingest_references', ['--pdf_directory', uploadsDir]]);
+    expect(vi.mocked(callSidecar).mock.calls[0]).toStrictEqual(['ingest_references', { pdf_directory: uploadsDir }]);
     expect(result).toStrictEqual([]);
   });
 

--- a/src/api/ingestion.ts
+++ b/src/api/ingestion.ts
@@ -22,7 +22,7 @@ function parsePdfIngestionResponse(response: IngestResponse): ReferenceItem[] {
 
 export async function runPDFIngestion(): Promise<ReferenceItem[]> {
   const uploadsDir = await getSystemPath(getUploadsDir());
-  const response = await callSidecar('ingest', ['--pdf_directory', String(uploadsDir)]);
+  const response = await callSidecar('ingest', { pdf_directory: String(uploadsDir) });
   return parsePdfIngestionResponse(response);
 }
 
@@ -35,7 +35,7 @@ export async function removeReferences(fileNames: string[]) {
 
 export async function getIngestedReferences(): Promise<ReferenceItem[]> {
   const uploadsDir = await getSystemPath(getUploadsDir());
-  const response = await callSidecar('ingest_references', ['--pdf_directory', String(uploadsDir)]);
+  const response = await callSidecar('ingest_references', { pdf_directory: String(uploadsDir) });
   return parsePdfIngestionResponse(response);
 }
 

--- a/src/api/sidecar.ts
+++ b/src/api/sidecar.ts
@@ -5,11 +5,10 @@ import { Command } from '@tauri-apps/api/shell';
 import { getCachedSetting } from '../settings/settingsManager';
 import { CliCommands } from './types';
 
-export async function callSidecar<
-  T extends keyof CliCommands,
-  CliCommandRequest = CliCommands[T][0],
-  CliCommandResponse = CliCommands[T][1],
->(subcommand: T, arg: CliCommandRequest): Promise<CliCommandResponse> {
+export async function callSidecar<T extends keyof CliCommands>(
+  subcommand: T,
+  arg: CliCommands[T][0],
+): Promise<CliCommands[T][1]> {
   const generalSettings = getCachedSetting('general');
   const openAISettings = getCachedSetting('openAI');
   const sidecarSettings = getCachedSetting('sidecar');
@@ -36,7 +35,7 @@ export async function callSidecar<
   }
   console.log('sidecar output: ', output.stdout);
 
-  const response = JSON.parse(output.stdout) as CliCommandResponse;
+  const response = JSON.parse(output.stdout) as CliCommands[T][1];
   console.log('sidecar response', response);
   return response;
 }


### PR DESCRIPTION
Fixes #278 

The code to run ingestion had not been updated with the new arguments format for the sidecar, making the command fail.
his was not caught by TypeScript because `callSidecar` was generic on `CliCommandRequest` and `CliCommandResponse`, making it possible to call it with anything.

This updates `sidecar.ts` to pass arguments with the expected format. And this also updates `callSidecar` to remove the generic types, to ensure the types of the arguments when using it.

If we want to keep the `CliCommandRequest` and `CliCommandResponse` types,  we could also write
```typescript
callSidecar<
  T extends keyof CliCommands,
  CliCommandRequest extends CliCommands[T][0] = CliCommands[T][0],
  CliCommandResponse extends CliCommands[T][1] = CliCommands[T][1],
>(subcommand: T, arg: CliCommandRequest): Promise<CliCommandResponse> {
```
However, `CliCommandRequest` is only used once and `CliCommandResponse` twice in the function, so I think it's fine to use `CliCommands[T][0/1]` directly