### PR TITLE
fix: use roboto font in splashscreen

### DIFF
--- a/splashscreen.html
+++ b/splashscreen.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@900&display=swap');
+    </style>
+
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
This adds the Roboto font import statement to the splashscreen file
<img width="638" alt="Screenshot 2023-08-29 at 14 37 35" src="https://github.com/refstudio/refstudio/assets/58954208/9e9e7f64-7882-4b4d-bbaf-07a43facb153">

Fixes #436 