### PR TITLE
140 link reference doi to S2 id

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -413,3 +413,31 @@ poetry run python main.py search '{ "query": "your search query", "limit": 1 }' 
   ]
 }
 ```
+
+### Link References (Semantic Scholar)
+
+`link_references` links the `doi` of each reference in `references.json` to the corresponding Semantic Scholar paper and fetches the `s2_paper_id` which can be used as primary key to fetch additional information about the paper later.
+
+```bash
+poetry run python main.py link_references '{ "doi": true }'
+```
+
+```json
+{
+  "status": "ok",
+  "message": "Linking with s2 complete for 21 out of 25 references"
+}
+```
+
+Each reference will have a `s2_paper_id` field added to it.
+
+```json
+{
+    "source_filename": "91190.2-20201218131630-covered-e0fd13ba177f913fd3156f593ead4cfd.pdf",
+    "status": "complete",
+    "citation_key": "ayers2017",
+    "doi": "10.1172/jci91190",
+    "s2_paperId": "43120eca376614a844320d50ba42e8259797a48a",
+    "title": "IFN related mRNA profile predicts clinical response to PD-1 blockade",
+    . . }
+```

--- a/python/cli.schema.json
+++ b/python/cli.schema.json
@@ -118,6 +118,19 @@
           "$ref": "#/definitions/SearchResponse"
         }
       ]
+    },
+    "link_references": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": [
+        {
+          "$ref": "#/definitions/LinkRequest"
+        },
+        {
+          "$ref": "#/definitions/LinkResponse"
+        }
+      ]
     }
   },
   "required": [
@@ -129,7 +142,8 @@
     "chat",
     "update",
     "delete",
-    "search"
+    "search",
+    "link_references"
   ],
   "definitions": {
     "IngestRequest": {
@@ -213,6 +227,9 @@
           "type": "string"
         },
         "doi": {
+          "type": "string"
+        },
+        "s2_paperId": {
           "type": "string"
         },
         "title": {
@@ -670,6 +687,32 @@
         "status",
         "message",
         "results"
+      ]
+    },
+    "LinkRequest": {
+      "title": "LinkRequest",
+      "type": "object",
+      "properties": {
+        "doi": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "LinkResponse": {
+      "title": "LinkResponse",
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResponseStatus"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "status",
+        "message"
       ]
     }
   }

--- a/python/main.py
+++ b/python/main.py
@@ -57,6 +57,10 @@ if __name__ == '__main__':
     elif args.command == "search":
         response = search.search_s2(param_obj)
         sys.stdout.write(response.json())
+    
+    elif args.command == "link_references":
+        response = storage.link_references(param_obj)
+        sys.stdout.write(response.json())
 
     else:
         raise NotImplementedError(f"Command {args.command} is not implemented.")

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -43,6 +43,7 @@ class Reference(RefStudioModel):
     status: IngestStatus
     citation_key: str | None = None
     doi: str | None = None
+    s2_paperId: str | None = None
     title: str | None = None
     abstract: str | None = None
     contents: str | None = None
@@ -200,6 +201,13 @@ class SearchResponse(RefStudioModel):
     message: str
     results: list[S2SearchResult] 
 
+class LinkRequest(RefStudioModel):
+    doi: bool = False
+
+
+class LinkResponse(RefStudioModel):
+    status: ResponseStatus
+    message: str
 
 class CliCommands(RefStudioModel):
     ingest: tuple[IngestRequest, IngestResponse]
@@ -220,6 +228,8 @@ class CliCommands(RefStudioModel):
     """Deletes a Reference"""
     search: tuple[SearchRequest, SearchResponse]
     """Searches for papers on Semantic Scholar"""
+    link_references: tuple[LinkRequest, LinkResponse]
+    """Links references to Semantic Scholar papers"""
 
 
 Reference.update_forward_refs()

--- a/python/tests/fixtures/data/references.json
+++ b/python/tests/fixtures/data/references.json
@@ -2,6 +2,8 @@
   {
     "source_filename": "some_file.pdf",
     "status": "complete",
+    "doi": null,
+    "s2_paperId": null,
     "title": "Some title",
     "abstract": null,
     "contents": null,
@@ -66,6 +68,7 @@
   {
     "source_filename": "another_file.pdf",
     "status": "complete",
+    "doi": "10.1234/5678",
     "title": "Another title",
     "abstract": null,
     "contents": null,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -64,6 +64,11 @@ export interface CliCommands {
    * @maxItems 2
    */
   search: [SearchRequest, SearchResponse];
+  /**
+   * @minItems 2
+   * @maxItems 2
+   */
+  link_references: [LinkRequest, LinkResponse];
 }
 export interface IngestRequest {
   pdf_directory: string;
@@ -80,6 +85,7 @@ export interface Reference {
   status: IngestStatus;
   citation_key?: string;
   doi?: string;
+  s2_paperId?: string;
   title?: string;
   abstract?: string;
   contents?: string;
@@ -193,4 +199,11 @@ export interface S2SearchResult {
   citationCount?: number;
   openAccessPdf?: string;
   authors?: string[];
+}
+export interface LinkRequest {
+  doi?: boolean;
+}
+export interface LinkResponse {
+  status: ResponseStatus;
+  message: string;
 }


### PR DESCRIPTION
Fixes [#140](https://github.com/refstudio/refstudio/issues/140).
Parent PR: [#340](https://github.com/refstudio/refstudio/pull/340). A few changes on the backend were initiated that resulted in conflicts. 

This addition will link a paper with DOI to S2. Having a linked a reference to S2, we can now verify and normalize the title, abstract and augment other information about a paper like field of study, citation count etc.

Once the linking is complete the code will output - 

```json
{
  "status": "ok",
  "message": "Linking with s2 complete for 21 out of 25 references"
}
```
