### PR TITLE
fix: make indent commands return proper command result

### DIFF
--- a/src/features/textEditor/components/tipTapNodes/notionBlock/NotionBlockNode.ts
+++ b/src/features/textEditor/components/tipTapNodes/notionBlock/NotionBlockNode.ts
@@ -250,7 +250,14 @@ export const NotionBlockNode = Node.create({
 
   addKeyboardShortcuts() {
     return {
-      Tab: ({ editor }) => editor.commands.command(indent),
+      Tab: ({ editor }) => {
+        editor.commands.command(indent);
+        return true;
+      },
+      'Shift-Tab': ({ editor }) => {
+        editor.commands.command(unindent);
+        return true;
+      },
       Enter: ({ editor }) => {
         const { selection } = editor.state;
         if (
@@ -301,7 +308,6 @@ export const NotionBlockNode = Node.create({
 
         return editor.commands.command(joinBackward);
       },
-      'Shift-Tab': ({ editor }) => editor.commands.command(unindent),
       Delete: ({ editor }) => editor.commands.command(joinForward),
       'Cmd-Enter': ({ editor }) => {
         const { $from } = editor.state.selection;

--- a/src/features/textEditor/components/tipTapNodes/notionBlock/commands/indent.ts
+++ b/src/features/textEditor/components/tipTapNodes/notionBlock/commands/indent.ts
@@ -30,7 +30,7 @@ export const indent: Command = ({ tr, dispatch }) => {
     ($from.node(-2).type.name === 'doc' && indexInParent < 2) ||
     ($from.node(-2).type.name === NotionBlockNode.name && indexInParent < 3)
   ) {
-    return true;
+    return false;
   }
 
   if (dispatch) {

--- a/src/features/textEditor/components/tipTapNodes/notionBlock/commands/unindent.ts
+++ b/src/features/textEditor/components/tipTapNodes/notionBlock/commands/unindent.ts
@@ -20,12 +20,12 @@ export function addUnindentSteps(tr: Transaction, pos: number): void {
 export const unindent: Command = ({ tr, dispatch }) => {
   const { $from } = tr.selection;
   if (!tr.selection.empty || $from.node(-1).type.name !== NotionBlockNode.name) {
-    return true;
+    return false;
   }
 
   // If the current node's grandparent is not a NotionBlockNode, then the node cannot be unindented
   if ($from.depth <= 2 || $from.node(-2).type.name !== NotionBlockNode.name) {
-    return true;
+    return false;
   }
 
   if (dispatch) {


### PR DESCRIPTION
**Problem**
`indent` and `unindent` commands were returning `true` to block default behavior of `Tab` and `Shift-Tab` shortcuts. However this made the `Backspace` command believe that the content could be unindented, blocking the fallback behavior of the shortcut, which is merging the line with the previous one.

**Solution**
This changes the return result of `indent` and `unindent` commands back to the proper boolean indicating whether the command can run.
`Tab` and `Shift-Tab` shortcuts are now the one responsible for returning `true` to block the default behavior of these shortcuts.

Fixes #342 