### PR TITLE
fix: remove pdf viewer

### DIFF
--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -11,11 +11,11 @@ import { emitEvent } from '../events';
 import { AIPanel } from '../features/ai/AIPanel';
 import { ReferencesDropZone } from '../features/references/components/ReferencesDropZone';
 import { ReferencesPanel } from '../features/references/sidebar/ReferencesPanel';
+import { useDebouncedCallback } from '../hooks/useDebouncedCallback';
 import { ensureProjectFileStructure } from '../io/filesystem';
 import { notifyInfo } from '../notifications/notifications';
 import { interceptConsoleMessages } from '../notifications/notifications.console';
 import { SettingsModalOpener } from '../settings/SettingsModalOpener';
-import { PdfViewerAPI } from '../types/PdfViewerAPI';
 import { ApplicationFrame } from '../wrappers/ApplicationFrame';
 import { ContextMenus } from '../wrappers/ContextMenus';
 import { EventsListener } from '../wrappers/EventsListener';
@@ -32,10 +32,18 @@ function App() {
     emitEvent('refstudio://references/load');
   });
 
-  const pdfViewerRef = React.useRef<PdfViewerAPI>(null);
-  const updatePDFViewerWidth = useCallback(() => {
-    pdfViewerRef.current?.updateWidth();
-  }, [pdfViewerRef]);
+  const handleLayoutUpdate = useDebouncedCallback(
+    useCallback(() => emitEvent('refstudio://layout/update'), []),
+    200,
+  );
+
+  useEffect(() => {
+    window.addEventListener('resize', handleLayoutUpdate);
+
+    return () => {
+      window.removeEventListener('resize', handleLayoutUpdate);
+    };
+  }, [handleLayoutUpdate]);
 
   return (
     <EventsListener>
@@ -46,11 +54,11 @@ function App() {
               autoSaveId="refstudio"
               className="relative h-full"
               direction="horizontal"
-              onLayout={updatePDFViewerWidth}
+              onLayout={handleLayoutUpdate}
             >
               <LeftSidePanelWrapper />
               <Panel defaultSize={60} order={2}>
-                <MainPanel pdfViewerRef={pdfViewerRef} />
+                <MainPanel />
               </Panel>
               <RightPanelWrapper />
             </PanelGroup>

--- a/src/application/views/PdfViewer.tsx
+++ b/src/application/views/PdfViewer.tsx
@@ -1,52 +1,33 @@
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
 import 'react-pdf/dist/esm/Page/TextLayer.css';
 
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Document, Page, pdfjs } from 'react-pdf';
 
 import { PdfEditorContent } from '../../atoms/types/EditorContent';
-import { useDebouncedCallback } from '../../hooks/useDebouncedCallback';
-import { PdfViewerAPI } from '../../types/PdfViewerAPI';
+import { useListenEvent } from '../../hooks/useListenEvent';
 
 pdfjs.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.js', import.meta.url).toString();
 
 interface PdfViewerProps {
   file: PdfEditorContent;
-  pdfViewerRef: React.MutableRefObject<PdfViewerAPI | null>;
 }
 
-export function PdfViewer({ file, pdfViewerRef }: PdfViewerProps) {
+export function PdfViewer({ file }: PdfViewerProps) {
   const [numPages, setNumPages] = useState<number | null>(null);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [pdfViewerWidth, setPdfViewerWidth] = useState<number>();
 
+  const fileData = useMemo(() => ({ data: file.binaryContent }), [file]);
+
   const updateWidth = useCallback(() => {
     setPdfViewerWidth(containerRef.current?.getBoundingClientRect().width);
   }, []);
-
-  const debouncedUpdateWidth = useDebouncedCallback(updateWidth, 200);
+  useListenEvent('refstudio://layout/update', updateWidth);
 
   // Update viewer's width on mount
-  useLayoutEffect(debouncedUpdateWidth, [debouncedUpdateWidth]);
-
-  // Update viewer's width on window resize
-  useEffect(() => {
-    window.addEventListener('resize', debouncedUpdateWidth);
-
-    return () => {
-      window.removeEventListener('resize', debouncedUpdateWidth);
-    };
-  }, [debouncedUpdateWidth]);
-
-  // Update viewer's width on panel resize
-  useEffect(() => {
-    pdfViewerRef.current = { updateWidth: debouncedUpdateWidth };
-
-    return () => {
-      pdfViewerRef.current = null;
-    };
-  }, [pdfViewerRef, debouncedUpdateWidth]);
+  useLayoutEffect(updateWidth, [updateWidth]);
 
   const onDocumentLoadSuccess = (pdf: { numPages: number }) => {
     setNumPages(pdf.numPages);
@@ -57,12 +38,12 @@ export function PdfViewer({ file, pdfViewerRef }: PdfViewerProps) {
       <Document
         className="flex-1 overflow-y-auto"
         externalLinkTarget="_blank"
-        file={{ data: file.binaryContent }}
+        file={fileData}
         onLoadSuccess={onDocumentLoadSuccess}
       >
         {numPages &&
           Array.from(new Array(numPages), (_, index) => (
-            <Page key={`page_${index + 1}`} pageNumber={index + 1} width={pdfViewerWidth} />
+            <Page key={`page_${index + 1}`} loading="" pageNumber={index + 1} width={pdfViewerWidth} />
           ))}
       </Document>
     </div>

--- a/src/events.ts
+++ b/src/events.ts
@@ -23,6 +23,7 @@ interface RefStudioEvents {
   'refstudio://notifications/popup/close': undefined;
   'refstudio://explorer/rename': { path: string; newName?: string };
   'refstudio://ai/suggestion/insert': { text: string };
+  'refstudio://layout/update': undefined;
 }
 
 export type RefStudioEventName = keyof RefStudioEvents;

--- a/src/types/PdfViewerAPI.ts
+++ b/src/types/PdfViewerAPI.ts
@@ -1,3 +1,0 @@
-export interface PdfViewerAPI {
-  updateWidth: () => void;
-}


### PR DESCRIPTION
** Problems **
 - Because binary data was not properly memoized, resizing the window caused the PdfViewer to load the file again.
 - Each loading page of a PDF was displaying a message `Loading page...`, which seemed weird
 - When having 2 PDFs side by side, only the one which had been open the last was updated when resizing the window because we were using a ref so the last open was overriding it.

** Solutions **
 - Properly memoize file content
 - Remove loading message for pages; now only the message `Loading document...` will be displayed
 - Emit an event when window is resized or when the layout is changed and make PdfViewer listen to this event and update its width when receiving it.

Note: Resizing the window doesn't make the component reload the PDF document anymore. However, there is still some time for it to create the canvas with the new dimension, so there is still a flickering effect. I don't see any easy fix for the issue.