### PR TITLE
Disable inlay hints in Rust

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,7 @@
   },
   "[rust]": {
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.inlayHints.enabled": "offUnlessPressed"
   }
 }


### PR DESCRIPTION
Forked off of #368. This hides these "inlay hints" (the text with the gray background) which makes it much easier to tell what's actually in your Rust code:

<img width="880" alt="image" src="https://github.com/refstudio/refstudio/assets/98301/3523fc81-ade9-4525-95ee-7d8b894ea1fa">
