### PR TITLE
fix: hide splashscreen instead of closing

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,7 +11,7 @@ fn get_environment_variable(name: &str) -> String {
 async fn close_splashscreen(window: tauri::Window) {
     // Close splashscreen
     if let Some(splashscreen) = window.get_window("splashscreen") {
-        splashscreen.close().unwrap();
+        splashscreen.hide().unwrap();
     }
     // Show main window
     window.get_window("main").unwrap().show().unwrap();


### PR DESCRIPTION
Fixes #315 

**Problem**

Changing files while developing causes the app to reload. Sometimes, the app is being re-rendered, and tries to close the splashscreen. Since the splashscreen is not open, the app crashes.

**Solution**

Hide the splashscreen instead of closing it