### PR TITLE
feat: Command Palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "fuse.js": "^6.6.2",
     "highlight.js": "^11.8.0",
     "jotai": "^2.1.0",
+    "kmenu": "^1.4.11-beta",
     "lowlight": "^2.9.0",
     "postcss": "^8.4.23",
     "react": "^18.2.0",

--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -1,5 +1,6 @@
 import 'react-contexify/dist/ReactContexify.css';
 
+import { MenuProvider } from 'kmenu';
 import React, { useCallback, useEffect, useState } from 'react';
 import { VscChevronUp } from 'react-icons/vsc';
 import { ImperativePanelHandle, Panel, PanelGroup } from 'react-resizable-panels';
@@ -19,6 +20,7 @@ import { PdfViewerAPI } from '../types/PdfViewerAPI';
 import { ApplicationFrame } from '../wrappers/ApplicationFrame';
 import { ContextMenus } from '../wrappers/ContextMenus';
 import { EventsListener } from '../wrappers/EventsListener';
+import { CommandPalette } from './CommandPalette';
 import { MainPanel } from './components/MainPanel';
 import { ExplorerPanel } from './sidebar/ExplorerPanel';
 
@@ -42,18 +44,21 @@ function App() {
       <ReferencesDropZone>
         <ApplicationFrame>
           <ContextMenus>
-            <PanelGroup
-              autoSaveId="refstudio"
-              className="relative h-full"
-              direction="horizontal"
-              onLayout={updatePDFViewerWidth}
-            >
-              <LeftSidePanelWrapper />
-              <Panel defaultSize={60} order={2}>
-                <MainPanel pdfViewerRef={pdfViewerRef} />
-              </Panel>
-              <RightPanelWrapper />
-            </PanelGroup>
+            <MenuProvider config={{ animationDuration: 0 }}>
+              <CommandPalette />
+              <PanelGroup
+                autoSaveId="refstudio"
+                className="relative h-full"
+                direction="horizontal"
+                onLayout={updatePDFViewerWidth}
+              >
+                <LeftSidePanelWrapper />
+                <Panel defaultSize={60} order={2}>
+                  <MainPanel pdfViewerRef={pdfViewerRef} />
+                </Panel>
+                <RightPanelWrapper />
+              </PanelGroup>
+            </MenuProvider>
           </ContextMenus>
         </ApplicationFrame>
         <SettingsModalOpener />

--- a/src/application/CommandPalette.css
+++ b/src/application/CommandPalette.css
@@ -1,0 +1,136 @@
+/*
+ NOTE: Styles adapted from https://github.com/harshhhdev/kmenu/blob/master/src/styles/index.css
+       We've had to create a rule prefix (.command-palette) to wrap all the style definitions for isolation
+ */
+.command-palette .backdrop {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: hidden;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 50;
+  width: 100vw;
+  height: 100vh;
+  user-select: none;
+}
+
+.command-palette .dialog {
+  padding: 0.5rem;
+  width: 640px;
+  transition: 0.1s ease 0s;
+  will-change: height;
+  position: fixed;
+  border-style: solid;
+  background-color: red;
+  top: 20%;
+}
+
+.command-palette .crumbs {
+  display: flex;
+  margin: 5px 0px 0px 5px;
+}
+
+.command-palette .breadcrumb {
+  border: none;
+  outline: none;
+  padding: 5px 10px;
+  margin-right: 7px;
+  cursor: pointer;
+}
+
+.command-palette .searchbar {
+  border: none;
+  padding: 20px 10px;
+  margin: 0 0 8px;
+  background-color: transparent;
+  font-size: 18px;
+  width: 100%;
+  outline: 0;
+  font-family: inherit;
+}
+
+.command-palette .command_wrapper {
+  display: flex;
+  overflow-y: auto;
+  overflow-x: hidden;
+  flex-direction: column;
+  width: 100%;
+  transition: height 0.1s ease 0s;
+  will-change: height;
+}
+
+.command-palette .command {
+  display: flex;
+  justify-content: space-between;
+  position: relative;
+  height: 54px;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  align-items: center;
+  text-decoration: none;
+  cursor: pointer;
+  transition: 0.1s linear;
+}
+
+.command-palette .shortcuts > kbd {
+  padding: 3px 6px;
+  border-radius: 3px;
+  font-size: 14px;
+  margin-right: 7px;
+  font-family: monospace;
+}
+
+.command-palette .shortcuts {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+}
+
+.command-palette .info_wrapper {
+  display: flex;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  margin-left: 20px;
+}
+
+.command-palette .info_wrapper > svg {
+  width: 20px;
+  height: 20px;
+  margin-right: 12px;
+}
+
+.command-palette .category_header {
+  margin: 5px 0 10px 10px;
+  font-size: 14px;
+}
+
+.command-palette .selected {
+  position: absolute;
+  width: 100%;
+  height: 54px;
+  border-radius: 0.5rem;
+}
+
+.command-palette .command_text {
+  max-width: 90%;
+  width: fit-content;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+}
+
+.command-palette .scroll_ref {
+  margin-top: 20px;
+}
+
+@media only screen and (max-width: 700px) {
+  .command-palette .dialog {
+    width: 90%;
+  }
+}

--- a/src/application/CommandPalette.tsx
+++ b/src/application/CommandPalette.tsx
@@ -1,0 +1,100 @@
+import './CommandPalette.css';
+
+import { useAtomValue, useSetAtom } from 'jotai';
+import { Command, CommandMenu, CommandWrapper, useCommands, useKmenu } from 'kmenu';
+import { CategoryCommand } from 'kmenu/dist/types';
+import { VscBell, VscClose, VscGear, VscLibrary, VscNewFile, VscSearch } from 'react-icons/vsc';
+
+import { openReferenceAtom } from '../atoms/editorActions';
+import { getReferencesAtom } from '../atoms/referencesState';
+import { emitEvent } from '../events';
+
+export function CommandPalette() {
+  const { setOpen } = useKmenu();
+
+  const main: Command[] = [
+    {
+      category: 'Actions',
+      commands: [
+        {
+          icon: <VscNewFile />,
+          text: 'New File',
+          perform: () => emitEvent('refstudio://menu/file/new'),
+        },
+        {
+          icon: <VscClose />,
+          text: 'Close Active Editor',
+          perform: () => emitEvent('refstudio://menu/file/close'),
+        },
+      ],
+      // Commands that aren't visible to the user (only after search)
+      subCommands: [
+        {
+          icon: <VscBell />,
+          text: 'Toggle Notifications Popup',
+          perform: () => emitEvent('refstudio://menu/view/notifications'),
+        },
+        {
+          icon: <VscGear />,
+          text: 'Open Settings',
+          perform: () => emitEvent('refstudio://menu/settings'),
+        },
+      ],
+    },
+    {
+      category: 'References',
+      commands: [
+        {
+          icon: <VscSearch />,
+          text: 'Find Reference...',
+          perform: () => setOpen(2),
+        },
+        {
+          icon: <VscLibrary />,
+          text: 'Open References',
+          perform: () => emitEvent('refstudio://menu/references/open'),
+        },
+        {
+          icon: <VscNewFile />,
+          text: 'Upload References',
+          perform: () => emitEvent('refstudio://menu/references/upload'),
+        },
+      ],
+    },
+  ];
+
+  const [mainCommands] = useCommands(main);
+
+  return (
+    <div className="command-palette">
+      <CommandWrapper>
+        <CommandMenu commands={mainCommands} crumbs={[]} index={1} placeholder="Search commands" />
+        <ReferencesCommandMenu index={2} />
+      </CommandWrapper>
+    </div>
+  );
+}
+
+function ReferencesCommandMenu({ index }: { index: number }) {
+  const references = useAtomValue(getReferencesAtom);
+  const openReference = useSetAtom(openReferenceAtom);
+
+  const commands: Command[] = [
+    {
+      category: 'References',
+      commands: references.map(
+        (reference) =>
+          ({
+            text: reference.title,
+            perform: () => openReference(reference.id),
+          } as CategoryCommand),
+      ),
+    },
+  ];
+
+  const [referencesCommands] = useCommands(commands);
+
+  return (
+    <CommandMenu commands={referencesCommands} crumbs={['References']} index={index} placeholder="Search references" />
+  );
+}

--- a/src/notifications/footer/NotificationsPopup.tsx
+++ b/src/notifications/footer/NotificationsPopup.tsx
@@ -105,10 +105,10 @@ function NotificationItemWidget({ item, expanded }: { item: ReadonlyNotification
 function NotificationIcon({ type }: { type: NotificationItemType }) {
   switch (type) {
     case 'info':
-      return <VscInfo className="text-blue-400" size={20} />;
+      return <VscInfo className="shrink-0 text-blue-400" size={20} />;
     case 'warning':
-      return <VscWarning className="text-orange-400" size={20} />;
+      return <VscWarning className="shrink-0 text-orange-400" size={20} />;
     case 'error':
-      return <VscError className="text-red-400" size={20} />;
+      return <VscError className="shrink-0 text-red-400" size={20} />;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,6 +396,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/is-prop-valid@npm:^0.8.2":
+  version: 0.8.8
+  resolution: "@emotion/is-prop-valid@npm:0.8.8"
+  dependencies:
+    "@emotion/memoize": 0.7.4
+  checksum: bb7ec6d48c572c540e24e47cc94fc2f8dec2d6a342ae97bc9c8b6388d9b8d283862672172a1bb62d335c02662afe6291e10c71e9b8642664a8b43416cdceffac
+  languageName: node
+  linkType: hard
+
+"@emotion/memoize@npm:0.7.4":
+  version: 0.7.4
+  resolution: "@emotion/memoize@npm:0.7.4"
+  checksum: 4e3920d4ec95995657a37beb43d3f4b7d89fed6caa2b173a4c04d10482d089d5c3ea50bbc96618d918b020f26ed6e9c4026bbd45433566576c1f7b056c3271dc
+  languageName: node
+  linkType: hard
+
 "@es-joy/jsdoccomment@npm:~0.39.4":
   version: 0.39.4
   resolution: "@es-joy/jsdoccomment@npm:0.39.4"
@@ -3859,6 +3875,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"framer-motion@npm:^9.0.1":
+  version: 9.1.7
+  resolution: "framer-motion@npm:9.1.7"
+  dependencies:
+    "@emotion/is-prop-valid": ^0.8.2
+    tslib: ^2.4.0
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  dependenciesMeta:
+    "@emotion/is-prop-valid":
+      optional: true
+  checksum: 8ab21a2c15eb2494644b09c91c91aec3c01575e2148ff17621df4fca44bc64a8c03bc1cf6a5261ec0cebb7504fea8d75480e93b1799e8842337f8b1863af8c14
+  languageName: node
+  linkType: hard
+
 "fs-minipass@npm:^2.0.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
@@ -4979,6 +5011,18 @@ __metadata:
     array-includes: ^3.1.5
     object.assign: ^4.1.3
   checksum: a2ed78cac49a0f0c4be8b1eafe3c5257a1411341d8e7f1ac740debae003de04e5f6372bfcfbd9d082e954ffd99aac85bcda85b7c6bc11609992483f4cdc0f745
+  languageName: node
+  linkType: hard
+
+"kmenu@npm:^1.4.11-beta":
+  version: 1.4.11-beta
+  resolution: "kmenu@npm:1.4.11-beta"
+  dependencies:
+    framer-motion: ^9.0.1
+    react-scrollbar-size: ^5.0.0
+  peerDependencies:
+    react: ^18.2.0
+  checksum: 76e4c495bcbf146d1dee960ade55320bfd6205eb24d3bb45113d0308d6b557e7af9e4149e31475a10d6f0f4284421924524403fb2f92387b537fbe467429ed82
   languageName: node
   linkType: hard
 
@@ -6512,6 +6556,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-scrollbar-size@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "react-scrollbar-size@npm:5.0.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.1 || ^18.0.0
+  checksum: 7c44cb16fc507b59429641c09741cbbbc7a42da1f687d8c5590c151706e8aa8cd905973e69b5a7e94b90557190c5adc0f7151ce55073009c8a4cd2f5244d5f53
+  languageName: node
+  linkType: hard
+
 "react@npm:^18.2.0":
   version: 18.2.0
   resolution: "react@npm:18.2.0"
@@ -6626,6 +6679,7 @@ __metadata:
     jotai: ^2.1.0
     jsdom: ^22.1.0
     json-schema-to-typescript: ^13.0.1
+    kmenu: ^1.4.11-beta
     knip: ^2.14.3
     lowlight: ^2.9.0
     postcss: ^8.4.23
@@ -7540,6 +7594,13 @@ __metadata:
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.4.0":
+  version: 2.6.0
+  resolution: "tslib@npm:2.6.0"
+  checksum: c01066038f950016a18106ddeca4649b4d76caa76ec5a31e2a26e10586a59fceb4ee45e96719bf6c715648e7c14085a81fee5c62f7e9ebee68e77a5396e5538f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR selects [kmenu](https://github.com/harshhhdev/kmenu) as command palette library for the `CMD+K` shortcut action.

This library was the simpler to use (api ergonomics) and was also very easy so setup and style.

| Main view | After selecting "Find Reference..." |
|--------|--------|
| ![image](https://github.com/refstudio/refstudio/assets/174127/1c708139-f079-47b0-b174-b21262559906) | ![image](https://github.com/refstudio/refstudio/assets/174127/6a6c9eee-b192-4bda-aa7f-f39cb2478d06) | 

