### PR TITLE
Sentence completion in the editor

### DIFF
--- a/src/api/completion.ts
+++ b/src/api/completion.ts
@@ -1,0 +1,15 @@
+import { callSidecar } from './sidecar';
+
+export async function completeSentence(text: string): Promise<string[]> {
+  try {
+    if (text.trim() === '') {
+      return [];
+    }
+
+    const response = await callSidecar('completion', { text, n_choices: 3 });
+    return response.map((suggestion) => suggestion.text);
+  } catch (err) {
+    console.error('Rewrite error', err);
+    return [];
+  }
+}

--- a/src/application/components/MainPanel.tsx
+++ b/src/application/components/MainPanel.tsx
@@ -104,7 +104,6 @@ function MainPaneViewContent({ activeEditorAtoms }: MainPaneViewContentProps) {
       return <ReferencesTableView defaultFilter={data.filter} />;
     default: {
       assertNever(data);
-      return null;
     }
   }
 }

--- a/src/features/references/components/ReferencesItemStatusLabel.tsx
+++ b/src/features/references/components/ReferencesItemStatusLabel.tsx
@@ -21,6 +21,5 @@ export function ReferencesItemStatusLabel({ status }: { status: ReferenceItemSta
       );
     default:
       assertNever(status);
-      return null;
   }
 }

--- a/src/features/textEditor/components/TipTapEditor.css
+++ b/src/features/textEditor/components/TipTapEditor.css
@@ -22,7 +22,3 @@
 .tiptap-editor {
   @apply flex-1 overflow-y-scroll pl-1 pr-2 pt-2;
 }
-
-.tiptap-editor .sentence-suggestion {
-  @apply text-gray-400;
-}

--- a/src/features/textEditor/components/TipTapEditor.css
+++ b/src/features/textEditor/components/TipTapEditor.css
@@ -22,3 +22,7 @@
 .tiptap-editor {
   @apply flex-1 overflow-y-scroll pl-1 pr-2 pt-2;
 }
+
+.tiptap-editor .sentence-suggestion {
+  @apply text-gray-400;
+}

--- a/src/features/textEditor/components/tipTapEditorConfigs.ts
+++ b/src/features/textEditor/components/tipTapEditorConfigs.ts
@@ -13,6 +13,7 @@ import { CollapsibleBlockContentNode } from './tipTapNodes/collapsibleBlock/node
 import { CollapsibleBlockNode } from './tipTapNodes/collapsibleBlock/nodes/CollapsibleBlockNode';
 import { CollapsibleBlockSummaryNode } from './tipTapNodes/collapsibleBlock/nodes/CollapsibleBlockSummary';
 import { DraggableBlockNode } from './tipTapNodes/draggableBlock/DraggableBlockNode';
+import { SentenceCompletionExtension } from './tipTapNodes/plugins/sentenceCompletion';
 import { ReferenceNode } from './tipTapNodes/referenceNode/ReferenceNode';
 import { RefStudioDocument } from './tipTapNodes/refStudioDocument/RefStudioDocument';
 lowlight.registerLanguage('markdown', markdown);
@@ -44,6 +45,7 @@ export const EDITOR_EXTENSIONS: Extensions = [
   CollapsibleBlockContentNode,
   CollapsibleBlockSummaryNode,
   ReferenceNode,
+  SentenceCompletionExtension,
 ];
 
 export function transformPasted(slice: Slice) {

--- a/src/features/textEditor/components/tipTapNodes/plugins/__tests__/sentenceCompletion.test.tsx
+++ b/src/features/textEditor/components/tipTapNodes/plugins/__tests__/sentenceCompletion.test.tsx
@@ -1,0 +1,220 @@
+import { Editor, EditorContent } from '@tiptap/react';
+
+import { completeSentence } from '../../../../../../api/completion';
+import { act, screen, setup, waitFor } from '../../../../../../test/test-utils';
+import { EDITOR_EXTENSIONS } from '../../../tipTapEditorConfigs';
+import { getPrettyHTMLWithSelection, setUpEditorWithSelection } from '../../__tests__/test-utils';
+import { sentenceCompletionCommand } from '../helpers/sentenceCompletionCommand';
+import { sentenceCompletionPluginKey } from '../sentenceCompletion';
+
+vi.mock('../../../../../../api/completion');
+
+global.document.elementFromPoint = vi.fn();
+
+describe('SentenceCompletionExtension', () => {
+  const editor = new Editor({
+    extensions: EDITOR_EXTENSIONS,
+  });
+  let resolveCompletionChoices: (choices: string[]) => void;
+
+  beforeEach(() => {
+    vi.mocked(completeSentence).mockImplementation(
+      () =>
+        new Promise<string[]>((res) => {
+          resolveCompletionChoices = res;
+        }),
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should send text to complete to the api', async () => {
+    setUpEditorWithSelection(editor, 'Sentence to complete|');
+    setup(<EditorContent editor={editor} />);
+
+    editor.commands.command(sentenceCompletionCommand);
+    await waitFor(() => expect(vi.mocked(completeSentence)).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(completeSentence)).toHaveBeenCalledWith('Sentence to complete');
+  });
+
+  it('should only send text before the cursor to the api', () => {
+    setUpEditorWithSelection(editor, 'Sentence to| complete');
+    setup(<EditorContent editor={editor} />);
+
+    editor.commands.command(sentenceCompletionCommand);
+    expect(vi.mocked(completeSentence)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(completeSentence)).toHaveBeenCalledWith('Sentence to');
+  });
+
+  it('should not call the api is the selection is not empty', () => {
+    setUpEditorWithSelection(editor, 'Sentence to| complete|');
+    setup(<EditorContent editor={editor} />);
+
+    editor.commands.command(sentenceCompletionCommand);
+    expect(vi.mocked(completeSentence)).not.toHaveBeenCalled();
+  });
+
+  it('should display ellipsis while the result is pending', () => {
+    setUpEditorWithSelection(editor, 'Sentence to complete|');
+    setup(<EditorContent editor={editor} />);
+
+    editor.commands.command(sentenceCompletionCommand);
+
+    expect(screen.getByText('...')).toBeInTheDocument();
+  });
+
+  it('should display the first choice when the api result is available', async () => {
+    setUpEditorWithSelection(editor, 'Sentence to complete|');
+    setup(<EditorContent editor={editor} />);
+
+    editor.commands.command(sentenceCompletionCommand);
+    act(() => resolveCompletionChoices(['Choice 1', 'Choice 2']));
+
+    expect(await screen.findByText('Choice 1')).toBeInTheDocument();
+  });
+
+  it('should not update the editor content if the suggestion has not been accepted yet', async () => {
+    setUpEditorWithSelection(editor, 'Sentence to complete|');
+    setup(<EditorContent editor={editor} />);
+
+    editor.commands.command(sentenceCompletionCommand);
+
+    act(() => resolveCompletionChoices(['Choice 1', 'Choice 2']));
+    expect(await screen.findByText('Choice 1')).toBeInTheDocument();
+
+    expect(getPrettyHTMLWithSelection(editor)).toMatchInlineSnapshot('"<p>Sentence to complete|</p>"');
+  });
+
+  it('should cycle through choices', async () => {
+    setUpEditorWithSelection(editor, 'Sentence to complete|');
+    setup(<EditorContent editor={editor} />);
+
+    editor.commands.command(sentenceCompletionCommand);
+    act(() => resolveCompletionChoices(['Choice 1', 'Choice 2']));
+    expect(await screen.findByText('Choice 1')).toBeInTheDocument();
+
+    editor.commands.command(sentenceCompletionCommand);
+    expect(screen.getByText('Choice 2')).toBeInTheDocument();
+
+    editor.commands.command(sentenceCompletionCommand);
+    expect(screen.getByText('Choice 1')).toBeInTheDocument();
+
+    expect(vi.mocked(completeSentence)).toHaveBeenCalledTimes(1);
+  });
+
+  it('should display an error message if the api response is empty', async () => {
+    setUpEditorWithSelection(editor, 'Sentence to complete|');
+    setup(<EditorContent editor={editor} />);
+
+    editor.commands.command(sentenceCompletionCommand);
+    act(() => resolveCompletionChoices([]));
+
+    expect(await screen.findByText('Sentence completion returned no result')).toBeInTheDocument();
+  });
+
+  it('should retry when an error occured and the command is run again', async () => {
+    setUpEditorWithSelection(editor, 'Sentence to complete|');
+    setup(<EditorContent editor={editor} />);
+
+    editor.commands.command(sentenceCompletionCommand);
+    act(() => resolveCompletionChoices([]));
+
+    expect(await screen.findByText('Sentence completion returned no result')).toBeInTheDocument();
+
+    editor.commands.command(sentenceCompletionCommand);
+    expect(vi.mocked(completeSentence)).toHaveBeenCalledTimes(2);
+    expect(screen.getByText('...')).toBeInTheDocument();
+  });
+
+  it('should remove the error message when any transaction is dispatched', async () => {
+    setUpEditorWithSelection(editor, 'Sentence to complete|');
+    setup(<EditorContent editor={editor} />);
+
+    editor.commands.command(sentenceCompletionCommand);
+    act(() => resolveCompletionChoices([]));
+
+    expect(await screen.findByText('Sentence completion returned no result')).toBeInTheDocument();
+
+    act(() => editor.view.dispatch(editor.state.tr));
+    expect(screen.queryByText('...')).not.toBeInTheDocument();
+  });
+
+  it('should close the suggestion widget when pressing Escape', async () => {
+    setUpEditorWithSelection(editor, 'Sentence to complete|');
+    const { user } = setup(<EditorContent editor={editor} />);
+
+    await user.click(screen.getByText('Sentence to complete'));
+    editor.commands.command(sentenceCompletionCommand);
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByText('...')).not.toBeInTheDocument();
+  });
+
+  it.each(['Tab', 'Enter', 'ArrowRight'])('should accept the suggestion when pressing %s', async (key) => {
+    setUpEditorWithSelection(editor, 'Sentence to complete|');
+    const { user } = setup(<EditorContent editor={editor} />);
+
+    await user.click(screen.getByText('Sentence to complete'));
+    editor.commands.command(sentenceCompletionCommand);
+    act(() => resolveCompletionChoices(['completed!']));
+    expect(await screen.findByText('completed!')).toBeInTheDocument();
+    await user.keyboard(`{${key}}`);
+
+    expect(getPrettyHTMLWithSelection(editor)).toBe('<p>Sentence to completecompleted!|</p>');
+  });
+
+  it('should not catch key events if the widget is closed', async () => {
+    setUpEditorWithSelection(editor, 'Sentence to complete|');
+    const { user } = setup(<EditorContent editor={editor} />);
+
+    await user.click(screen.getByText('Sentence to complete'));
+    await act(() => editor.commands.command(sentenceCompletionCommand));
+    await user.keyboard('{Escape}');
+    await user.keyboard('{Enter}');
+
+    expect(screen.queryByText('...')).not.toBeInTheDocument();
+    expect(getPrettyHTMLWithSelection(editor)).toMatchInlineSnapshot(`
+      "<p>Sentence to complete</p>
+      <p>|</p>"
+    `);
+  });
+
+  it('should not catch key events other than Enter, Escape, Tab and ArrowRight', async () => {
+    // This is not ideal, but we need to mock these methods that are called by prosemirror
+    window.Range.prototype.getClientRects = vi.fn().mockImplementation(() => []);
+    window.Range.prototype.getBoundingClientRect = vi.fn().mockImplementation(() => ({ width: 0 }));
+
+    setUpEditorWithSelection(editor, 'Sentence to complete|');
+    const { user } = setup(<EditorContent editor={editor} />);
+
+    await user.click(screen.getByText('Sentence to complete'));
+    editor.commands.command(sentenceCompletionCommand);
+    await user.keyboard('a');
+
+    await waitFor(() => expect(screen.queryByText('...')).not.toBeInTheDocument());
+    expect(getPrettyHTMLWithSelection(editor)).toMatchInlineSnapshot('"<p>Sentence to completea|</p>"');
+  });
+
+  it('should not do anything if the api response is received after the widget has been closed', async () => {
+    setUpEditorWithSelection(editor, 'Sentence to complete|');
+    const { user } = setup(<EditorContent editor={editor} />);
+
+    await user.click(screen.getByText('Sentence to complete'));
+    editor.commands.command(sentenceCompletionCommand);
+    await user.keyboard('{Escape}');
+
+    act(() => resolveCompletionChoices(['Choice 1']));
+
+    expect(screen.queryByText('Choice 1')).not.toBeInTheDocument();
+  });
+
+  it('should throw an error when the metadata is invalid', () => {
+    setup(<EditorContent editor={editor} />);
+    const invalidMetadata = { [Symbol.toStringTag]: 'Invalid metadata' };
+    expect(() =>
+      editor.view.dispatch(editor.state.tr.setMeta(sentenceCompletionPluginKey, invalidMetadata)),
+    ).toThrowErrorMatchingInlineSnapshot('"Reached the unreachable: [object Invalid metadata]"');
+  });
+});

--- a/src/features/textEditor/components/tipTapNodes/plugins/helpers/sentenceCompletionCommand.ts
+++ b/src/features/textEditor/components/tipTapNodes/plugins/helpers/sentenceCompletionCommand.ts
@@ -1,0 +1,24 @@
+import { Command } from '@tiptap/react';
+
+import { SentenceCompletionMetadata } from '../../types/SentenceCompletionMetadata';
+import { sentenceCompletionPluginKey } from '../sentenceCompletion';
+
+export const sentenceCompletionCommand: Command = ({ dispatch, state, tr }) => {
+  if (!state.selection.empty) {
+    return false;
+  }
+  if (dispatch) {
+    const { parent, parentOffset } = state.selection.$from;
+    const text = parent.textBetween(0, parentOffset);
+
+    const openMetadata: SentenceCompletionMetadata = {
+      type: 'open',
+      query: text,
+    };
+
+    tr.setMeta(sentenceCompletionPluginKey, openMetadata);
+
+    dispatch(tr);
+  }
+  return true;
+};

--- a/src/features/textEditor/components/tipTapNodes/plugins/helpers/sentenceCompletionCommand.ts
+++ b/src/features/textEditor/components/tipTapNodes/plugins/helpers/sentenceCompletionCommand.ts
@@ -1,6 +1,6 @@
 import { Command } from '@tiptap/react';
 
-import { SentenceCompletionMetadata } from '../../types/SentenceCompletionMetadata';
+import { createOpenAction } from '../../types/SentenceCompletionMetadata';
 import { sentenceCompletionPluginKey } from '../sentenceCompletion';
 
 export const sentenceCompletionCommand: Command = ({ dispatch, state, tr }) => {
@@ -11,12 +11,7 @@ export const sentenceCompletionCommand: Command = ({ dispatch, state, tr }) => {
     const { parent, parentOffset } = state.selection.$from;
     const text = parent.textBetween(0, parentOffset);
 
-    const openMetadata: SentenceCompletionMetadata = {
-      type: 'open',
-      query: text,
-    };
-
-    tr.setMeta(sentenceCompletionPluginKey, openMetadata);
+    tr.setMeta(sentenceCompletionPluginKey, createOpenAction(text));
 
     dispatch(tr);
   }

--- a/src/features/textEditor/components/tipTapNodes/plugins/sentenceCompletion.ts
+++ b/src/features/textEditor/components/tipTapNodes/plugins/sentenceCompletion.ts
@@ -4,7 +4,11 @@ import { Decoration, DecorationSet } from '@tiptap/pm/view';
 
 import { completeSentence } from '../../../../../api/completion';
 import { assertNever } from '../../../../../lib/assertNever';
-import { SentenceCompletionMetadata } from '../types/SentenceCompletionMetadata';
+import {
+  createCloseAction,
+  createPopulateAction,
+  SentenceCompletionMetadata,
+} from '../types/SentenceCompletionMetadata';
 import { SentenceCompletionState } from '../types/SentenceCompletionState';
 import { sentenceCompletionCommand } from './helpers/sentenceCompletionCommand';
 
@@ -15,25 +19,24 @@ const sentenceCompletionPlugin = new Plugin<SentenceCompletionState>({
     init: () => ({ status: 'closed' }),
     apply: (transaction, state): SentenceCompletionState => {
       const metadata = transaction.getMeta(sentenceCompletionPluginKey) as SentenceCompletionMetadata | undefined;
-      if (!metadata || metadata.type === 'close') {
+      if (!metadata || metadata.action === 'close' || (state.status === 'error' && metadata.action !== 'open')) {
         return { status: 'closed' };
       }
 
-      const cursorPos = transaction.selection.$to.pos;
-
-      switch (metadata.type) {
+      switch (metadata.action) {
         case 'open': {
-          // If the plugin is already open, cycle through the choices
-          if (state.status === 'open') {
-            const newIndex = (state.index + 1) % state.suggestionChoices.length;
-            return { ...state, index: newIndex };
+          // If the plugin was not open, open it with 'pending' status
+          if (state.status !== 'open') {
+            const cursorPos = transaction.selection.$to.pos;
+            return {
+              status: 'pending',
+              pos: cursorPos,
+              query: metadata.query,
+            };
           }
-          // Otherwise open the plugin with 'pending' status
-          return {
-            status: 'pending',
-            pos: cursorPos,
-            query: metadata.query,
-          };
+          // Otherwise, cycle through the choices
+          const newIndex = (state.visibleChoiceIndex + 1) % state.suggestionChoices.length;
+          return { ...state, visibleChoiceIndex: newIndex };
         }
         case 'populate': {
           // If the plugin has been closed before receiving the results, there is nothing to update
@@ -41,13 +44,12 @@ const sentenceCompletionPlugin = new Plugin<SentenceCompletionState>({
             return state;
           }
           if (metadata.suggestionChoices.length === 0) {
-            console.warn('Sentence completion returned no result');
-            return { status: 'closed' };
+            return { pos: state.pos, status: 'error', text: 'Sentence completion returned no result' };
           }
           return {
             status: 'open',
             pos: state.pos,
-            index: 0,
+            visibleChoiceIndex: 0,
             suggestionChoices: metadata.suggestionChoices,
           };
         }
@@ -63,11 +65,7 @@ const sentenceCompletionPlugin = new Plugin<SentenceCompletionState>({
 
       if (prevPluginState?.status !== nextPluginState?.status && nextPluginState?.status === 'pending') {
         void completeSentence(nextPluginState.query).then((suggestionChoices) => {
-          const metadata: SentenceCompletionMetadata = {
-            type: 'populate',
-            suggestionChoices,
-          };
-          view.dispatch(view.state.tr.setMeta(sentenceCompletionPluginKey, metadata));
+          view.dispatch(view.state.tr.setMeta(sentenceCompletionPluginKey, createPopulateAction(suggestionChoices)));
         });
       }
     },
@@ -81,14 +79,22 @@ const sentenceCompletionPlugin = new Plugin<SentenceCompletionState>({
 
       const { pos } = currentState;
       const suggestionText =
-        currentState.status === 'pending' ? ' ...' : ` ${currentState.suggestionChoices[currentState.index]}`;
+        currentState.status === 'pending'
+          ? '...'
+          : currentState.status === 'error'
+          ? currentState.text
+          : currentState.suggestionChoices[currentState.visibleChoiceIndex];
 
       return DecorationSet.create(state.doc, [
         Decoration.widget(pos, () => {
           const parentNode = document.createElement('span');
 
           parentNode.innerHTML = suggestionText;
-          parentNode.classList.add('sentence-suggestion');
+          parentNode.style.color = 'hsl(var(--color-muted))';
+
+          if (currentState.status === 'error') {
+            parentNode.style.color = 'hsl(var(--color-error))';
+          }
 
           return parentNode;
         }),
@@ -102,21 +108,18 @@ const sentenceCompletionPlugin = new Plugin<SentenceCompletionState>({
 
       if (event.code === 'Tab' || event.code === 'ArrowRight' || event.code === 'Enter') {
         if (currentState.status === 'open') {
-          const { suggestionChoices, index } = currentState;
-          const closeMetadata: SentenceCompletionMetadata = { type: 'close' };
+          const { suggestionChoices, visibleChoiceIndex: index } = currentState;
 
           view.dispatch(
             view.state.tr
-              .insertText(` ${suggestionChoices[index]}`)
-              .setMeta(sentenceCompletionPluginKey, closeMetadata),
+              .insertText(suggestionChoices[index])
+              .setMeta(sentenceCompletionPluginKey, createCloseAction()),
           );
         }
         return true;
       }
       if (event.code === 'Escape') {
-        const closeMetadata: SentenceCompletionMetadata = { type: 'close' };
-
-        view.dispatch(view.state.tr.setMeta(sentenceCompletionPluginKey, closeMetadata));
+        view.dispatch(view.state.tr.setMeta(sentenceCompletionPluginKey, createCloseAction()));
         return true;
       }
       return false;
@@ -130,5 +133,8 @@ export const SentenceCompletionExtension = Extension.create({
 
   addProseMirrorPlugins: () => [sentenceCompletionPlugin],
 
-  addKeyboardShortcuts: () => ({ 'Mod-j': ({ editor }) => editor.commands.command(sentenceCompletionCommand) }),
+  addKeyboardShortcuts: () => ({
+    /* c8 ignore next */
+    'Mod-j': ({ editor }) => editor.commands.command(sentenceCompletionCommand),
+  }),
 });

--- a/src/features/textEditor/components/tipTapNodes/plugins/sentenceCompletion.ts
+++ b/src/features/textEditor/components/tipTapNodes/plugins/sentenceCompletion.ts
@@ -70,8 +70,6 @@ const sentenceCompletionPlugin = new Plugin<SentenceCompletionState>({
           view.dispatch(view.state.tr.setMeta(sentenceCompletionPluginKey, metadata));
         });
       }
-
-      return false;
     },
   }),
   props: {

--- a/src/features/textEditor/components/tipTapNodes/plugins/sentenceCompletion.ts
+++ b/src/features/textEditor/components/tipTapNodes/plugins/sentenceCompletion.ts
@@ -1,0 +1,136 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Decoration, DecorationSet } from '@tiptap/pm/view';
+
+import { completeSentence } from '../../../../../api/completion';
+import { assertNever } from '../../../../../lib/assertNever';
+import { SentenceCompletionMetadata } from '../types/SentenceCompletionMetadata';
+import { SentenceCompletionState } from '../types/SentenceCompletionState';
+import { sentenceCompletionCommand } from './helpers/sentenceCompletionCommand';
+
+export const sentenceCompletionPluginKey = new PluginKey<SentenceCompletionState>('sentenceCompletionPlugin');
+
+const sentenceCompletionPlugin = new Plugin<SentenceCompletionState>({
+  state: {
+    init: () => ({ status: 'closed' }),
+    apply: (transaction, state): SentenceCompletionState => {
+      const metadata = transaction.getMeta(sentenceCompletionPluginKey) as SentenceCompletionMetadata | undefined;
+      if (!metadata || metadata.type === 'close') {
+        return { status: 'closed' };
+      }
+
+      const cursorPos = transaction.selection.$to.pos;
+
+      switch (metadata.type) {
+        case 'open': {
+          // If the plugin is already open, cycle through the choices
+          if (state.status === 'open') {
+            const newIndex = (state.index + 1) % state.suggestionChoices.length;
+            return { ...state, index: newIndex };
+          }
+          // Otherwise open the plugin with 'pending' status
+          return {
+            status: 'pending',
+            pos: cursorPos,
+            query: metadata.query,
+          };
+        }
+        case 'populate': {
+          // If the plugin has been closed before receiving the results, there is nothing to update
+          if (state.status === 'closed') {
+            return state;
+          }
+          if (metadata.suggestionChoices.length === 0) {
+            console.warn('Sentence completion returned no result');
+            return { status: 'closed' };
+          }
+          return {
+            status: 'open',
+            pos: state.pos,
+            index: 0,
+            suggestionChoices: metadata.suggestionChoices,
+          };
+        }
+        default:
+          assertNever(metadata);
+      }
+    },
+  },
+  view: () => ({
+    update: (view, prevState) => {
+      const prevPluginState = sentenceCompletionPluginKey.getState(prevState);
+      const nextPluginState = sentenceCompletionPluginKey.getState(view.state);
+
+      if (prevPluginState?.status !== nextPluginState?.status && nextPluginState?.status === 'pending') {
+        void completeSentence(nextPluginState.query).then((suggestionChoices) => {
+          const metadata: SentenceCompletionMetadata = {
+            type: 'populate',
+            suggestionChoices,
+          };
+          view.dispatch(view.state.tr.setMeta(sentenceCompletionPluginKey, metadata));
+        });
+      }
+
+      return false;
+    },
+  }),
+  props: {
+    decorations(state) {
+      const currentState = this.getState(state);
+      if (!currentState || currentState.status === 'closed') {
+        return null;
+      }
+
+      const { pos } = currentState;
+      const suggestionText =
+        currentState.status === 'pending' ? ' ...' : ` ${currentState.suggestionChoices[currentState.index]}`;
+
+      return DecorationSet.create(state.doc, [
+        Decoration.widget(pos, () => {
+          const parentNode = document.createElement('span');
+
+          parentNode.innerHTML = suggestionText;
+          parentNode.classList.add('sentence-suggestion');
+
+          return parentNode;
+        }),
+      ]);
+    },
+    handleKeyDown(view, event) {
+      const currentState = this.getState(view.state);
+      if (!currentState || currentState.status === 'closed') {
+        return false;
+      }
+
+      if (event.code === 'Tab' || event.code === 'ArrowRight' || event.code === 'Enter') {
+        if (currentState.status === 'open') {
+          const { suggestionChoices, index } = currentState;
+          const closeMetadata: SentenceCompletionMetadata = { type: 'close' };
+
+          view.dispatch(
+            view.state.tr
+              .insertText(` ${suggestionChoices[index]}`)
+              .setMeta(sentenceCompletionPluginKey, closeMetadata),
+          );
+        }
+        return true;
+      }
+      if (event.code === 'Escape') {
+        const closeMetadata: SentenceCompletionMetadata = { type: 'close' };
+
+        view.dispatch(view.state.tr.setMeta(sentenceCompletionPluginKey, closeMetadata));
+        return true;
+      }
+      return false;
+    },
+  },
+  key: sentenceCompletionPluginKey,
+});
+
+export const SentenceCompletionExtension = Extension.create({
+  name: 'SentenceCompletionExtension',
+
+  addProseMirrorPlugins: () => [sentenceCompletionPlugin],
+
+  addKeyboardShortcuts: () => ({ 'Mod-j': ({ editor }) => editor.commands.command(sentenceCompletionCommand) }),
+});

--- a/src/features/textEditor/components/tipTapNodes/types/SentenceCompletionMetadata.ts
+++ b/src/features/textEditor/components/tipTapNodes/types/SentenceCompletionMetadata.ts
@@ -1,15 +1,31 @@
 interface CloseMetadata {
-  type: 'close';
+  action: 'close';
 }
 
 interface OpenMetadata {
-  type: 'open';
+  action: 'open';
   query: string;
 }
 
 interface PopulateMetadata {
-  type: 'populate';
+  action: 'populate';
   suggestionChoices: string[];
 }
 
 export type SentenceCompletionMetadata = CloseMetadata | OpenMetadata | PopulateMetadata;
+export function createCloseAction(): SentenceCompletionMetadata {
+  return { action: 'close' };
+}
+export function createPopulateAction(suggestionChoices: string[]): SentenceCompletionMetadata {
+  return {
+    action: 'populate',
+    suggestionChoices,
+  };
+}
+
+export function createOpenAction(query: string): SentenceCompletionMetadata {
+  return {
+    action: 'open',
+    query,
+  };
+}

--- a/src/features/textEditor/components/tipTapNodes/types/SentenceCompletionMetadata.ts
+++ b/src/features/textEditor/components/tipTapNodes/types/SentenceCompletionMetadata.ts
@@ -1,0 +1,15 @@
+interface CloseMetadata {
+  type: 'close';
+}
+
+interface OpenMetadata {
+  type: 'open';
+  query: string;
+}
+
+interface PopulateMetadata {
+  type: 'populate';
+  suggestionChoices: string[];
+}
+
+export type SentenceCompletionMetadata = CloseMetadata | OpenMetadata | PopulateMetadata;

--- a/src/features/textEditor/components/tipTapNodes/types/SentenceCompletionState.ts
+++ b/src/features/textEditor/components/tipTapNodes/types/SentenceCompletionState.ts
@@ -10,12 +10,19 @@ interface PendingSentenceCompletionState {
 
 interface OpenSentenceCompletionState {
   status: 'open';
-  index: number;
+  visibleChoiceIndex: number;
   pos: number;
   suggestionChoices: string[];
+}
+
+interface ErrorSentenceCompletionState {
+  pos: number;
+  status: 'error';
+  text: string;
 }
 
 export type SentenceCompletionState =
   | ClosedSentenceCompletionState
   | PendingSentenceCompletionState
-  | OpenSentenceCompletionState;
+  | OpenSentenceCompletionState
+  | ErrorSentenceCompletionState;

--- a/src/features/textEditor/components/tipTapNodes/types/SentenceCompletionState.ts
+++ b/src/features/textEditor/components/tipTapNodes/types/SentenceCompletionState.ts
@@ -1,0 +1,21 @@
+interface ClosedSentenceCompletionState {
+  status: 'closed';
+}
+
+interface PendingSentenceCompletionState {
+  status: 'pending';
+  pos: number;
+  query: string;
+}
+
+interface OpenSentenceCompletionState {
+  status: 'open';
+  index: number;
+  pos: number;
+  suggestionChoices: string[];
+}
+
+export type SentenceCompletionState =
+  | ClosedSentenceCompletionState
+  | PendingSentenceCompletionState
+  | OpenSentenceCompletionState;

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,8 @@
     --color-primary-hover: 152deg 54% 48%;
     --color-secondary: 193deg 37% 69%;
     --color-secondary-hover: 193deg 37% 48%;
+    --color-muted: 218deg 11% 65%;
+    --color-error: 0deg 84% 60%;
   }
 }
 

--- a/src/lib/assertNever.ts
+++ b/src/lib/assertNever.ts
@@ -1,5 +1,5 @@
 /* c8 ignore next 4 */
 /** Use this to assert that a branch is unreachable (for exhaustiveness checking). */
-export function assertNever(val: never) {
+export function assertNever(val: never): never {
   throw new Error(`Reached the unreachable: ${val}`);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,36 +9,38 @@ export default {
         // Using modern `hsl`
         primary: {
           DEFAULT: 'hsl(var(--color-primary) / <alpha-value>)',
-          hover: 'hsl(var(--color-primary-hover) / <alpha-value>)'
+          hover: 'hsl(var(--color-primary-hover) / <alpha-value>)',
         },
         secondary: {
           DEFAULT: 'hsl(var(--color-secondary) / <alpha-value>)',
-          hover: 'hsl(var(--color-secondary-hover) / <alpha-value>)'
-        }
+          hover: 'hsl(var(--color-secondary-hover) / <alpha-value>)',
+        },
+        muted: 'hsl(var(--color-muted) / <alpha-value>)',
+        error: 'hsl(var(--color-error) / <alpha-value>)',
       },
-      zIndex: {
-        "modals":        99999,
-        'notifications': 88888,
-        'drop-zone':     55555,
-      }
+      zIndex: {
+        modals: 99999,
+        notifications: 88888,
+        'drop-zone': 55555,
+      },
     },
   },
-  plugins: [debugPlugin(), autocompleteCustomComponentsPlugin()], 
+  plugins: [debugPlugin(), autocompleteCustomComponentsPlugin()],
 };
 
 /**
  * Custom plugin that provide auto-complete support for the listed classes.
  *
  * The style definitions can be found in `index.css` under the `@layer components {` section
- * 
+ *
  */
 function autocompleteCustomComponentsPlugin() {
   return plugin(function ({ addComponents }) {
     addComponents({
       '.btn-primary': {},
-      '.debug-widget': {}
-    })
-  })
+      '.debug-widget': {},
+    });
+  });
 }
 
 /**


### PR DESCRIPTION
This adds the shortcut cmd+J to run sentence completion in the editor.
The completion only runs if the selection is empty. The text sent as input for the LLM is the text between the beginning of the current block (current draggable block, current list item, etc.) and the position of the cursor.