### PR TITLE
fix: bug where full prompt is included in completion response

### DIFF
--- a/python/sidecar/rewrite.py
+++ b/python/sidecar/rewrite.py
@@ -80,7 +80,7 @@ class Rewriter:
             response_type: TextSuggestionChoice
         ) -> list[TextSuggestionChoice]:
         return [
-            response_type(index=choice['index'], text=choice["message"]["content"])
+            response_type(index=choice['index'], text=choice["message"]["content"].strip())
             for choice in response['choices']
         ]
 

--- a/python/sidecar/shared.py
+++ b/python/sidecar/shared.py
@@ -64,12 +64,11 @@ def trim_completion_prefix_from_choices(
     sentence_splitter_regex = r'(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?)\s'
     prefix_sentences = re.split(sentence_splitter_regex, prefix)
 
-    # OpenAI response may include the last sentence of the prefix
-    # if so, remove it from the choices for consistency
-    last_prefix_piece = prefix_sentences[-1]
+    # and remove any sentences from the prompt that were included in the responses
     for choice in choices:
-        if choice.text.startswith(last_prefix_piece):
-            choice.text = choice.text[len(last_prefix_piece):]
+        for sentence in prefix_sentences:
+            if choice.text.strip().startswith(sentence.strip()):
+                choice.text = choice.text[len(sentence):].strip()
     return choices
 
 

--- a/python/sidecar/shared.py
+++ b/python/sidecar/shared.py
@@ -69,6 +69,9 @@ def trim_completion_prefix_from_choices(
         for sentence in prefix_sentences:
             if choice.text.strip().startswith(sentence.strip()):
                 choice.text = choice.text[len(sentence):].strip()
+
+            if '[MASK]' in choice.text:
+                choice.text = choice.text.replace('[MASK]', '')
     return choices
 
 

--- a/python/tests/test_shared.py
+++ b/python/tests/test_shared.py
@@ -156,3 +156,28 @@ def test_trim_completion_prefix_from_choices():
     assert trimmed_choices[0].text == "part of the prefix."
     assert trimmed_choices[1].text == "part of the test."
     assert trimmed_choices[2].text == "something else."
+
+    # test 3: prefix is many sentences and response includes the entire prefix
+    test_prefix = "This is a very long prefix. But we only append to the last piece. The last piece is "
+    choices = [
+        typing.TextCompletionChoice(
+            index=0,
+            text=("This is a very long prefix. But we only append to the last piece. "
+                  "The last piece is part of the prefix.")
+        ),
+        typing.TextCompletionChoice(
+            index=1,
+            text=("This is a very long prefix. But we only append to the last piece. "
+                  "The last piece is part of the test.")
+        ),
+        typing.TextCompletionChoice(
+            index=2,
+            text=("This is a very long prefix. But we only append to the last piece. "
+                  "The last piece is something else.")
+        ),
+    ]
+    trimmed_choices = shared.trim_completion_prefix_from_choices(test_prefix, choices)
+    assert len(trimmed_choices) == 3
+    assert trimmed_choices[0].text == "part of the prefix."
+    assert trimmed_choices[1].text == "part of the test."
+    assert trimmed_choices[2].text == "something else."


### PR DESCRIPTION
fixes #294

We still won't be able to catch all edges with this function, but we will at least handle this case now.