### PR TITLE
fix: rename files regression

### DIFF
--- a/src/api/projectsAPI.ts
+++ b/src/api/projectsAPI.ts
@@ -130,7 +130,7 @@ export const renameProjectFile = async (projectId: string, relativeFilePath: str
     throw new Error("File to rename don't exists in the project.");
   }
   const targetFileExists = await existsProjectFile(projectId, newFilePath);
-  if (!targetFileExists) {
+  if (targetFileExists) {
     throw new Error('Target file name already exists in the project.');
   }
 

--- a/src/atoms/__tests__/fileEntryActions.test.ts
+++ b/src/atoms/__tests__/fileEntryActions.test.ts
@@ -39,7 +39,7 @@ describe('fileEntryActions', () => {
 
     const leftPaneActiveEditorId = runHookWithJotaiProvider(() => useActiveEditorIdForPane('LEFT'), store).current;
     expect(leftPaneActiveEditorId).not.toBeNull();
-    expect(leftPaneActiveEditorId).toMatchInlineSnapshot('"refstudio://refstudio/Untitled-1"');
+    expect(leftPaneActiveEditorId).toMatchInlineSnapshot('"refstudio://refstudio/Untitled-1.refstudio"');
   });
 
   it('should create a file with the first available name', async () => {
@@ -54,7 +54,7 @@ describe('fileEntryActions', () => {
 
     const leftPaneActiveEditorId = runHookWithJotaiProvider(() => useActiveEditorIdForPane('LEFT'), store).current;
     expect(leftPaneActiveEditorId).not.toBeNull();
-    expect(leftPaneActiveEditorId).toMatchInlineSnapshot('"refstudio://refstudio/Untitled-3"');
+    expect(leftPaneActiveEditorId).toMatchInlineSnapshot('"refstudio://refstudio/Untitled-2.refstudio"');
   });
 
   it('should delete the file', async () => {

--- a/src/atoms/fileEntryActions.ts
+++ b/src/atoms/fileEntryActions.ts
@@ -68,7 +68,7 @@ export const createFileAtom = atom(null, (get, set) => {
 });
 
 function generateFileName(existingFileNames: Set<string>) {
-  const nameFromIndex = (index: number) => `Untitled-${index}`;
+  const nameFromIndex = (index: number) => `Untitled-${index}.refstudio`;
   let i = 1;
   while (existingFileNames.has(nameFromIndex(i))) {
     i++;

--- a/src/io/__tests__/filesystem.test.ts
+++ b/src/io/__tests__/filesystem.test.ts
@@ -267,7 +267,7 @@ describe('filesystem', () => {
       expect(result).toBeFalsy();
     });
 
-    it.skip('should rename file content via projects API', async () => {
+    it('should rename file content via projects API', async () => {
       vi.mocked(existsProjectFile).mockResolvedValue(false);
       const result = await renameFile('relative.txt', 'updated.txt');
       expect(result).toStrictEqual({ success: true, newPath: 'updated.txt' });
@@ -276,19 +276,13 @@ describe('filesystem', () => {
       expect(renameProjectFile).toHaveBeenCalledWith(PROJECT_ID, 'relative.txt', 'updated.txt');
     });
 
-    it.skip('should return unsuccessful if rename file outside of root', async () => {
+    it('should return unsuccessful if rename file outside of root', async () => {
       const result = await renameFile('outside/relative.txt', 'updated.txt');
       expect(result).toStrictEqual({ success: false });
     });
 
-    it.skip('should return unsuccessful if projects API fails for rename (file exists)', async () => {
-      vi.mocked(existsProjectFile).mockResolvedValue(true);
-      const result = await renameFile('relative.txt', 'updated.txt');
-      expect(result).toStrictEqual({ success: false });
-    });
-
-    it.skip('should return unsuccessful if projects API fails for rename (rename fails)', async () => {
-      vi.mocked(existsProjectFile).mockRejectedValue(false);
+    it('should return unsuccessful if projects API fails for rename', async () => {
+      vi.mocked(renameProjectFile).mockRejectedValue(false);
       const result = await renameFile('relative.txt', 'updated.txt');
       expect(result).toStrictEqual({ success: false });
     });


### PR DESCRIPTION
This fixes #454 and adopt `.refstudio` file extension when creating new files.

<img width="1840" alt="Screenshot 2023-08-31 at 11 45 39" src="https://github.com/refstudio/refstudio/assets/174127/1f1ef40f-b096-4635-9d03-984a828a5844">
