### PR TITLE
doi extraction for linking to external databases

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -71,6 +71,7 @@ $ poetry run python main.py ingest '{ "pdf_directory": "tests/fixtures/pdf/" }' 
       "title": "A Few Useful Things to Know about Machine Learning",
       "abstract": "... PDF abstract here ...",
       "contents": "... PDF body here ...",
+      "doi": None,
       "authors": [
         {
           "full_name": "Pedro Domingos",

--- a/python/cli.schema.json
+++ b/python/cli.schema.json
@@ -212,6 +212,9 @@
         "citation_key": {
           "type": "string"
         },
+        "doi": {
+          "type": "string"
+        },
         "title": {
           "type": "string"
         },

--- a/python/sidecar/ingest.py
+++ b/python/sidecar/ingest.py
@@ -300,6 +300,7 @@ class PDFIngestion:
             "title": header.get("title"),
             "authors": authors,
             "published_date": header.get("date"),
+            "doi": header.get("doi"),  # Added DOI extraction
         }
 
     def _create_author(self, author_dict: dict) -> Author:
@@ -456,6 +457,7 @@ class PDFIngestion:
                 status=typing.IngestStatus.COMPLETE,
                 title=header.get("title"),
                 authors=header.get("authors"),
+                doi=header.get("doi"),
                 published_date=pub_date,
                 abstract=doc.get("abstract"),
                 contents=doc.get("body"),

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -42,6 +42,7 @@ class Reference(RefStudioModel):
     source_filename: str
     status: IngestStatus
     citation_key: str | None = None
+    doi: str | None = None
     title: str | None = None
     abstract: str | None = None
     contents: str | None = None

--- a/python/tests/test_ingest.py
+++ b/python/tests/test_ingest.py
@@ -74,6 +74,7 @@ def test_run_ingest(monkeypatch, tmp_path, capsys):
 
     # check that test.pdf was parsed correctly
     assert references[1]['title'] == "A Few Useful Things to Know about Machine Learning"
+    assert references[1]['doi'] is None
     assert len(references[1]['authors']) == 1
     assert references[1]['authors'][0]['full_name'] == "Pedro Domingos"
     assert references[1]['citation_key'] == "domingos"

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -79,6 +79,7 @@ export interface Reference {
   source_filename: string;
   status: IngestStatus;
   citation_key?: string;
+  doi?: string;
   title?: string;
   abstract?: string;
   contents?: string;


### PR DESCRIPTION
Adds `doi` field from grobid extraction to the `references.json`. For most papers this can be used to link to other databases mentioned in https://github.com/refstudio/refstudio/issues/140