### PR TITLE
fix: uncollapse collapsible blocks when changing type

### DIFF
--- a/src/features/textEditor/components/tipTapNodes/notionBlock/NotionBlock.tsx
+++ b/src/features/textEditor/components/tipTapNodes/notionBlock/NotionBlock.tsx
@@ -12,7 +12,7 @@ interface NotionBlockProps {
 export function NotionBlock({ node }: NotionBlockProps) {
   return (
     <NodeViewWrapper>
-      <div className={cx('notion-block', { collapsed: !!node.attrs.collapsed })}>
+      <div className={cx('notion-block', { collapsed: node.attrs.type === 'collapsible' && !!node.attrs.collapsed })}>
         <div className="drag-handle" contentEditable="false" data-drag-handle />
         <NodeViewContent className="content" />
       </div>

--- a/src/features/textEditor/components/tipTapNodes/notionBlock/inputRuleHandlers/createNotionBlockInputRule.ts
+++ b/src/features/textEditor/components/tipTapNodes/notionBlock/inputRuleHandlers/createNotionBlockInputRule.ts
@@ -23,6 +23,7 @@ export function createNotionBlockInputRule(inputRegex: RegExp, type: string): In
         if (dispatch) {
           tr.replace(from, to);
           tr.setNodeAttribute(resolvedFrom.before(-1), 'type', type);
+          tr.setNodeAttribute(resolvedFrom.before(-1), 'collapsed', null);
         }
         return true;
       });


### PR DESCRIPTION
Turning a collapsible block into an ordered or unordered list item did not uncollapse the block first, making its content invisible and impossible to bring back