### PR TITLE
feat: Handle errors, retries, and improve response types

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
+APP_DATA_DIR=/Users/greg/Library/Application Support/com.tauri.dev
+PROJECT_NAME=project-x
 OPENAI_API_KEY=
-OPENAI_COMPLETE_MODEL=davinci
 OPENAI_CHAT_MODEL=gpt-3.5-turbo
 SIDECAR_LOG_DIR=/tmp
 SIDECAR_ENABLE_LOGGING=true
-

--- a/poetry.lock
+++ b/poetry.lock
@@ -618,6 +618,17 @@ pure-eval = "*"
 tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
+name = "tenacity"
+version = "8.2.2"
+description = "Retry code until it succeeds"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+doc = ["reno", "sphinx", "tornado (>=4.5)"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -699,7 +710,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9, <3.12"  # pyinstaller requires Python <3.12
-content-hash = "7bf10c5078083143de483c2e4b28dff44ee5a13bbad9627a706d8d91e632f292"
+content-hash = "7587769f6653bd069b1be05689ea7f4688f36edd0bcce1e249deda44bdf2c862"
 
 [metadata.files]
 aiohttp = [
@@ -1354,6 +1365,10 @@ six = [
 stack-data = [
     {file = "stack_data-0.6.2-py3-none-any.whl", hash = "sha256:cbb2a53eb64e5785878201a97ed7c7b94883f48b87bfb0bbe8b623c74679e4a8"},
     {file = "stack_data-0.6.2.tar.gz", hash = "sha256:32d2dd0376772d01b6cb9fc996f3c8b57a357089dec328ed4b6553d037eaf815"},
+]
+tenacity = [
+    {file = "tenacity-8.2.2-py3-none-any.whl", hash = "sha256:2f277afb21b851637e8f52e6a613ff08734c347dc19ade928e519d7d2d8569b0"},
+    {file = "tenacity-8.2.2.tar.gz", hash = "sha256:43af037822bd0029025877f3b2d97cc4d7bb0c2991000a3d59d71517c5c969e0"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ python-dotenv = "^1.0.0"
 pydantic = "^1.10.9"
 rank-bm25 = "^0.2.2"
 pypdf = "^3.11.1"
+tenacity = "^8.2.2"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "^8.13.2"

--- a/python/cli.schema.json
+++ b/python/cli.schema.json
@@ -454,6 +454,10 @@
         "n_choices": {
           "default": 1,
           "type": "integer"
+        },
+        "temperature": {
+          "default": 0.7,
+          "type": "number"
         }
       },
       "required": [

--- a/python/cli.schema.json
+++ b/python/cli.schema.json
@@ -50,10 +50,7 @@
           "$ref": "#/definitions/RewriteRequest"
         },
         {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/RewriteChoice"
-          }
+          "$ref": "#/definitions/RewriteResponse"
         }
       ]
     },
@@ -66,10 +63,7 @@
           "$ref": "#/definitions/TextCompletionRequest"
         },
         {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TextCompletionChoice"
-          }
+          "$ref": "#/definitions/TextCompletionResponse"
         }
       ]
     },
@@ -82,10 +76,7 @@
           "$ref": "#/definitions/ChatRequest"
         },
         {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ChatResponseChoice"
-          }
+          "$ref": "#/definitions/ChatResponse"
         }
       ]
     },
@@ -343,6 +334,29 @@
         "text"
       ]
     },
+    "RewriteResponse": {
+      "title": "RewriteResponse",
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResponseStatus"
+        },
+        "message": {
+          "type": "string"
+        },
+        "choices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RewriteChoice"
+          }
+        }
+      },
+      "required": [
+        "status",
+        "message",
+        "choices"
+      ]
+    },
     "TextCompletionRequest": {
       "title": "TextCompletionRequest",
       "type": "object",
@@ -389,6 +403,29 @@
         "text"
       ]
     },
+    "TextCompletionResponse": {
+      "title": "TextCompletionResponse",
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResponseStatus"
+        },
+        "message": {
+          "type": "string"
+        },
+        "choices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TextCompletionChoice"
+          }
+        }
+      },
+      "required": [
+        "status",
+        "message",
+        "choices"
+      ]
+    },
     "ChatRequest": {
       "title": "ChatRequest",
       "type": "object",
@@ -419,6 +456,29 @@
       "required": [
         "index",
         "text"
+      ]
+    },
+    "ChatResponse": {
+      "title": "ChatResponse",
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResponseStatus"
+        },
+        "message": {
+          "type": "string"
+        },
+        "choices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ChatResponseChoice"
+          }
+        }
+      },
+      "required": [
+        "status",
+        "message",
+        "choices"
       ]
     },
     "ReferencePatch": {

--- a/python/main.py
+++ b/python/main.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
         ingest.get_references(param_obj)
 
     elif args.command == "rewrite":
-        rewrite.summarize(param_obj)
+        rewrite.rewrite(param_obj)
 
     elif args.command == "completion":
         rewrite.complete_text(param_obj)

--- a/python/sidecar/chat.py
+++ b/python/sidecar/chat.py
@@ -17,6 +17,8 @@ openai.api_key = os.environ.get("OPENAI_API_KEY")
 def ask_question(request: ChatRequest):
     input_text = request.text
     n_choices = request.n_choices
+    temperature = request.temperature
+
     logger.info(f"Calling chat with the following parameters: {request.dict()}")
 
     storage = JsonStorage(filepath=settings.REFERENCES_JSON_PATH)
@@ -28,7 +30,7 @@ def ask_question(request: ChatRequest):
     chat = Chat(input_text=input_text, storage=storage, ranker=ranker)
 
     try:
-        choices = chat.ask_question(n_choices=n_choices)
+        choices = chat.ask_question(n_choices=n_choices, temperature=temperature)
     except Exception as e:
         logger.error(e)
         response = ChatResponse(
@@ -64,13 +66,13 @@ class Chat:
         return docs
 
     @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
-    def call_model(self, messages: list, n_choices: int = 1):
+    def call_model(self, messages: list, n_choices: int = 1, temperature: float = 0.7):
         logger.info(f"Calling OpenAI chat API with the following input message(s): {messages}")
         response = openai.ChatCompletion.create(
             model=os.environ["OPENAI_CHAT_MODEL"],
             messages=messages,
             n=n_choices,  # number of completions to generate
-            temperature=0,  # 0 = no randomness, deterministic
+            temperature=temperature,  # 0 = no randomness, deterministic
             # max_tokens=200,
         )
         logger.info(f"Received response from OpenAI chat API: {response}")
@@ -88,13 +90,13 @@ class Chat:
             for choice in response['choices']
         ]
 
-    def ask_question(self, n_choices: int = 1) -> dict:
+    def ask_question(self, n_choices: int = 1, temperature: float = 0.7) -> dict:
         logger.info("Fetching 5 most relevant document chunks from storage")
         docs = self.get_relevant_documents()
         logger.info("Creating input prompt for chat API")
         context_str = prompts.prepare_chunks_for_prompt(chunks=docs)
         prompt = prompts.create_prompt_for_chat(query=self.input_text, context=context_str)
         messages = self.prepare_messages_for_chat(text=prompt)
-        response = self.call_model(messages=messages, n_choices=n_choices)
+        response = self.call_model(messages=messages, n_choices=n_choices, temperature=temperature)
         choices = self.prepare_choices_for_client(response=response)
         return choices

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -163,6 +163,7 @@ class TextCompletionResponse(RefStudioModel):
 class ChatRequest(RefStudioModel):
     text: str
     n_choices: int = 1
+    temperature: float = 0.7
 
 
 class ChatResponseChoice(TextSuggestionChoice):

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -120,6 +120,12 @@ class RewriteChoice(TextSuggestionChoice):
     pass
 
 
+class RewriteResponse(RefStudioModel):
+    status: ResponseStatus
+    message: str
+    choices: list[RewriteChoice]
+
+
 class TextCompletionRequest(RefStudioModel):
     text: str
     n_choices: int = 1
@@ -133,14 +139,25 @@ class TextCompletionChoice(TextSuggestionChoice):
     pass
 
 
+class TextCompletionResponse(RefStudioModel):
+    status: ResponseStatus
+    message: str
+    choices: list[TextCompletionChoice]
+
+
 class ChatRequest(RefStudioModel):
     text: str
     n_choices: int = 1
 
 
-class ChatResponseChoice(RefStudioModel):
-    index: int
-    text: str
+class ChatResponseChoice(TextSuggestionChoice):
+    pass
+
+
+class ChatResponse(RefStudioModel):
+    status: ResponseStatus
+    message: str
+    choices: list[ChatResponseChoice]
 
 
 class CliCommands(RefStudioModel):
@@ -150,11 +167,11 @@ class CliCommands(RefStudioModel):
     """Retrieve ingestion status of uploads"""
     ingest_references: tuple[IngestRequest, IngestResponse]
     """Retrieve ingested PDF references"""
-    rewrite: tuple[RewriteRequest, list[RewriteChoice]]
+    rewrite: tuple[RewriteRequest, RewriteResponse]
     """"Rewrites a block of text in a more concise manner"""
-    completion: tuple[TextCompletionRequest, list[TextCompletionChoice]]
+    completion: tuple[TextCompletionRequest, TextCompletionResponse]
     """Completes a body of text"""
-    chat: tuple[ChatRequest, list[ChatResponseChoice]]
+    chat: tuple[ChatRequest, ChatResponse]
     """Chat with the AI"""
     update: tuple[ReferenceUpdate, UpdateStatusResponse]
     """Update metadata for a Reference"""

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,35 @@
+import pytest
+
+
+@pytest.fixture
+def mock_call_model_is_ok(*args, **kwargs):
+    def mock_call_model_response(*args, **kwargs):
+        return {
+            "choices": [
+                {
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {
+                    "content": "This is a mocked response",
+                    "role": "assistant"
+                }
+                }
+            ],
+            "created": 1685588892,
+            "id": "chatcmpl-somelonghashedstring",
+            "model": "gpt-3.5-turbo-0301",
+            "object": "chat.completion",
+            "usage": {
+                "completion_tokens": 121,
+                "prompt_tokens": 351,
+                "total_tokens": 472
+            }
+        }
+    return mock_call_model_response
+
+
+@pytest.fixture
+def mock_call_model_is_error(*args, **kwargs):
+    def mock_call_model_response(*args, **kwargs):
+        raise Exception("This is a mocked error")
+    return mock_call_model_response

--- a/python/tests/test_chat.py
+++ b/python/tests/test_chat.py
@@ -7,32 +7,8 @@ from sidecar.typing import ChatRequest
 from .test_ingest import _copy_fixture_to_temp_dir
 
 
-def test_chat_ask_question(monkeypatch, capsys, tmp_path):
-    def mock_call_model(*args, **kwargs):
-        response = {
-            "choices": [
-                {
-                "finish_reason": "stop",
-                "index": 0,
-                "message": {
-                    "content": "This is a mocked response",
-                    "role": "assistant"
-                }
-                }
-            ],
-            "created": 1685588892,
-            "id": "chatcmpl-somelonghashedstring",
-            "model": "gpt-3.5-turbo-0301",
-            "object": "chat.completion",
-            "usage": {
-                "completion_tokens": 121,
-                "prompt_tokens": 351,
-                "total_tokens": 472
-            }
-        }
-        return response
-
-    monkeypatch.setattr(chat.Chat, "call_model", mock_call_model)
+def test_chat_ask_question_is_ok(monkeypatch, capsys, tmp_path, mock_call_model_is_ok):
+    monkeypatch.setattr(chat.Chat, "call_model", mock_call_model_is_ok)
     
     # copy references.json to temp dir and mock settings.REFERENCES_JSON_PATH
     test_file = "fixtures/data/references.json"
@@ -48,7 +24,29 @@ def test_chat_ask_question(monkeypatch, capsys, tmp_path):
     captured = capsys.readouterr()
     output = json.loads(captured.out)
 
-    assert len(output) == 1
-    assert output[0]["index"] == 0
-    assert output[0]["text"] == "This is a mocked response"
-    assert output[0]["text"] == "This is a mocked response"
+    assert output["status"] == "ok"
+    assert output["message"] == ""
+    assert len(output["choices"]) == 1
+    assert output["choices"][0]["index"] == 0
+
+
+def test_chat_ask_question_is_openai_error(monkeypatch, capsys, tmp_path, mock_call_model_is_error):
+    monkeypatch.setattr(chat.Chat, "call_model", mock_call_model_is_error)
+    
+    # copy references.json to temp dir and mock settings.REFERENCES_JSON_PATH
+    test_file = "fixtures/data/references.json"
+    path_to_test_file = Path(__file__).parent.joinpath(test_file)
+    mocked_path = tmp_path.joinpath("references.json")
+
+    _copy_fixture_to_temp_dir(path_to_test_file, mocked_path)
+    monkeypatch.setattr(settings, "REFERENCES_JSON_PATH", mocked_path)
+
+    _ = chat.ask_question(
+        request=ChatRequest(text="This is a question about something"),
+    )
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+
+    assert output["status"] == "error"
+    assert output["message"] == "This is a mocked error"
+    assert len(output["choices"]) == 0

--- a/python/tests/test_rewrite.py
+++ b/python/tests/test_rewrite.py
@@ -4,73 +4,53 @@ from sidecar import rewrite
 from sidecar.typing import RewriteRequest, TextCompletionRequest
 
 
-def test_summarize(monkeypatch, capsys):
-    def mock_call_model(*args, **kwargs):
-        response = {
-            "choices": [
-                {
-                "finish_reason": "stop",
-                "index": 0,
-                "message": {
-                    "content": "This is a mocked response",
-                    "role": "assistant"
-                }
-                }
-            ],
-            "created": 1685588892,
-            "id": "chatcmpl-somelonghashedstring",
-            "model": "gpt-3.5-turbo-0301",
-            "object": "chat.completion",
-            "usage": {
-                "completion_tokens": 121,
-                "prompt_tokens": 351,
-                "total_tokens": 472
-            }
-        }
-        return response
+def test_rewrite_is_ok(monkeypatch, mock_call_model_is_ok, capsys):
+    monkeypatch.setattr(rewrite.Rewriter, "call_model", mock_call_model_is_ok)
 
-    monkeypatch.setattr(rewrite.Rewriter, "call_model", mock_call_model)
-
-    _ = rewrite.summarize(RewriteRequest(text="This is a test"))
+    _ = rewrite.rewrite(RewriteRequest(text="This is a test"))
     captured = capsys.readouterr()
     output = json.loads(captured.out)
 
-    assert len(output) == 1
-    assert output[0]["index"] == 0
-    assert output[0]["text"] == "This is a mocked response"
+    assert output['status'] == "ok"
+    assert output['message'] == ""
+    assert len(output['choices']) == 1
+    assert output['choices'][0]['index'] == 0
+    assert output['choices'][0]['text'] == "This is a mocked response"
 
 
-def test_complete_text(monkeypatch, capsys):
-    def mock_call_model(*args, **kwargs):
-        response = {
-            "choices": [
-                {
-                "finish_reason": "stop",
-                "index": 0,
-                "message": {
-                    "content": "This is a mocked response",
-                    "role": "assistant"
-                }
-                }
-            ],
-            "created": 1685588892,
-            "id": "chatcmpl-somelonghashedstring",
-            "model": "gpt-3.5-turbo-0301",
-            "object": "chat.completion",
-            "usage": {
-                "completion_tokens": 121,
-                "prompt_tokens": 351,
-                "total_tokens": 472
-            }
-        }
-        return response
+def test_rewrite_is_error(monkeypatch, mock_call_model_is_error, capsys):
+    monkeypatch.setattr(rewrite.Rewriter, "call_model", mock_call_model_is_error)
 
-    monkeypatch.setattr(rewrite.Rewriter, "call_model", mock_call_model)
+    _ = rewrite.rewrite(RewriteRequest(text="This is a test"))
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+
+    assert output['status'] == "error"
+    assert output['message'] == "This is a mocked error"
+    assert len(output['choices']) == 0
+
+
+def test_complete_text_is_ok(monkeypatch, mock_call_model_is_ok, capsys):
+    monkeypatch.setattr(rewrite.Rewriter, "call_model", mock_call_model_is_ok)
 
     _ = rewrite.complete_text(TextCompletionRequest(text="This is a test"))
     captured = capsys.readouterr()
     output = json.loads(captured.out)
 
-    assert len(output) == 1
-    assert output[0]["index"] == 0
-    assert output[0]["text"] == "This is a mocked response"
+    assert output['status'] == "ok"
+    assert output['message'] == ""
+    assert len(output['choices']) == 1
+    assert output['choices'][0]['index'] == 0
+    assert output['choices'][0]['text'] == "This is a mocked response"
+
+
+def test_complete_text_is_error(monkeypatch, mock_call_model_is_error, capsys):
+    monkeypatch.setattr(rewrite.Rewriter, "call_model", mock_call_model_is_error)
+
+    _ = rewrite.complete_text(TextCompletionRequest(text="This is a test"))
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+
+    assert output['status'] == "error"
+    assert output['message'] == "This is a mocked error"
+    assert len(output['choices']) == 0

--- a/scripts/reset_uploads.sh
+++ b/scripts/reset_uploads.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PROJECT_DIR="$HOME/Library/Application Support/com.tauri.dev/project-x"
+PROJECT_DIR="$HOME/Library/Application Support/studio.ref.desktop/project-x"
 
 rm -f "$PROJECT_DIR/uploads/"*.pdf
 rm -rf "$PROJECT_DIR/.staging"

--- a/src/api/__tests__/chat.test.ts
+++ b/src/api/__tests__/chat.test.ts
@@ -9,39 +9,45 @@ describe('chatWithAI', () => {
   });
 
   it('should return list of strings with content returned by sidecar', async () => {
-    vi.mocked(callSidecar).mockResolvedValue([
-      {
-        index: 0,
-        text: 'some reply',
-      },
-    ]);
+    vi.mocked(callSidecar).mockResolvedValue({
+      status: 'ok',
+      message: '',
+      choices: [
+        {
+          index: 0,
+          text: 'some reply',
+        },
+      ],
+    });
 
     const response = await chatWithAI('input text');
     expect(response).toStrictEqual(['some reply']);
   });
 
   it('should return list of strings with content returned by sidecar 2', async () => {
-    vi.mocked(callSidecar).mockResolvedValue([
-      {
-        index: 0,
-        text: 'some reply',
-      },
-      {
-        index: 1,
-        text: 'Another reply',
-      },
-    ]);
+    vi.mocked(callSidecar).mockResolvedValue({
+      status: 'ok',
+      message: '',
+      choices: [
+        {
+          index: 0,
+          text: 'some reply',
+        },
+        {
+          index: 1,
+          text: 'Another reply',
+        },
+      ],
+    });
 
     const response = await chatWithAI('input text');
     expect(response).toStrictEqual(['some reply', 'Another reply']);
   });
 
   it('should return empty list, and not call sidecar, if provided text is empty', async () => {
-    const callSidecarMock = vi.mocked(callSidecar).mockResolvedValue([]);
-
     const response = await chatWithAI('');
     expect(response).toStrictEqual([]);
-    expect(callSidecarMock.mock.calls.length).toBe(0);
+    expect(callSidecar).not.toHaveBeenCalled();
   });
 
   it('should return error message reply if exception thrown calling sidecar', async () => {

--- a/src/api/__tests__/rewrite.test.ts
+++ b/src/api/__tests__/rewrite.test.ts
@@ -1,6 +1,6 @@
 import { askForRewrite } from '../rewrite';
 import { callSidecar } from '../sidecar';
-import { RewriteChoice } from '../types';
+import { RewriteResponse } from '../types';
 
 vi.mock('../sidecar');
 
@@ -10,7 +10,8 @@ describe('askForRewrite', () => {
   });
 
   it('should call sidecar rewrite with text', async () => {
-    vi.mocked(callSidecar).mockResolvedValue([] as RewriteChoice[]);
+    const response: RewriteResponse = { status: 'ok', message: '', choices: [] };
+    vi.mocked(callSidecar).mockResolvedValue(response);
 
     const REWRITE_REQUEST_TEXT = 'Some text to rewrite';
     await askForRewrite(REWRITE_REQUEST_TEXT);
@@ -20,12 +21,17 @@ describe('askForRewrite', () => {
 
   it('Should return text from first RewriteChoice', async () => {
     const REWRITE_REPLY_TEXT = 'The rewrite reply!';
-    vi.mocked(callSidecar).mockResolvedValue([
-      {
-        index: 0,
-        text: REWRITE_REPLY_TEXT,
-      },
-    ] as RewriteChoice[]);
+    const mockResponse: RewriteResponse = {
+      status: 'ok',
+      message: '',
+      choices: [
+        {
+          index: 0,
+          text: REWRITE_REPLY_TEXT,
+        },
+      ],
+    };
+    vi.mocked(callSidecar).mockResolvedValue(mockResponse);
 
     const response = await askForRewrite('some input');
     expect(response).toBe(REWRITE_REPLY_TEXT);

--- a/src/api/__tests__/sidecar.test.ts
+++ b/src/api/__tests__/sidecar.test.ts
@@ -21,7 +21,6 @@ const mockSettings: SettingsSchema = {
   openAI: {
     apiKey: 'API KEY',
     chatModel: 'CHAT MODEL',
-    completeModel: 'COMPLETE MODEL',
   },
   sidecar: {
     logging: {
@@ -68,7 +67,7 @@ describe('sidecar', () => {
     await callSidecar('chat', { text: 'Hello chatbot!' });
 
     expect(vi.mocked(getCachedSetting).mock.calls.length).toBeGreaterThan(0);
-    expect(Object.keys(env ?? {}).length).toBe(7);
+    expect(Object.keys(env ?? {}).length).toBe(6);
 
     // General
     expect(env?.APP_DATA_DIR).toBe(mockSettings.general.appDataDir);
@@ -76,7 +75,6 @@ describe('sidecar', () => {
     // OpenAI
     expect(env?.OPENAI_API_KEY).toBe(mockSettings.openAI.apiKey);
     expect(env?.OPENAI_CHAT_MODEL).toBe(mockSettings.openAI.chatModel);
-    expect(env?.OPENAI_COMPLETE_MODEL).toBe(mockSettings.openAI.completeModel);
     // Logging
     expect(env?.SIDECAR_ENABLE_LOGGING).toBe(String(mockSettings.sidecar.logging.active));
     expect(env?.SIDECAR_LOG_DIR).toBe(mockSettings.sidecar.logging.path);

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -1,3 +1,4 @@
+import { notifyError } from '../notifications/notifications';
 import { callSidecar } from './sidecar';
 
 export async function chatWithAI(text: string): Promise<string[]> {
@@ -6,7 +7,12 @@ export async function chatWithAI(text: string): Promise<string[]> {
       return [];
     }
     const response = await callSidecar('chat', { text });
-    return response.map((choice) => choice.text);
+
+    if (response.status === 'error') {
+      notifyError('Chat error', response.message);
+    }
+
+    return response.choices.map((choice) => choice.text);
   } catch (err) {
     return [`Chat error: ${String(err)}`];
   }

--- a/src/api/rewrite.ts
+++ b/src/api/rewrite.ts
@@ -1,3 +1,4 @@
+import { notifyError } from '../notifications/notifications';
 import { callSidecar } from './sidecar';
 
 export async function askForRewrite(selection: string): Promise<string> {
@@ -7,7 +8,12 @@ export async function askForRewrite(selection: string): Promise<string> {
     }
 
     const response = await callSidecar('rewrite', { text: selection });
-    return response[0].text;
+
+    if (response.status === 'error') {
+      notifyError('Rewrite error', response.message);
+    }
+
+    return response.choices[0].text;
   } catch (err) {
     return `Rewrite error: ${String(err)}`;
   }

--- a/src/api/sidecar.ts
+++ b/src/api/sidecar.ts
@@ -19,7 +19,6 @@ export async function callSidecar<T extends keyof CliCommands>(
     // Open AI
     OPENAI_API_KEY: openAISettings.apiKey,
     OPENAI_CHAT_MODEL: openAISettings.chatModel,
-    OPENAI_COMPLETE_MODEL: openAISettings.completeModel,
     // Sidecar
     SIDECAR_ENABLE_LOGGING: String(sidecarSettings.logging.active),
     SIDECAR_LOG_DIR: sidecarSettings.logging.path,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -136,6 +136,7 @@ export interface TextCompletionChoice {
 export interface ChatRequest {
   text: string;
   n_choices?: number;
+  temperature?: number;
 }
 export interface ChatResponse {
   status: ResponseStatus;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -34,17 +34,17 @@ export interface CliCommands {
    * @minItems 2
    * @maxItems 2
    */
-  rewrite: [RewriteRequest, RewriteChoice[]];
+  rewrite: [RewriteRequest, RewriteResponse];
   /**
    * @minItems 2
    * @maxItems 2
    */
-  completion: [TextCompletionRequest, TextCompletionChoice[]];
+  completion: [TextCompletionRequest, TextCompletionResponse];
   /**
    * @minItems 2
    * @maxItems 2
    */
-  chat: [ChatRequest, ChatResponseChoice[]];
+  chat: [ChatRequest, ChatResponse];
   /**
    * @minItems 2
    * @maxItems 2
@@ -102,6 +102,11 @@ export interface RewriteRequest {
   n_choices?: number;
   temperature?: number;
 }
+export interface RewriteResponse {
+  status: ResponseStatus;
+  message: string;
+  choices: RewriteChoice[];
+}
 export interface RewriteChoice {
   index: number;
   text: string;
@@ -114,6 +119,11 @@ export interface TextCompletionRequest {
   title?: string;
   abstract?: string;
 }
+export interface TextCompletionResponse {
+  status: ResponseStatus;
+  message: string;
+  choices: TextCompletionChoice[];
+}
 export interface TextCompletionChoice {
   index: number;
   text: string;
@@ -121,6 +131,11 @@ export interface TextCompletionChoice {
 export interface ChatRequest {
   text: string;
   n_choices?: number;
+}
+export interface ChatResponse {
+  status: ResponseStatus;
+  message: string;
+  choices: ChatResponseChoice[];
 }
 export interface ChatResponseChoice {
   index: number;

--- a/src/features/ai/settings/OpenAiSettingsPane.tsx
+++ b/src/features/ai/settings/OpenAiSettingsPane.tsx
@@ -50,15 +50,6 @@ export function OpenAiSettingsPane({ config }: SettingsPaneProps) {
               onChange={(e) => setPaneSettings({ ...paneSettings, chatModel: e.currentTarget.value })}
             />
           </div>
-          <div>
-            <label htmlFor="completeModel">Complete Model</label>
-            <input
-              className="w-full border bg-slate-50 px-2 py-0.5"
-              id="completeModel"
-              value={paneSettings.completeModel}
-              onChange={(e) => setPaneSettings({ ...paneSettings, completeModel: e.currentTarget.value })}
-            />
-          </div>
         </fieldset>
         <fieldset className="mt-10 flex items-center justify-end">
           {saveMutation.isSuccess && <span className="px-2 text-primary">Saved!</span>}

--- a/src/features/ai/settings/__tests__/OpenAiSettingsPane.test.tsx
+++ b/src/features/ai/settings/__tests__/OpenAiSettingsPane.test.tsx
@@ -23,7 +23,6 @@ const mockSettings: Pick<SettingsSchema, 'openAI'> = {
   openAI: {
     apiKey: 'API KEY',
     chatModel: 'CHAT MODEL',
-    completeModel: 'COMPLETE MODEL',
   },
 };
 
@@ -51,7 +50,6 @@ describe('OpenAiSettingsPane component', () => {
     expect(vi.mocked(getCachedSetting).mock.calls.length).toBeGreaterThan(0);
     expect(screen.getByLabelText('API Key')).toHaveValue(mockSettings.openAI.apiKey);
     expect(screen.getByLabelText('Chat Model')).toHaveValue(mockSettings.openAI.chatModel);
-    expect(screen.getByLabelText('Complete Model')).toHaveValue(mockSettings.openAI.completeModel);
   });
 
   it('should save (setCached, flush) with edited values on save', async () => {
@@ -64,10 +62,8 @@ describe('OpenAiSettingsPane component', () => {
     // Type
     await user.type(screen.getByLabelText('API Key'), '-Updated-1');
     await user.type(screen.getByLabelText('Chat Model'), '-Updated-2');
-    await user.type(screen.getByLabelText('Complete Model'), '-Updated-3');
     expect(screen.getByLabelText('API Key')).toHaveValue(`${mockSettings.openAI.apiKey}-Updated-1`);
     expect(screen.getByLabelText('Chat Model')).toHaveValue(`${mockSettings.openAI.chatModel}-Updated-2`);
-    expect(screen.getByLabelText('Complete Model')).toHaveValue(`${mockSettings.openAI.completeModel}-Updated-3`);
     expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
 
     // Submit
@@ -78,7 +74,6 @@ describe('OpenAiSettingsPane component', () => {
       {
         apiKey: `${mockSettings.openAI.apiKey}-Updated-1`,
         chatModel: `${mockSettings.openAI.chatModel}-Updated-2`,
-        completeModel: `${mockSettings.openAI.completeModel}-Updated-3`,
       },
     ]);
     expect(vi.mocked(saveCachedSettings).mock.calls.length).toBe(1);

--- a/src/settings/__tests__/settings.test.ts
+++ b/src/settings/__tests__/settings.test.ts
@@ -61,7 +61,7 @@ describe('settings', () => {
   });
 
   it('should read default value from env', async () => {
-    vi.mocked(readEnv).mockResolvedValue('OPENAI_COMPLETE_MODEL-value');
+    vi.mocked(readEnv).mockResolvedValue('OPENAI_CHAT_MODEL-value');
     const fn = vi.fn();
     vi.mocked(SettingsManager<SettingsSchema>).mockImplementation(
       (defaultSettings) =>
@@ -71,7 +71,7 @@ describe('settings', () => {
         } as unknown as SettingsManager<SettingsSchema>),
     );
     await initSettings();
-    expect(getSettings().default.openAI.chatModel).toBe('OPENAI_COMPLETE_MODEL-value');
+    expect(getSettings().default.openAI.chatModel).toBe('OPENAI_CHAT_MODEL-value');
   });
 
   it('should call settingsManager via getCachedSetting and setCachedSetting', async () => {

--- a/src/settings/panes/__tests__/DebugSettingsPane.test.tsx
+++ b/src/settings/panes/__tests__/DebugSettingsPane.test.tsx
@@ -22,7 +22,6 @@ const mockSettings: SettingsSchema = {
   },
   openAI: {
     apiKey: '',
-    completeModel: 'davinci',
     chatModel: 'gpt-3.5-turbo',
   },
   sidecar: {

--- a/src/settings/settingsManager.ts
+++ b/src/settings/settingsManager.ts
@@ -11,7 +11,6 @@ export interface SettingsSchema {
   };
   openAI: {
     apiKey: string;
-    completeModel: string;
     chatModel: string;
   };
   sidecar: {
@@ -36,7 +35,6 @@ export async function initSettings() {
       },
       openAI: {
         apiKey: await readEnv('OPENAI_API_KEY', ''),
-        completeModel: await readEnv('OPENAI_COMPLETE_MODEL', DEFAULT_OPEN_AI_COMPLETE_MODEL),
         chatModel: await readEnv('OPENAI_CHAT_MODEL', DEFAULT_OPEN_AI_CHAT_MODEL),
       },
       sidecar: {

--- a/src/settings/settingsManager.ts
+++ b/src/settings/settingsManager.ts
@@ -23,7 +23,6 @@ export interface SettingsSchema {
 
 let settingsManager: SettingsManager<SettingsSchema> | undefined;
 
-export const DEFAULT_OPEN_AI_COMPLETE_MODEL = 'davinci';
 export const DEFAULT_OPEN_AI_CHAT_MODEL = 'gpt-3.5-turbo';
 
 export async function initSettings() {


### PR DESCRIPTION
@cguedes @sehyod I pushed this with `no-verify` since I figured we might have some discussion on the typing changes. Leaving as draft for now, but please feel free to add your feedback.
______
fixes #85 and allows errors to be return within the sidecar response types

For now, I'm passing through the exception in the `message`, but I figured this PR would lead to some follow-up discussion on what we'd want to see on errors.
_____

*Ok*
```
{
  "status": "ok",
  "message": "",
  "choices": [
    {
      "index": 0,
      "text": "ML engineering is an experimental and iterative discipline, unlike traditional software engineering. Despite the negative perception of many failed experiments and models not being deployed, it is acceptable for them to not reach production."
    }
  ]
}
```

*Error*
```
{
  "status": "error",
  "message": "RetryError[<Future at 0x118d40700 state=finished raised AuthenticationError>]",
  "choices": []
}
```