### PR TITLE
Export references

### DIFF
--- a/src/components/PanelSection.tsx
+++ b/src/components/PanelSection.tsx
@@ -4,6 +4,15 @@ import { VscChevronDown, VscChevronRight } from 'react-icons/vsc';
 
 import { cx } from '../lib/cx';
 
+interface Icon {
+  key: string;
+  disabled?: boolean;
+  Icon: IconType;
+  title?: string;
+  className?: string;
+  onClick: () => void;
+}
+
 export function PanelSection({
   title,
   children,
@@ -13,7 +22,7 @@ export function PanelSection({
   title: string;
   children: React.ReactNode;
   grow?: boolean;
-  rightIcons?: { key: string; Icon: IconType; title?: string; className?: string; onClick: () => void }[];
+  rightIcons?: Icon[];
 }) {
   const [expanded, setExpanded] = useState(true);
 
@@ -40,16 +49,23 @@ export function PanelSection({
             'invisible group-hover/panel-section:visible',
           )}
         >
-          {rightIcons.map(({ key, Icon, title: iconTitle, className, onClick }) => (
+          {rightIcons.map(({ key, disabled, Icon, title: iconTitle, className, onClick }) => (
             <Icon
-              className={cx('cursor-pointer hover:bg-slate-200', className)}
+              aria-disabled={disabled}
+              className={cx('cursor-pointer', className, {
+                disabled,
+                'text-slate-600/50': disabled,
+                'hover:bg-slate-200': !disabled,
+              })}
               key={key}
               size={20}
               title={iconTitle}
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                onClick();
+                if (!disabled) {
+                  onClick();
+                }
               }}
             />
           ))}

--- a/src/features/references/sidebar/ReferencesPanel.tsx
+++ b/src/features/references/sidebar/ReferencesPanel.tsx
@@ -73,9 +73,9 @@ export function ReferencesPanel() {
           { key: 'open', Icon: VscOpenPreview, title: 'Open References', onClick: handleOpenReferences },
           {
             key: 'export',
+            disabled: references.length === 0,
             Icon: VscDesktopDownload,
-            title: 'Export References (NOT IMPLEMENTED)',
-            className: 'text-slate-600/50',
+            title: 'Export References',
             onClick: () => handleExportReferences(),
           },
         ]}

--- a/src/features/references/sidebar/__tests__/ReferencesPanel.test.tsx
+++ b/src/features/references/sidebar/__tests__/ReferencesPanel.test.tsx
@@ -34,7 +34,6 @@ describe('ReferencesPanel', () => {
   it.each<{ title: string; event: RefStudioEventName }>([
     { title: 'Add References', event: 'refstudio://menu/references/upload' },
     { title: 'Open References', event: 'refstudio://menu/references/open' },
-    { title: 'Export References (NOT IMPLEMENTED)', event: 'refstudio://menu/references/export' },
   ])('should trigger $title on click', async ({ title, event }) => {
     const { user } = setupWithJotaiProvider(<ReferencesPanel />);
     await user.click(screen.getByTitle(title));
@@ -113,5 +112,25 @@ describe('ReferencesPanel', () => {
     expect(vi.mocked(emitEvent)).toBeCalledWith<
       [RefStudioEventName, RefStudioEventPayload<'refstudio://references/remove'>]
     >('refstudio://references/remove', { referenceIds: [ref1.id] });
+  });
+
+  it('should have disabled export button when no reference is in the store', async () => {
+    const { user } = setupWithJotaiProvider(<ReferencesPanel />);
+    const exportButton = screen.getByTitle('Export References');
+
+    expect(exportButton).toBeInTheDocument();
+
+    await user.click(exportButton);
+    expect(vi.mocked(emitEvent)).not.toBeCalled();
+  });
+
+  it("should emit 'refstudio://menu/references/export' when clicking on the export button", async () => {
+    const { user } = setupWithJotaiProvider(<ReferencesPanel />, store);
+    const exportButton = screen.getByTitle('Export References');
+
+    expect(exportButton).toBeInTheDocument();
+
+    await user.click(exportButton);
+    expect(vi.mocked(emitEvent)).toBeCalledWith<[RefStudioEventName]>('refstudio://menu/references/export');
   });
 });

--- a/src/wrappers/EventsListener.tsx
+++ b/src/wrappers/EventsListener.tsx
@@ -15,10 +15,11 @@ import {
 import { createFileAtom, deleteFileAtom, renameFileAtom } from '../atoms/fileEntryActions';
 import { fileExplorerEntryPathBeingRenamed } from '../atoms/fileExplorerActions';
 import { useActiveEditorContentAtoms } from '../atoms/hooks/useActiveEditorContentAtoms';
-import { removeReferencesAtom } from '../atoms/referencesState';
+import { getReferencesAtom, removeReferencesAtom } from '../atoms/referencesState';
 import { PaneEditorId } from '../atoms/types/PaneGroup';
 import { emitEvent, RefStudioEventPayload } from '../events';
 import { useListenEvent } from '../hooks/useListenEvent';
+import { exportReferences } from '../io/filesystem';
 import { asyncNoop, noop } from '../lib/noop';
 import {
   useClearNotificationsListener,
@@ -46,6 +47,7 @@ export function EventsListener({ children }: { children?: React.ReactNode }) {
   useListenEvent('refstudio://explorer/delete', useDeleteFileListener());
   // References
   useListenEvent('refstudio://references/remove', useRemoveReferencesListener());
+  useListenEvent('refstudio://menu/references/export', useExportReferencesListener());
   // Notifications
   useListenEvent('refstudio://notifications/new', useCreateNotificationListener());
   useListenEvent('refstudio://notifications/clear', useClearNotificationsListener());
@@ -101,6 +103,11 @@ function useCloseEditorListener() {
 function useRemoveReferencesListener() {
   const removeReferences = useSetAtom(removeReferencesAtom);
   return ({ referenceIds }: { referenceIds: string[] }) => void removeReferences(referenceIds);
+}
+
+function useExportReferencesListener() {
+  const references = useAtomValue(getReferencesAtom);
+  return () => void exportReferences(references);
 }
 
 function useDeleteFileListener() {


### PR DESCRIPTION
This adds the function to exports the entire list of references as a .bib file. Clicking on the button opens a dialog to choose where the file should be saved (defaulting to the `exports` folder of the project)
When no reference has been ingested, the button is disabled

Closes #345 