### PR TITLE
fix: address comments from design

### DIFF
--- a/src/application/sidebar/LeftSidePanelWrapper.tsx
+++ b/src/application/sidebar/LeftSidePanelWrapper.tsx
@@ -71,7 +71,7 @@ export function LeftSidePanelWrapper() {
         {primaryPane === 'Explorer' && <ExplorerPanel />}
         {primaryPane === 'References' && <ReferencesPanel />}
       </Panel>
-      <VerticalResizeHandle />
+      <VerticalResizeHandle transparent />
     </>
   );
 }

--- a/src/application/sidebar/RightSidePanelWrapper.tsx
+++ b/src/application/sidebar/RightSidePanelWrapper.tsx
@@ -40,7 +40,7 @@ export function RightSidePanelWrapper() {
 
   return (
     <>
-      <VerticalResizeHandle />
+      <VerticalResizeHandle transparent />
       <Panel collapsible order={3} ref={rightPanelRef} onCollapse={(collapsed) => setSecondaryPaneCollapsed(collapsed)}>
         {secondaryPane === 'Rewriter' && <RewriterPanel />}
         {secondaryPane === 'Chatbot' && <ChatbotPanel />}

--- a/src/components/TabCloseButton.tsx
+++ b/src/components/TabCloseButton.tsx
@@ -1,6 +1,5 @@
-import { VscCircleFilled, VscClose } from 'react-icons/vsc';
-
 import { cx } from '../lib/cx';
+import { CircleIcon, CloseIcon } from './icons';
 
 interface CloseButtonProps {
   className?: string;
@@ -24,23 +23,25 @@ export function TabCloseButton({ isDirty, onClick }: CloseButtonProps) {
         },
       )}
     >
-      <VscClose
-        className={cx('block', 'group-hover/tab-close-button:!block', {
+      <div
+        className={cx('block', 'group-hover/tab-close-button:!block', 'hover:text-btn-ico-top-bar-active', {
           '!hidden': isDirty,
         })}
-        color="currentcolor"
         role="button"
         onClick={(e) => {
           e.stopPropagation();
           onClick();
         }}
-      />
-      <VscCircleFilled
+      >
+        <CloseIcon />
+      </div>
+      <div
         className={cx('hidden', 'group-hover/tab-close-button:!hidden', {
           '!block': isDirty,
         })}
-        color="currentcolor"
-      />
+      >
+        <CircleIcon />
+      </div>
     </div>
   );
 }

--- a/src/components/VerticalResizeHandle.tsx
+++ b/src/components/VerticalResizeHandle.tsx
@@ -3,15 +3,23 @@ import { PanelResizeHandle } from 'react-resizable-panels';
 
 import { cx } from '../lib/cx';
 
-export function VerticalResizeHandle() {
+export function VerticalResizeHandle({ transparent }: { transparent?: boolean }) {
   const [isDragging, setDragging] = useState(false);
 
   return (
-    <PanelResizeHandle
-      className={cx('flex h-full w-1', 'bg-resizer-bg-default hover:bg-resizer-bg-hover', {
-        'bg-resizer-bg-hover': isDragging,
-      })}
-      onDragging={setDragging}
-    />
+    <div className="relative">
+      <PanelResizeHandle
+        className={cx(
+          'flex h-full w-1',
+          'bg-resizer-bg-default hover:bg-resizer-bg-hover',
+          'absolute -ml-0.5 z-resize-handle',
+          {
+            'bg-resizer-bg-hover': isDragging,
+            'bg-transparent': transparent && !isDragging,
+          },
+        )}
+        onDragging={setDragging}
+      />
+    </div>
   );
 }

--- a/src/components/VerticalResizeHandle.tsx
+++ b/src/components/VerticalResizeHandle.tsx
@@ -12,7 +12,7 @@ export function VerticalResizeHandle({ transparent }: { transparent?: boolean })
         className={cx(
           'flex h-full w-1',
           'bg-resizer-bg-default hover:bg-resizer-bg-hover',
-          'absolute -ml-0.5 z-resize-handle',
+          'absolute z-resize-handle -ml-0.5',
           {
             'bg-resizer-bg-hover': isDragging,
             'bg-transparent': transparent && !isDragging,

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -10,3 +10,20 @@ export const RefStudioEditorIcon = () => (
     </svg>
   </div>
 );
+
+export const CloseIcon = () => (
+  <div className="flex h-6 w-6 items-center justify-center">
+    <svg height="12" viewBox="0 0 12 12" width="12" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M6.00012 7.41433L1.75748 11.657L0.343262 10.2428L4.5859 6.00012L0.343262 1.75748L1.75748 0.343262L6.00012 4.5859L10.2428 0.343262L11.657 1.75748L7.41433 6.00012L11.657 10.2428L10.2428 11.657L6.00012 7.41433Z"
+        fill="currentcolor"
+      />
+    </svg>
+  </div>
+);
+
+export const CircleIcon = () => (
+  <div className="flex h-6 w-6 items-center justify-center">
+    <div className="h-2 w-2 shrink-0 rounded-2xl bg-current" />
+  </div>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -190,6 +190,7 @@ export default {
         modals: 99999,
         notifications: 88888,
         'drop-zone': 55555,
+        'resize-handle': 44444,
       },
     },
   },


### PR DESCRIPTION
This makes the resize handles for sidebars transparent (only visible when hovering them)

https://github.com/refstudio/refstudio/assets/58954208/41fcdfa6-ba52-4614-beee-fbd39e767d13

This also replaces the icons for close button and unsaved changes circle to use custom icons created by the design team

<img width="188" alt="Screenshot 2023-08-24 at 11 57 02" src="https://github.com/refstudio/refstudio/assets/58954208/cc4aafd4-0bdd-44e5-bca7-26385556b385">
<img width="199" alt="Screenshot 2023-08-24 at 11 57 12" src="https://github.com/refstudio/refstudio/assets/58954208/298a38fb-3148-4420-8889-3b80e942e414">

Fixes #409 