### PR TITLE
461-remove-references-regression-after-425

### DIFF
--- a/src/api/__tests__/ingestion.delete.test.ts
+++ b/src/api/__tests__/ingestion.delete.test.ts
@@ -1,4 +1,4 @@
-import { universalDelete } from '../api';
+import { universalPost } from '../api';
 import { removeReferences } from '../ingestion';
 import { DeleteStatusResponse } from '../types';
 
@@ -11,21 +11,21 @@ describe('ingestion.delete', () => {
   });
 
   it('should call backend API delete with --reference_ids', async () => {
-    vi.mocked(universalDelete).mockResolvedValue({
+    vi.mocked(universalPost).mockResolvedValue({
       status: 'ok',
     } as DeleteStatusResponse);
 
     const referenceIds = ['45722618-c4fb-4ae1-9230-7fc19a7219ed', '45722618-c4fb-4ae1-9230-7fc19a7219ed'];
     const result = await removeReferences(referenceIds, 'project-id');
-    expect(universalDelete).toHaveBeenCalledTimes(1);
-    expect(universalDelete).toHaveBeenCalledWith('/api/references/project-id/bulk_delete', {
+    expect(universalPost).toHaveBeenCalledTimes(1);
+    expect(universalPost).toHaveBeenCalledWith('/api/references/project-id/bulk_delete', {
       reference_ids: referenceIds,
     });
     expect(result).toBeUndefined();
   });
 
   it('should throw exception if call to backend API delete returns status error', async () => {
-    vi.mocked(universalDelete).mockResolvedValue({
+    vi.mocked(universalPost).mockResolvedValue({
       status: 'error',
       message: 'error message',
     } as DeleteStatusResponse);

--- a/src/api/ingestion.ts
+++ b/src/api/ingestion.ts
@@ -1,6 +1,6 @@
 import { makeUploadPath } from '../io/filesystem';
 import { ReferenceItem } from '../types/ReferenceItem';
-import { universalDelete, universalGet, universalPatch, universalPost } from './api';
+import { universalGet, universalPatch, universalPost } from './api';
 import { DeleteStatusResponse, UpdateStatusResponse } from './api-types';
 import { callSidecar } from './sidecar';
 import { IngestResponse, Reference } from './types';
@@ -29,7 +29,7 @@ export async function runPDFIngestion(projectId: string): Promise<ReferenceItem[
 }
 
 export async function removeReferences(ids: string[], projectId: string) {
-  const status = await universalDelete<DeleteStatusResponse>(`/api/references/${projectId}/bulk_delete`, {
+  const status = await universalPost<DeleteStatusResponse>(`/api/references/${projectId}/bulk_delete`, {
     reference_ids: ids,
   });
   if (status.status !== 'ok') {

--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -3,11 +3,12 @@ import 'react-contexify/dist/ReactContexify.css';
 import { MenuProvider } from 'kmenu';
 import React, { useCallback, useLayoutEffect } from 'react';
 import { ImperativePanelGroupHandle, Panel, PanelGroup } from 'react-resizable-panels';
-import { useLocalStorage, useWindowSize } from 'usehooks-ts';
+import { useEventListener, useLocalStorage, useWindowSize } from 'usehooks-ts';
 
 import { emitEvent } from '../events';
 import { ReferencesDropZone } from '../features/references/components/ReferencesDropZone';
 import { useDebouncedCallback } from '../hooks/useDebouncedCallback';
+import { notifyError } from '../notifications/notifications';
 import { SettingsModalOpener } from '../settings/SettingsModalOpener';
 import { ApplicationFrame } from '../wrappers/ApplicationFrame';
 import { ContextMenus } from '../wrappers/ContextMenus';
@@ -40,6 +41,10 @@ export function App() {
     ),
     200,
   );
+
+  useEventListener('unhandledrejection', (event) => {
+    notifyError('An error occurred', `Unhandled rejection in promise. Reason: ${event.reason}).`);
+  });
 
   // React to width resize or panelDimensions resize (via setLayout/resize panels)
   useLayoutEffect(() => {

--- a/src/atoms/referencesState.ts
+++ b/src/atoms/referencesState.ts
@@ -123,7 +123,7 @@ export const removeReferencesAtom = atom(null, async (get, set, ids: string[], p
 
   // Remove references from BE
   await removeReferences(
-    referencesToRemove.map((ref) => ref.filename),
+    referencesToRemove.map((ref) => ref.id),
     projectId,
   );
 


### PR DESCRIPTION
This fixes #468

Also adds handler for Unhandled rejection in promise that displays in the notification tray
