### PR TITLE
Create distinct types for Settings / SettingsPatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "react-popper": "^2.3.0",
     "react-resizable-panels": "^0.0.51",
     "tailwindcss": "^3.3.2",
-    "tauri-settings": "^0.3.2",
     "tiptap-markdown": "^0.7.2",
     "turndown": "^7.1.2",
     "usehooks-ts": "^2.9.1"

--- a/python/api.schema.json
+++ b/python/api.schema.json
@@ -522,114 +522,68 @@
       ],
       "title": "Body_create_file__project_id___filepath__put"
     },
-    "LoggingSettings": {
-      "properties": {
-        "enable": {
-          "type": "boolean",
-          "default": false
-        },
-        "filepath": {
-          "type": "string",
-          "default": "/tmp/refstudio-sidecar.log"
-        }
-      },
-      "type": "object",
-      "title": "LoggingSettings"
-    },
-    "OpenAISettings": {
-      "properties": {
-        "api_key": {
-          "type": "string",
-          "default": ""
-        },
-        "chat_model": {
-          "type": "string",
-          "default": "gpt-3.5-turbo"
-        },
-        "manner": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/RewriteMannerType"
-            }
-          ],
-          "default": "scholarly"
-        },
-        "temperature": {
-          "type": "number",
-          "default": 0.7
-        }
-      },
-      "type": "object",
-      "title": "OpenAISettings"
-    },
-    "ProjectSettings": {
+    "FlatSettingsSchema": {
       "properties": {
         "current_directory": {
-          "type": "string",
-          "default": ""
-        }
-      },
-      "type": "object",
-      "title": "ProjectSettings"
-    },
-    "SettingsSchema": {
-      "properties": {
-        "project": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/ProjectSettings"
-            }
-          ],
-          "default": {
-            "current_directory": ""
-          }
+          "type": "string"
         },
-        "openai": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/OpenAISettings"
-            }
-          ],
-          "default": {
-            "api_key": "",
-            "chat_model": "gpt-3.5-turbo",
-            "manner": "scholarly",
-            "temperature": 0.7
-          }
+        "logging_enabled": {
+          "type": "boolean"
         },
-        "sidecar": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/SidecarSettings"
-            }
-          ],
-          "default": {
-            "logging": {
-              "enable": false,
-              "filepath": "/tmp/refstudio-sidecar.log"
-            }
-          }
+        "logging_filepath": {
+          "type": "string"
+        },
+        "openai_api_key": {
+          "type": "string"
+        },
+        "openai_chat_model": {
+          "type": "string"
+        },
+        "openai_manner": {
+          "$ref": "#/definitions/RewriteMannerType"
+        },
+        "openai_temperature": {
+          "type": "number"
         }
       },
       "type": "object",
-      "title": "SettingsSchema"
+      "required": [
+        "current_directory",
+        "logging_enabled",
+        "logging_filepath",
+        "openai_api_key",
+        "openai_chat_model",
+        "openai_manner",
+        "openai_temperature"
+      ],
+      "title": "FlatSettingsSchema"
     },
-    "SidecarSettings": {
+    "FlatSettingsSchemaPatch": {
       "properties": {
-        "logging": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/LoggingSettings"
-            }
-          ],
-          "default": {
-            "enable": false,
-            "filepath": "/tmp/refstudio-sidecar.log"
-          }
+        "current_directory": {
+          "type": "string"
+        },
+        "logging_enabled": {
+          "type": "boolean"
+        },
+        "logging_filepath": {
+          "type": "string"
+        },
+        "openai_api_key": {
+          "type": "string"
+        },
+        "openai_chat_model": {
+          "type": "string"
+        },
+        "openai_manner": {
+          "$ref": "#/definitions/RewriteMannerType"
+        },
+        "openai_temperature": {
+          "type": "number"
         }
       },
       "type": "object",
-      "title": "SidecarSettings"
+      "title": "FlatSettingsSchemaPatch"
     }
   }
 }

--- a/python/openapi.json
+++ b/python/openapi.json
@@ -153,6 +153,69 @@
         "title": "DeleteStatusResponse",
         "type": "object"
       },
+      "FlatSettingsSchema": {
+        "properties": {
+          "current_directory": {
+            "type": "string"
+          },
+          "logging_enabled": {
+            "type": "boolean"
+          },
+          "logging_filepath": {
+            "type": "string"
+          },
+          "openai_api_key": {
+            "type": "string"
+          },
+          "openai_chat_model": {
+            "type": "string"
+          },
+          "openai_manner": {
+            "$ref": "#/components/schemas/RewriteMannerType"
+          },
+          "openai_temperature": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "current_directory",
+          "logging_enabled",
+          "logging_filepath",
+          "openai_api_key",
+          "openai_chat_model",
+          "openai_manner",
+          "openai_temperature"
+        ],
+        "title": "FlatSettingsSchema",
+        "type": "object"
+      },
+      "FlatSettingsSchemaPatch": {
+        "properties": {
+          "current_directory": {
+            "type": "string"
+          },
+          "logging_enabled": {
+            "type": "boolean"
+          },
+          "logging_filepath": {
+            "type": "string"
+          },
+          "openai_api_key": {
+            "type": "string"
+          },
+          "openai_chat_model": {
+            "type": "string"
+          },
+          "openai_manner": {
+            "$ref": "#/components/schemas/RewriteMannerType"
+          },
+          "openai_temperature": {
+            "type": "number"
+          }
+        },
+        "title": "FlatSettingsSchemaPatch",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -175,56 +238,6 @@
         ],
         "title": "IngestStatus",
         "type": "string"
-      },
-      "LoggingSettings": {
-        "properties": {
-          "enable": {
-            "default": false,
-            "type": "boolean"
-          },
-          "filepath": {
-            "default": "/tmp/refstudio-sidecar.log",
-            "type": "string"
-          }
-        },
-        "title": "LoggingSettings",
-        "type": "object"
-      },
-      "OpenAISettings": {
-        "properties": {
-          "api_key": {
-            "default": "",
-            "type": "string"
-          },
-          "chat_model": {
-            "default": "gpt-3.5-turbo",
-            "type": "string"
-          },
-          "manner": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/RewriteMannerType"
-              }
-            ],
-            "default": "scholarly"
-          },
-          "temperature": {
-            "default": 0.7,
-            "type": "number"
-          }
-        },
-        "title": "OpenAISettings",
-        "type": "object"
-      },
-      "ProjectSettings": {
-        "properties": {
-          "current_directory": {
-            "default": "",
-            "type": "string"
-          }
-        },
-        "title": "ProjectSettings",
-        "type": "object"
       },
       "Reference": {
         "description": "A reference for an academic paper / PDF",
@@ -453,65 +466,6 @@
           "results"
         ],
         "title": "SearchResponse",
-        "type": "object"
-      },
-      "SettingsSchema": {
-        "properties": {
-          "openai": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAISettings"
-              }
-            ],
-            "default": {
-              "api_key": "",
-              "chat_model": "gpt-3.5-turbo",
-              "manner": "scholarly",
-              "temperature": 0.7
-            }
-          },
-          "project": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ProjectSettings"
-              }
-            ],
-            "default": {
-              "current_directory": ""
-            }
-          },
-          "sidecar": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/SidecarSettings"
-              }
-            ],
-            "default": {
-              "logging": {
-                "enable": false,
-                "filepath": "/tmp/refstudio-sidecar.log"
-              }
-            }
-          }
-        },
-        "title": "SettingsSchema",
-        "type": "object"
-      },
-      "SidecarSettings": {
-        "properties": {
-          "logging": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LoggingSettings"
-              }
-            ],
-            "default": {
-              "enable": false,
-              "filepath": "/tmp/refstudio-sidecar.log"
-            }
-          }
-        },
-        "title": "SidecarSettings",
         "type": "object"
       },
       "TextCompletionChoice": {
@@ -1487,7 +1441,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SettingsSchema"
+                  "$ref": "#/components/schemas/FlatSettingsSchema"
                 }
               }
             },
@@ -1502,7 +1456,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SettingsSchema"
+                "$ref": "#/components/schemas/FlatSettingsSchemaPatch"
               }
             }
           },
@@ -1513,7 +1467,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SettingsSchema"
+                  "$ref": "#/components/schemas/FlatSettingsSchema"
                 }
               }
             },

--- a/python/sidecar/chat.py
+++ b/python/sidecar/chat.py
@@ -12,15 +12,15 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 def ask_question(
     request: ChatRequest,
     project_id: str = None,
-    user_settings: typing.SettingsSchema = None,
+    user_settings: typing.FlatSettingsSchema = None,
 ) -> typing.ChatResponse:
     input_text = request.text
     n_choices = request.n_choices
     temperature = request.temperature
 
     if user_settings is not None:
-        openai.api_key = user_settings.openai.api_key
-        model = user_settings.openai.chat_model
+        openai.api_key = user_settings.openai_api_key
+        model = user_settings.openai_chat_model
     else:
         openai.api_key = os.environ.get("OPENAI_API_KEY")
         model = "gpt-3.5-turbo"

--- a/python/sidecar/http.py
+++ b/python/sidecar/http.py
@@ -334,4 +334,3 @@ async def get_settings() -> FlatSettingsSchema:
 async def update_settings(req: FlatSettingsSchemaPatch) -> FlatSettingsSchema:
     user_id = "user1"
     return settings.update_settings_for_user(user_id, req)
-    return settings.update_settings_for_user(user_id, req)

--- a/python/sidecar/http.py
+++ b/python/sidecar/http.py
@@ -13,6 +13,8 @@ from sidecar.typing import (
     ChatResponse,
     DeleteRequest,
     DeleteStatusResponse,
+    FlatSettingsSchema,
+    FlatSettingsSchemaPatch,
     IngestRequest,
     Reference,
     ReferencePatch,
@@ -20,13 +22,10 @@ from sidecar.typing import (
     RewriteResponse,
     SearchRequest,
     SearchResponse,
-    SettingsSchema,
     TextCompletionRequest,
     TextCompletionResponse,
     UpdateStatusResponse,
 )
-
-from python.sidecar.typing import FlatSettingsSchema, FlatSettingsSchemaPatch
 
 load_dotenv()
 
@@ -334,4 +333,5 @@ async def get_settings() -> FlatSettingsSchema:
 @settings_api.put("/")
 async def update_settings(req: FlatSettingsSchemaPatch) -> FlatSettingsSchema:
     user_id = "user1"
+    return settings.update_settings_for_user(user_id, req)
     return settings.update_settings_for_user(user_id, req)

--- a/python/sidecar/http.py
+++ b/python/sidecar/http.py
@@ -26,6 +26,8 @@ from sidecar.typing import (
     UpdateStatusResponse,
 )
 
+from python.sidecar.typing import FlatSettingsSchema, FlatSettingsSchemaPatch
+
 load_dotenv()
 
 references_api = FastAPI()  # API for interacting with references
@@ -324,12 +326,12 @@ async def shutdown():
 # Settings API
 # --------------
 @settings_api.get("/")
-async def get_settings() -> SettingsSchema:
+async def get_settings() -> FlatSettingsSchema:
     user_id = "user1"
     return settings.get_settings_for_user(user_id)
 
 
 @settings_api.put("/")
-async def update_settings(req: SettingsSchema) -> SettingsSchema:
+async def update_settings(req: FlatSettingsSchemaPatch) -> FlatSettingsSchema:
     user_id = "user1"
     return settings.update_settings_for_user(user_id, req)

--- a/python/sidecar/pydantic_utils.py
+++ b/python/sidecar/pydantic_utils.py
@@ -1,0 +1,38 @@
+from typing import Optional, Type, get_type_hints
+
+from pydantic import BaseModel
+
+
+def make_optional(
+    include: Optional[list[str]] = None,
+    exclude: Optional[list[str]] = None,
+):
+    """Return a decorator to make model fields optional"""
+    # See https://stackoverflow.com/a/74296358/388951
+
+    if exclude is None:
+        exclude = []
+
+    # Create the decorator
+    def decorator(cls: Type[BaseModel]):
+        type_hints = get_type_hints(cls)
+        fields = cls.__fields__
+        if include is None:
+            fields = fields.items()
+        else:
+            # Create iterator for specified fields
+            fields = ((name, fields[name]) for name in include if name in fields)
+            # Fields in 'include' that are not in the model are simply ignored,
+            # as in BaseModel.dict
+        for name, field in fields:
+            if name in exclude:
+                continue
+            if not field.required:
+                continue
+            # Update pydantic ModelField to not required
+            field.required = False
+            # Update/append annotation
+            cls.__annotations__[name] = Optional[type_hints[name]]
+        return cls
+
+    return decorator

--- a/python/sidecar/rewrite.py
+++ b/python/sidecar/rewrite.py
@@ -13,15 +13,15 @@ from sidecar.typing import (
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 
-def rewrite(arg: RewriteRequest, user_settings: typing.SettingsSchema = None):
+def rewrite(arg: RewriteRequest, user_settings: typing.FlatSettingsSchema = None):
     text = arg.text
     manner = arg.manner
     n_choices = arg.n_choices
     temperature = arg.temperature
 
     if user_settings is not None:
-        openai.api_key = user_settings.openai.api_key
-        model = user_settings.openai.chat_model
+        openai.api_key = user_settings.openai_api_key
+        model = user_settings.openai_chat_model
     else:
         openai.api_key = os.environ.get("OPENAI_API_KEY")
         model = "gpt-3.5-turbo"
@@ -57,11 +57,11 @@ def rewrite(arg: RewriteRequest, user_settings: typing.SettingsSchema = None):
 
 
 def complete_text(
-    request: TextCompletionRequest, user_settings: typing.SettingsSchema = None
+    request: TextCompletionRequest, user_settings: typing.FlatSettingsSchema = None
 ):
     if user_settings is not None:
-        openai.api_key = user_settings.openai.api_key
-        model = user_settings.openai.chat_model
+        openai.api_key = user_settings.openai_api_key
+        model = user_settings.openai_chat_model
     else:
         openai.api_key = os.environ.get("OPENAI_API_KEY")
         model = "gpt-3.5-turbo"

--- a/python/sidecar/settings.py
+++ b/python/sidecar/settings.py
@@ -1,11 +1,16 @@
+import json
 import logging
 import os
-import json
 from pathlib import Path
 
 from dotenv import load_dotenv
-
 from sidecar.typing import SettingsSchema
+
+from python.sidecar.typing import (
+    FlatSettingsSchema,
+    FlatSettingsSchemaPatch,
+    RewriteMannerType,
+)
 
 load_dotenv()
 
@@ -35,17 +40,46 @@ def make_settings_json_path(user_id: str) -> Path:
     return filepath
 
 
+def default_settings() -> FlatSettingsSchema:
+    return FlatSettingsSchema(
+        current_directory="",
+        logging_enabled=False,
+        logging_filepath="/tmp/refstudio-sidecar.log",
+        openai_api_key="",
+        openai_chat_model="gpt-3.5-turbo",
+        openai_manner=RewriteMannerType.SCHOLARLY,
+        openai_temperature=0.7,
+    )
+
+
 def initialize_settings_for_user(user_id: str) -> None:
     filepath = make_settings_json_path(user_id)
     filepath.parent.mkdir(parents=True, exist_ok=True)
 
-    defaults = SettingsSchema()
+    defaults = default_settings()
 
     with open(filepath, "w") as f:
         json.dump(defaults.dict(), f)
 
 
-def get_settings_for_user(user_id: str) -> SettingsSchema:
+def migrate_settings(old_settings: dict) -> FlatSettingsSchema:
+    old_schema = SettingsSchema(
+        openai=old_settings.get("openai"),
+        project=old_settings.get("project"),
+        sidecar=old_settings.get("sidecar"),
+    )
+    return FlatSettingsSchema(
+        current_directory=old_schema.project.current_directory,
+        logging_enabled=old_schema.sidecar.logging.enable,
+        logging_filepath=old_schema.sidecar.logging.filepath,
+        openai_api_key=old_schema.openai.api_key,
+        openai_chat_model=old_schema.openai.chat_model,
+        openai_manner=old_schema.openai.manner,
+        openai_temperature=old_schema.openai.temperature,
+    )
+
+
+def get_settings_for_user(user_id: str) -> FlatSettingsSchema:
     """
     Reads a user's settings.json
     """
@@ -56,14 +90,15 @@ def get_settings_for_user(user_id: str) -> SettingsSchema:
 
     with open(filepath, "r") as f:
         data = json.load(f)
-    return SettingsSchema(
-        openai=data.get("openai"),
-        project=data.get("project"),
-        sidecar=data.get("sidecar"),
-    )
+
+    if "openai" in data:
+        return migrate_settings(data)
+    return FlatSettingsSchema(**data)
 
 
-def update_settings_for_user(user_id: str, settings: SettingsSchema) -> SettingsSchema:
+def update_settings_for_user(
+    user_id: str, settings: FlatSettingsSchemaPatch
+) -> FlatSettingsSchema:
     """
     Updates a user's settings.json
     """

--- a/python/sidecar/settings.py
+++ b/python/sidecar/settings.py
@@ -96,7 +96,7 @@ def get_settings_for_user(user_id: str) -> FlatSettingsSchema:
 
 
 def update_settings_for_user(
-    user_id: str, settings: FlatSettingsSchemaPatch
+    user_id: str, update: FlatSettingsSchemaPatch
 ) -> FlatSettingsSchema:
     """
     Updates a user's settings.json
@@ -109,7 +109,7 @@ def update_settings_for_user(
     response = get_settings_for_user(user_id)
 
     existing = response.dict()
-    existing.update(settings.dict())
+    existing.update({k: v for k, v in update.dict().items() if v is not None})
 
     with open(filepath, "w") as f:
         json.dump(existing, f)

--- a/python/sidecar/settings.py
+++ b/python/sidecar/settings.py
@@ -4,12 +4,11 @@ import os
 from pathlib import Path
 
 from dotenv import load_dotenv
-from sidecar.typing import SettingsSchema
-
-from python.sidecar.typing import (
+from sidecar.typing import (
     FlatSettingsSchema,
     FlatSettingsSchemaPatch,
     RewriteMannerType,
+    SettingsSchema,
 )
 
 load_dotenv()

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -232,6 +232,8 @@ class SidecarSettings(RefStudioModel):
 
 
 class SettingsSchema(RefStudioModel):
+    """@deprecated"""
+
     project: ProjectSettings = ProjectSettings()
     openai: OpenAISettings = OpenAISettings()
     sidecar: SidecarSettings = SidecarSettings()

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -3,8 +3,7 @@ from typing import Any
 
 from dotenv import load_dotenv
 from pydantic import BaseModel
-
-from python.sidecar.pydantic_utils import make_optional
+from sidecar.pydantic_utils import make_optional
 
 try:
     # introduced in Python 3.11 ...

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -1,42 +1,10 @@
 from datetime import date
-from typing import Any, Optional, Type, get_type_hints
+from typing import Any
 
 from dotenv import load_dotenv
 from pydantic import BaseModel
 
-
-def make_optional(
-    include: Optional[list[str]] = None,
-    exclude: Optional[list[str]] = None,
-):
-    """Return a decorator to make model fields optional"""
-
-    if exclude is None:
-        exclude = []
-
-    # Create the decorator
-    def decorator(cls: Type[BaseModel]):
-        type_hints = get_type_hints(cls)
-        fields = cls.__fields__
-        if include is None:
-            fields = fields.items()
-        else:
-            # Create iterator for specified fields
-            fields = ((name, fields[name]) for name in include if name in fields)
-            # Fields in 'include' that are not in the model are simply ignored, as in BaseModel.dict
-        for name, field in fields:
-            if name in exclude:
-                continue
-            if not field.required:
-                continue
-            # Update pydantic ModelField to not required
-            field.required = False
-            # Update/append annotation
-            cls.__annotations__[name] = Optional[type_hints[name]]
-        return cls
-
-    return decorator
-
+from python.sidecar.pydantic_utils import make_optional
 
 try:
     # introduced in Python 3.11 ...

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -20,7 +20,6 @@ def partial_model(model: Type[BaseModel]):
         f"Partial{model.__name__}",
         __base__=model,
         __module__=model.__module__,
-        __config__=model.__config__,
         **{
             field_name: make_field_optional(field_info)
             for field_name, field_info in model.__fields__.items()

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -555,7 +555,7 @@ def test_get_settings(monkeypatch, tmp_path, create_settings_json):  # noqa: F81
 
     response = settings_client.get("/")
     assert response.status_code == 200
-    assert response.json()["openai"]["api_key"] == "1234"
+    assert response.json()["openai_api_key"] == "1234"
 
 
 # ruff gets confused here:
@@ -565,11 +565,9 @@ def test_update_settings(monkeypatch, tmp_path, create_settings_json):  # noqa: 
     user_id = "user1"
 
     response = settings.get_settings_for_user(user_id)
+    assert response.openai_api_key != "test"
 
-    data = response.dict()
-    data["openai"] = {"api_key": "test"}
-
-    response = settings_client.put("/", json=data)
+    response = settings_client.put("/", json={"openai_api_key": "test"})
 
     assert response.status_code == 200
-    assert response.json()["openai"]["api_key"] == "test"
+    assert response.json()["openai_api_key"] == "test"

--- a/python/tests/test_settings.py
+++ b/python/tests/test_settings.py
@@ -76,3 +76,15 @@ def test_update_settings_for_user(monkeypatch, tmp_path, create_settings_json):
 
     # should be updated settings
     assert response.dict() == {**init_settings, "openai_temperature": 100.0}
+
+
+def test_migrate_settings():
+    old_settings = typing.SettingsSchema()
+    old_settings.openai.api_key = "abcd"
+    old_settings.sidecar.logging.enable = True
+    old_settings.project.current_directory = "/var/tmp"
+
+    new_settings = settings.migrate_settings(old_settings.dict())
+    assert new_settings.logging_enabled
+    assert new_settings.openai_api_key == "abcd"
+    assert new_settings.current_directory == "/var/tmp"

--- a/src/AppStartup.tsx
+++ b/src/AppStartup.tsx
@@ -41,7 +41,7 @@ export function AppStartup() {
 
         if (isMounted()) {
           setInitialized(true);
-          const projectId = getCachedSetting('project.current_directory'); // TODO: Open project using project ID
+          const projectId = getCachedSetting('current_directory'); // TODO: Open project using project ID
           if (projectId) {
             const projectInfo = await readProjectById(projectId);
             await openProject(projectId, projectInfo.path, projectInfo.name);

--- a/src/api/api-paths.ts
+++ b/src/api/api-paths.ts
@@ -9,11 +9,10 @@ import {
   Chunk,
   DeleteRequest,
   DeleteStatusResponse,
+  FlatSettingsSchema,
+  FlatSettingsSchemaPatch,
   HTTPValidationError,
   IngestStatus,
-  LoggingSettings,
-  OpenAISettings,
-  ProjectSettings,
   Reference,
   ReferencePatch,
   ResponseStatus,
@@ -24,8 +23,6 @@ import {
   S2SearchResult,
   SearchRequest,
   SearchResponse,
-  SettingsSchema,
-  SidecarSettings,
   TextCompletionChoice,
   TextCompletionRequest,
   TextCompletionResponse,
@@ -198,6 +195,26 @@ export interface components {
       message: string;
       status: ResponseStatus;
     };
+    /** FlatSettingsSchema */
+    FlatSettingsSchema: {
+      current_directory: string;
+      logging_enabled: boolean;
+      logging_filepath: string;
+      openai_api_key: string;
+      openai_chat_model: string;
+      openai_manner: RewriteMannerType;
+      openai_temperature: number;
+    };
+    /** FlatSettingsSchemaPatch */
+    FlatSettingsSchemaPatch: {
+      current_directory?: string;
+      logging_enabled?: boolean;
+      logging_filepath?: string;
+      openai_api_key?: string;
+      openai_chat_model?: string;
+      openai_manner?: RewriteMannerType;
+      openai_temperature?: number;
+    };
     /** HTTPValidationError */
     HTTPValidationError: {
       /** Detail */
@@ -209,29 +226,6 @@ export interface components {
      * @enum {string}
      */
     IngestStatus: 'processing' | 'failure' | 'complete';
-    /** LoggingSettings */
-    LoggingSettings: {
-      /** @default false */
-      enable?: boolean;
-      /** @default /tmp/refstudio-sidecar.log */
-      filepath?: string;
-    };
-    /** OpenAISettings */
-    OpenAISettings: {
-      /** @default */
-      api_key?: string;
-      /** @default gpt-3.5-turbo */
-      chat_model?: string;
-      /** @default scholarly */
-      manner?: RewriteMannerType;
-      /** @default 0.7 */
-      temperature?: number;
-    };
-    /** ProjectSettings */
-    ProjectSettings: {
-      /** @default */
-      current_directory?: string;
-    };
     /**
      * Reference
      * @description A reference for an academic paper / PDF
@@ -316,43 +310,6 @@ export interface components {
       message: string;
       results: S2SearchResult[];
       status: ResponseStatus;
-    };
-    /** SettingsSchema */
-    SettingsSchema: {
-      /**
-       * @default {
-       *   "api_key": "",
-       *   "chat_model": "gpt-3.5-turbo",
-       *   "manner": "scholarly",
-       *   "temperature": 0.7
-       * }
-       */
-      openai?: OpenAISettings;
-      /**
-       * @default {
-       *   "current_directory": ""
-       * }
-       */
-      project?: ProjectSettings;
-      /**
-       * @default {
-       *   "logging": {
-       *     "enable": false,
-       *     "filepath": "/tmp/refstudio-sidecar.log"
-       *   }
-       * }
-       */
-      sidecar?: SidecarSettings;
-    };
-    /** SidecarSettings */
-    SidecarSettings: {
-      /**
-       * @default {
-       *   "enable": false,
-       *   "filepath": "/tmp/refstudio-sidecar.log"
-       * }
-       */
-      logging?: LoggingSettings;
     };
     /** TextCompletionChoice */
     TextCompletionChoice: {
@@ -893,7 +850,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': SettingsSchema;
+          'application/json': FlatSettingsSchema;
         };
       };
     };
@@ -902,14 +859,14 @@ export interface operations {
   update_settings__put: {
     requestBody: {
       content: {
-        'application/json': SettingsSchema;
+        'application/json': FlatSettingsSchemaPatch;
       };
     };
     responses: {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': SettingsSchema;
+          'application/json': FlatSettingsSchema;
         };
       };
       /** @description Validation Error */

--- a/src/api/api-types.ts
+++ b/src/api/api-types.ts
@@ -245,42 +245,27 @@ export interface BodyCreateFile_ProjectId__Filepath_Put {
 }
 /**
  * This interface was referenced by `ApiSchema`'s JSON-Schema
- * via the `definition` "LoggingSettings".
+ * via the `definition` "FlatSettingsSchema".
  */
-export interface LoggingSettings {
-  enable?: boolean;
-  filepath?: string;
+export interface FlatSettingsSchema {
+  current_directory: string;
+  logging_enabled: boolean;
+  logging_filepath: string;
+  openai_api_key: string;
+  openai_chat_model: string;
+  openai_manner: RewriteMannerType;
+  openai_temperature: number;
 }
 /**
  * This interface was referenced by `ApiSchema`'s JSON-Schema
- * via the `definition` "OpenAISettings".
+ * via the `definition` "FlatSettingsSchemaPatch".
  */
-export interface OpenAISettings {
-  api_key?: string;
-  chat_model?: string;
-  manner?: RewriteMannerType & string;
-  temperature?: number;
-}
-/**
- * This interface was referenced by `ApiSchema`'s JSON-Schema
- * via the `definition` "ProjectSettings".
- */
-export interface ProjectSettings {
+export interface FlatSettingsSchemaPatch {
   current_directory?: string;
-}
-/**
- * This interface was referenced by `ApiSchema`'s JSON-Schema
- * via the `definition` "SettingsSchema".
- */
-export interface SettingsSchema {
-  project?: ProjectSettings;
-  openai?: OpenAISettings;
-  sidecar?: SidecarSettings;
-}
-/**
- * This interface was referenced by `ApiSchema`'s JSON-Schema
- * via the `definition` "SidecarSettings".
- */
-export interface SidecarSettings {
-  logging?: LoggingSettings;
+  logging_enabled?: boolean;
+  logging_filepath?: string;
+  openai_api_key?: string;
+  openai_chat_model?: string;
+  openai_manner?: RewriteMannerType;
+  openai_temperature?: number;
 }

--- a/src/api/sidecar.ts
+++ b/src/api/sidecar.ts
@@ -9,18 +9,15 @@ export async function callSidecar<T extends keyof CliCommands>(
   subcommand: T,
   arg: CliCommands[T][0],
 ): Promise<CliCommands[T][1]> {
-  const projectSettings = getCachedSetting('project');
-  const openAISettings = getCachedSetting('openai');
-  const sidecarSettings = getCachedSetting('sidecar');
   const env: Record<string, string> = {
     // Paths
-    PROJECT_DIR: projectSettings.current_directory,
+    PROJECT_DIR: getCachedSetting('current_directory'),
     // Open AI
-    OPENAI_API_KEY: openAISettings.api_key,
-    OPENAI_CHAT_MODEL: openAISettings.chat_model,
+    OPENAI_API_KEY: getCachedSetting('openai_api_key'),
+    OPENAI_CHAT_MODEL: getCachedSetting('openai_chat_model'),
     // Sidecar
-    SIDECAR_ENABLE_LOGGING: String(sidecarSettings.logging.enable),
-    SIDECAR_LOG_DIR: sidecarSettings.logging.filepath,
+    SIDECAR_ENABLE_LOGGING: String(getCachedSetting('logging_enabled')),
+    SIDECAR_LOG_DIR: getCachedSetting('logging_filepath'),
   };
 
   const command = new Command('call-sidecar', [subcommand, JSON.stringify(arg)], { env });

--- a/src/api/typed-api.ts
+++ b/src/api/typed-api.ts
@@ -1,6 +1,6 @@
 /** Type-safe access to the RefStudio HTTP APIs. */
 
-import { universalGet, universalPost } from './api';
+import { universalGet, universalPost, universalPut } from './api';
 import type { paths } from './api-paths';
 
 type LowerMethod = 'get' | 'post' | 'put' | 'delete' | 'patch';
@@ -78,7 +78,6 @@ function completePath(path: string, params: RouteParameters) {
 export async function apiGetJson<Path extends PathsForMethod<'get'>>(pathSpec: Path, ...args: PathArgs<Path, 'get'>) {
   const options = (args as unknown[])[0] as RouteParameters | undefined;
   const path = options ? completePath(pathSpec, options) : pathSpec;
-  console.log('apiGetJSON', pathSpec, path);
   type ResponseType = JsonResponseFor<Path, 'get'>;
   return universalGet<ResponseType>(path, undefined);
 }
@@ -96,7 +95,23 @@ export async function apiPost<Path extends PathsForMethod<'post'>>(
   const safeArgs = args as unknown as [params: RouteParameters, body: unknown] | [body: unknown];
   const [options, body] = safeArgs.length === 2 ? safeArgs : [undefined, ...safeArgs];
   const path = options ? completePath(pathSpec, options) : pathSpec;
-  console.log('apiPostJSON', pathSpec, path);
   type ResponseType = JsonResponseFor<Path, 'post'>;
   return universalPost<ResponseType>(path, body);
+}
+
+/**
+ * Issue a PUT request with a JSON payload to a RefStudio API endpoint.
+ *
+ * If the endpoint takes path parameters or search parameters, then that will be the second argument.
+ * The last argument (2nd or 3rd argument) is the request body.
+ */
+export async function apiPut<Path extends PathsForMethod<'put'>>(
+  pathSpec: Path,
+  ...args: [...params: PathArgs<Path, 'put'>, body: JsonRequestBodyFor<Path, 'put'>]
+) {
+  const safeArgs = args as unknown as [params: RouteParameters, body: unknown] | [body: unknown];
+  const [options, body] = safeArgs.length === 2 ? safeArgs : [undefined, ...safeArgs];
+  const path = options ? completePath(pathSpec, options) : pathSpec;
+  type ResponseType = JsonResponseFor<Path, 'post'>;
+  return universalPut<ResponseType>(path, body);
 }

--- a/src/application/listeners/projectEventListeners.ts
+++ b/src/application/listeners/projectEventListeners.ts
@@ -115,6 +115,6 @@ export function useFileProjectCloseListener() {
 
 // TODO: This method needs to be refactored to have use a project id instead of a path
 function persistActiveProjectInSettings(id: string) {
-  setCachedSetting('project.current_directory', id);
+  setCachedSetting('current_directory', id);
   void saveCachedSettings();
 }

--- a/src/features/ai/settings/OpenAiSettingsPane.tsx
+++ b/src/features/ai/settings/OpenAiSettingsPane.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 
+import { FlatSettingsSchema, RewriteMannerType } from '../../../api/api-types';
 import { JSONDebug, JSONDebugContainer } from '../../../components/JSONDebug';
 import { PasswordInput } from '../../../components/PasswordInput';
 import { SettingsPane, SettingsPaneProps } from '../../../settings/panes/SettingsPane';
@@ -8,17 +9,35 @@ import {
   getCachedSetting,
   getMannerOptions,
   getSettings,
-  OpenAiManner,
   saveCachedSettings,
   setCachedSetting,
 } from '../../../settings/settingsManager';
 
+interface OpenAISettings {
+  api_key: FlatSettingsSchema['openai_api_key'];
+  chat_model: FlatSettingsSchema['openai_chat_model'];
+  manner: FlatSettingsSchema['openai_manner'];
+  temperature: FlatSettingsSchema['openai_temperature'];
+}
+
+function getOpenAISettingsCached(): OpenAISettings {
+  return {
+    api_key: getCachedSetting('openai_api_key'),
+    chat_model: getCachedSetting('openai_chat_model'),
+    manner: getCachedSetting('openai_manner'),
+    temperature: getCachedSetting('openai_temperature'),
+  };
+}
+
 export function OpenAiSettingsPane({ config }: SettingsPaneProps) {
-  const [paneSettings, setPaneSettings] = useState(getCachedSetting('openai'));
+  const [paneSettings, setPaneSettings] = useState(getOpenAISettingsCached());
 
   const saveMutation = useMutation({
     mutationFn: async (value: typeof paneSettings) => {
-      setCachedSetting('openai', value);
+      setCachedSetting('openai_api_key', value.api_key);
+      setCachedSetting('openai_chat_model', value.chat_model);
+      setCachedSetting('openai_manner', value.manner);
+      setCachedSetting('openai_temperature', value.temperature);
       await saveCachedSettings();
       return getSettings();
     },
@@ -29,7 +48,7 @@ export function OpenAiSettingsPane({ config }: SettingsPaneProps) {
     saveMutation.mutate(paneSettings);
   };
 
-  const isDirty = JSON.stringify(paneSettings) !== JSON.stringify(getCachedSetting('openai'));
+  const isDirty = JSON.stringify(paneSettings) !== JSON.stringify(getOpenAISettingsCached());
 
   return (
     <SettingsPane
@@ -67,7 +86,7 @@ export function OpenAiSettingsPane({ config }: SettingsPaneProps) {
               id="manner"
               name="manner"
               value={paneSettings.manner}
-              onChange={(e) => setPaneSettings({ ...paneSettings, manner: e.currentTarget.value as OpenAiManner })}
+              onChange={(e) => setPaneSettings({ ...paneSettings, manner: e.currentTarget.value as RewriteMannerType })}
             >
               {getMannerOptions().map((m) => (
                 <option key={m} value={m}>

--- a/src/features/ai/settings/__tests__/OpenAiSettingsPane.test.tsx
+++ b/src/features/ai/settings/__tests__/OpenAiSettingsPane.test.tsx
@@ -32,7 +32,12 @@ describe('OpenAiSettingsPane component', () => {
     // Fake settings methods
     vi.mocked(initSettings).mockResolvedValue();
     vi.mocked(saveCachedSettings).mockResolvedValue();
-    vi.mocked(getCachedSetting).mockReturnValue(mockSettings.openai_manner);
+    vi.mocked(getCachedSetting).mockImplementation((key) => {
+      if (key in mockSettings) {
+        return mockSettings[key as keyof typeof mockSettings];
+      }
+      throw new Error('UNEXPECTED CALL FOR KEY ' + key);
+    });
     vi.mocked(setCachedSetting).mockImplementation(noop);
     vi.mocked(getMannerOptions).mockReturnValue(['concise', 'elaborate', 'scholarly']);
   });
@@ -80,16 +85,11 @@ describe('OpenAiSettingsPane component', () => {
 
     // Submit
     await user.click(screen.getByRole('button', { name: /save/i }));
-    expect(vi.mocked(setCachedSetting).mock.calls.length).toBe(1);
-    expect(vi.mocked(setCachedSetting).mock.calls[0]).toStrictEqual([
-      'openai',
-      {
-        api_key: `${mockSettings.openai_api_key}-Updated-1`,
-        chat_model: `${mockSettings.openai_chat_model}-Updated-2`,
-        manner: 'scholarly',
-        temperature: 0.9,
-      },
-    ]);
-    expect(vi.mocked(saveCachedSettings).mock.calls.length).toBe(1);
+    expect(vi.mocked(setCachedSetting)).toHaveBeenCalledTimes(4);
+    expect(vi.mocked(setCachedSetting)).toHaveBeenNthCalledWith(1, 'openai_api_key', 'API KEY-Updated-1');
+    expect(vi.mocked(setCachedSetting)).toHaveBeenNthCalledWith(2, 'openai_chat_model', 'CHAT MODEL-Updated-2');
+    expect(vi.mocked(setCachedSetting)).toHaveBeenNthCalledWith(3, 'openai_manner', 'scholarly');
+    expect(vi.mocked(setCachedSetting)).toHaveBeenNthCalledWith(4, 'openai_temperature', 0.9);
+    expect(vi.mocked(saveCachedSettings)).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/ai/settings/__tests__/OpenAiSettingsPane.test.tsx
+++ b/src/features/ai/settings/__tests__/OpenAiSettingsPane.test.tsx
@@ -1,12 +1,11 @@
+import { FlatSettingsSchema, RewriteMannerType } from '../../../../api/api-types';
 import { noop } from '../../../../lib/noop';
 import {
   getCachedSetting,
   getMannerOptions,
   initSettings,
-  OpenAiManner,
   saveCachedSettings,
   setCachedSetting,
-  SettingsSchema,
 } from '../../../../settings/settingsManager';
 import { PaneConfig } from '../../../../settings/types';
 import { fireEvent, render, screen, userEvent } from '../../../../test/test-utils';
@@ -21,21 +20,19 @@ const panelConfig: PaneConfig = {
   title: 'OPEN AI',
 };
 
-const mockSettings: Pick<SettingsSchema, 'openai'> = {
-  openai: {
-    api_key: 'API KEY',
-    chat_model: 'CHAT MODEL',
-    manner: 'elaborate',
-    temperature: 0.8,
-  },
-};
+const mockSettings = {
+  openai_api_key: 'API KEY',
+  openai_chat_model: 'CHAT MODEL',
+  openai_manner: 'elaborate',
+  openai_temperature: 0.8,
+} satisfies Partial<FlatSettingsSchema>;
 
 describe('OpenAiSettingsPane component', () => {
   beforeEach(() => {
     // Fake settings methods
     vi.mocked(initSettings).mockResolvedValue();
     vi.mocked(saveCachedSettings).mockResolvedValue();
-    vi.mocked(getCachedSetting).mockReturnValue(mockSettings.openai);
+    vi.mocked(getCachedSetting).mockReturnValue(mockSettings.openai_manner);
     vi.mocked(setCachedSetting).mockImplementation(noop);
     vi.mocked(getMannerOptions).mockReturnValue(['concise', 'elaborate', 'scholarly']);
   });
@@ -54,10 +51,10 @@ describe('OpenAiSettingsPane component', () => {
 
     expect(getCachedSetting).toHaveBeenCalled();
     expect(screen.getByTestId('openai-settings-form')).toHaveFormValues({
-      apiKey: mockSettings.openai.api_key,
-      chatModel: mockSettings.openai.chat_model,
-      manner: mockSettings.openai.manner,
-      temperature: String(mockSettings.openai.temperature),
+      apiKey: mockSettings.openai_api_key,
+      chatModel: mockSettings.openai_chat_model,
+      manner: mockSettings.openai_manner,
+      temperature: String(mockSettings.openai_temperature),
     });
   });
 
@@ -71,14 +68,14 @@ describe('OpenAiSettingsPane component', () => {
     // Type
     await user.type(screen.getByLabelText('API Key'), '-Updated-1');
     await user.type(screen.getByLabelText('Chat Model'), '-Updated-2');
-    await user.selectOptions(screen.getByLabelText('Manner'), 'scholarly' as OpenAiManner);
+    await user.selectOptions(screen.getByLabelText('Manner'), 'scholarly' as RewriteMannerType);
     const range = screen.getByLabelText('Creativity (temperature)');
     // https://github.com/testing-library/user-event/issues/871
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(range, { target: { value: 0.9 } });
 
-    expect(screen.getByLabelText('API Key')).toHaveValue(`${mockSettings.openai.api_key}-Updated-1`);
-    expect(screen.getByLabelText('Chat Model')).toHaveValue(`${mockSettings.openai.chat_model}-Updated-2`);
+    expect(screen.getByLabelText('API Key')).toHaveValue(`${mockSettings.openai_api_key}-Updated-1`);
+    expect(screen.getByLabelText('Chat Model')).toHaveValue(`${mockSettings.openai_chat_model}-Updated-2`);
     expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
 
     // Submit
@@ -87,8 +84,8 @@ describe('OpenAiSettingsPane component', () => {
     expect(vi.mocked(setCachedSetting).mock.calls[0]).toStrictEqual([
       'openai',
       {
-        api_key: `${mockSettings.openai.api_key}-Updated-1`,
-        chat_model: `${mockSettings.openai.chat_model}-Updated-2`,
+        api_key: `${mockSettings.openai_api_key}-Updated-1`,
+        chat_model: `${mockSettings.openai_chat_model}-Updated-2`,
         manner: 'scholarly',
         temperature: 0.9,
       },

--- a/src/features/components/RewriteWidget.tsx
+++ b/src/features/components/RewriteWidget.tsx
@@ -17,7 +17,10 @@ export function RewriteWidget({
   className?: string;
   onChoiceSelected?: (choice: string) => void;
 }) {
-  const openAiSettings = getCachedSetting('openai');
+  const openAiSettings = {
+    manner: getCachedSetting('openai_manner'),
+    temperature: getCachedSetting('openai_temperature'),
+  };
 
   const [rewriteOptions, setRewriteOptions] = useState<RewriteOptions>({
     nChoices: 3,

--- a/src/features/components/__tests__/RewriteWidget.test.tsx
+++ b/src/features/components/__tests__/RewriteWidget.test.tsx
@@ -1,10 +1,11 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 
+import { FlatSettingsSchema, RewriteMannerType } from '../../../api/api-types';
 import { askForRewrite, AskForRewriteReturn } from '../../../api/rewrite';
 import { RewriteOptions } from '../../../api/rewrite.config';
 import { emitEvent, RefStudioEventName } from '../../../events';
 import { noop } from '../../../lib/noop';
-import { getCachedSetting, OpenAiManner, SettingsSchema } from '../../../settings/settingsManager';
+import { getCachedSetting } from '../../../settings/settingsManager';
 import { render, setup } from '../../../test/test-utils';
 import { RewriteWidget } from '../../components/RewriteWidget';
 
@@ -18,24 +19,20 @@ vi.mock('../../../api/rewrite');
 vi.mock('../../../settings/settingsManager');
 vi.mock('../../../events');
 
-const mockSettings: Pick<SettingsSchema, 'openai'> = {
-  openai: {
-    chat_model: 'dont-care',
-    api_key: 'dont-care',
-    manner: 'elaborate',
-    temperature: 0.75,
-  },
-};
+const mockSettings = {
+  openai_chat_model: 'dont-care',
+  openai_api_key: 'dont-care',
+  openai_manner: 'elaborate',
+  openai_temperature: 0.75,
+} satisfies Partial<FlatSettingsSchema>;
 
 describe('RewriteWidget', () => {
   beforeEach(() => {
     vi.mocked(getCachedSetting).mockImplementation((key) => {
-      switch (key) {
-        case 'openai':
-          return mockSettings[key];
-        default:
-          throw new Error('UNEXPECTED CALL FOR KEY ' + key);
+      if (key in mockSettings) {
+        return mockSettings[key as keyof typeof mockSettings];
       }
+      throw new Error('UNEXPECTED CALL FOR KEY ' + key);
     });
   });
 
@@ -50,8 +47,8 @@ describe('RewriteWidget', () => {
 
   it('should display openAI settings by default', () => {
     render(<RewriteWidget selection={SELECTED_TEXT} onChoiceSelected={noop} />);
-    expect(screen.getByLabelText('creativity')).toHaveValue(String(mockSettings.openai.temperature));
-    expect(screen.getByLabelText('manner')).toHaveValue(mockSettings.openai.manner);
+    expect(screen.getByLabelText('creativity')).toHaveValue(String(mockSettings.openai_temperature));
+    expect(screen.getByLabelText('manner')).toHaveValue(mockSettings.openai_manner);
   });
 
   it('should configure openAI settings and call askForRewrite', async () => {
@@ -60,7 +57,7 @@ describe('RewriteWidget', () => {
     // https://github.com/testing-library/user-event/issues/871
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(screen.getByLabelText('creativity'), { target: { value: 0.85 } });
-    await user.selectOptions(screen.getByLabelText('manner'), 'scholarly' as OpenAiManner);
+    await user.selectOptions(screen.getByLabelText('manner'), 'scholarly' as RewriteMannerType);
 
     await user.click(screen.getByText('REWRITE'));
 

--- a/src/settings/panes/GeneralSettingsPane.tsx
+++ b/src/settings/panes/GeneralSettingsPane.tsx
@@ -1,15 +1,26 @@
 import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 
+import { FlatSettingsSchema } from '../../api/api-types';
 import { getCachedSetting, getSettings, saveCachedSettings, setCachedSetting } from '../settingsManager';
 import { SettingsPane, SettingsPaneProps } from './SettingsPane';
 
+type LoggingSettings = Pick<FlatSettingsSchema, 'logging_enabled' | 'logging_filepath'>;
+
+function getLoggingSettingsCached(): LoggingSettings {
+  return {
+    logging_enabled: getCachedSetting('logging_enabled'),
+    logging_filepath: getCachedSetting('logging_filepath'),
+  };
+}
+
 export function GeneralSettingsPane({ config }: SettingsPaneProps) {
-  const [sidecarLoggingSettings, setSidecarLoggingSettings] = useState(getCachedSetting('sidecar.logging'));
+  const [sidecarLoggingSettings, setSidecarLoggingSettings] = useState(getLoggingSettingsCached());
 
   const saveMutation = useMutation({
-    mutationFn: async (data: { sidecarLogging: typeof sidecarLoggingSettings }) => {
-      setCachedSetting('sidecar.logging', data.sidecarLogging);
+    mutationFn: async (data: { sidecarLogging: LoggingSettings }) => {
+      setCachedSetting('logging_enabled', data.sidecarLogging.logging_enabled);
+      setCachedSetting('logging_filepath', data.sidecarLogging.logging_filepath);
       await saveCachedSettings();
       return getSettings();
     },
@@ -20,7 +31,7 @@ export function GeneralSettingsPane({ config }: SettingsPaneProps) {
     saveMutation.mutate({ sidecarLogging: sidecarLoggingSettings });
   };
 
-  const isDirty = JSON.stringify(sidecarLoggingSettings) !== JSON.stringify(getCachedSetting('sidecar.logging'));
+  const isDirty = JSON.stringify(sidecarLoggingSettings) !== JSON.stringify(getLoggingSettingsCached());
 
   return (
     <SettingsPane config={config} header={config.title}>
@@ -32,12 +43,12 @@ export function GeneralSettingsPane({ config }: SettingsPaneProps) {
               Active
             </label>
             <input
-              checked={sidecarLoggingSettings.enable}
+              checked={sidecarLoggingSettings.logging_enabled}
               className="w-full border px-2 py-0.5"
               id="active"
               type="checkbox"
               onChange={(e) =>
-                setSidecarLoggingSettings({ ...sidecarLoggingSettings, enable: e.currentTarget.checked })
+                setSidecarLoggingSettings({ ...sidecarLoggingSettings, logging_enabled: e.currentTarget.checked })
               }
             />
           </div>
@@ -48,13 +59,14 @@ export function GeneralSettingsPane({ config }: SettingsPaneProps) {
             <input
               className="w-full border bg-slate-50 px-2 py-0.5"
               id="path"
-              value={sidecarLoggingSettings.filepath}
+              value={sidecarLoggingSettings.logging_filepath}
               onChange={(e) =>
-                setSidecarLoggingSettings({ ...sidecarLoggingSettings, filepath: e.currentTarget.value })
+                setSidecarLoggingSettings({ ...sidecarLoggingSettings, logging_filepath: e.currentTarget.value })
               }
             />
             <p className="text-xs text-gray-500">
-              The log filename can be located in <code>{sidecarLoggingSettings.filepath}/refstudio-sidecar.log</code>.
+              The log filename can be located in{' '}
+              <code>{sidecarLoggingSettings.logging_filepath}/refstudio-sidecar.log</code>.
             </p>
           </div>
         </fieldset>

--- a/src/settings/panes/__tests__/DebugSettingsPane.test.tsx
+++ b/src/settings/panes/__tests__/DebugSettingsPane.test.tsx
@@ -29,7 +29,6 @@ describe('DebugSettingsPane component', () => {
     // Fake settings methods
     vi.mocked(initSettings).mockResolvedValue();
     vi.mocked(saveCachedSettings).mockResolvedValue();
-    // eslint-disable-next-line
     vi.mocked(getSettings).mockResolvedValue({
       default: mockSettings,
     } as SettingsManagerView<FlatSettingsSchema>);

--- a/src/settings/panes/__tests__/DebugSettingsPane.test.tsx
+++ b/src/settings/panes/__tests__/DebugSettingsPane.test.tsx
@@ -1,7 +1,6 @@
-import { SettingsManager } from 'tauri-settings';
-
+import { FlatSettingsSchema } from '../../../api/api-types';
 import { render, screen } from '../../../test/test-utils';
-import { getSettings, initSettings, saveCachedSettings, SettingsSchema } from '../../settingsManager';
+import { getSettings, initSettings, saveCachedSettings, SettingsManagerView } from '../../settingsManager';
 import { PaneConfig } from '../../types';
 import { DebugSettingsPane } from '../DebugSettingsPane';
 import { GeneralSettingsPane } from '../GeneralSettingsPane';
@@ -15,22 +14,14 @@ const panelConfig: PaneConfig = {
   title: 'OPEN AI',
 };
 
-const mockSettings: SettingsSchema = {
-  project: {
-    current_directory: 'app-dir',
-  },
-  openai: {
-    api_key: '',
-    chat_model: 'gpt-3.5-turbo',
-    manner: 'concise',
-    temperature: 0.7,
-  },
-  sidecar: {
-    logging: {
-      enable: true,
-      filepath: '/tmp',
-    },
-  },
+const mockSettings: FlatSettingsSchema = {
+  current_directory: 'app-dir',
+  openai_api_key: '',
+  openai_chat_model: 'gpt-3.5-turbo',
+  openai_manner: 'concise',
+  openai_temperature: 0.7,
+  logging_enabled: true,
+  logging_filepath: '/tmp',
 };
 
 describe('DebugSettingsPane component', () => {
@@ -41,7 +32,7 @@ describe('DebugSettingsPane component', () => {
     // eslint-disable-next-line
     vi.mocked(getSettings).mockResolvedValue({
       default: mockSettings,
-    } as SettingsManager<SettingsSchema>);
+    } as SettingsManagerView<FlatSettingsSchema>);
   });
 
   afterEach(() => {

--- a/src/settings/panes/__tests__/GeneralSettingsPane.test.tsx
+++ b/src/settings/panes/__tests__/GeneralSettingsPane.test.tsx
@@ -67,7 +67,9 @@ describe('GeneralSettingsPane component', () => {
 
     // Submit
     await user.click(screen.getByRole('button', { name: /save/i }));
-    expect(setCachedSetting).toBeCalledTimes(1);
+    expect(setCachedSetting).toBeCalledTimes(2);
+    expect(setCachedSetting).toHaveBeenNthCalledWith(1, 'logging_enabled', false);
+    expect(setCachedSetting).toHaveBeenNthCalledWith(2, 'logging_filepath', 'PATH-Updated-2');
     expect(saveCachedSettings).toBeCalledTimes(1);
   });
 });

--- a/src/settings/panes/__tests__/GeneralSettingsPane.test.tsx
+++ b/src/settings/panes/__tests__/GeneralSettingsPane.test.tsx
@@ -1,12 +1,7 @@
+import { FlatSettingsSchema } from '../../../api/api-types';
 import { noop } from '../../../lib/noop';
 import { render, screen, userEvent } from '../../../test/test-utils';
-import {
-  getCachedSetting,
-  initSettings,
-  saveCachedSettings,
-  setCachedSetting,
-  SettingsSchema,
-} from '../../settingsManager';
+import { getCachedSetting, initSettings, saveCachedSettings, setCachedSetting } from '../../settingsManager';
 import { PaneConfig } from '../../types';
 import { GeneralSettingsPane } from '../GeneralSettingsPane';
 
@@ -19,17 +14,11 @@ const panelConfig: PaneConfig = {
   title: 'OPEN AI',
 };
 
-const mockSettings: Pick<SettingsSchema, 'project' | 'sidecar'> = {
-  project: {
-    current_directory: 'APP-DATA-DIR',
-  },
-  sidecar: {
-    logging: {
-      enable: true,
-      filepath: 'PATH',
-    },
-  },
-};
+const mockSettings = {
+  current_directory: 'APP-DATA-DIR',
+  logging_enabled: true,
+  logging_filepath: 'PATH',
+} satisfies Partial<FlatSettingsSchema>;
 
 describe('GeneralSettingsPane component', () => {
   beforeEach(() => {
@@ -37,14 +26,10 @@ describe('GeneralSettingsPane component', () => {
     vi.mocked(initSettings).mockResolvedValue();
     vi.mocked(saveCachedSettings).mockResolvedValue();
     vi.mocked(getCachedSetting).mockImplementation((key) => {
-      switch (key) {
-        case 'project':
-          return mockSettings.project;
-        case 'sidecar.logging':
-          return mockSettings.sidecar.logging;
-        default:
-          throw new Error('UNEXPECTED CALL FOR KEY ' + key);
+      if (key in mockSettings) {
+        return mockSettings[key as keyof typeof mockSettings];
       }
+      throw new Error('UNEXPECTED CALL FOR KEY ' + key);
     });
     vi.mocked(setCachedSetting).mockImplementation(noop);
   });
@@ -64,7 +49,7 @@ describe('GeneralSettingsPane component', () => {
 
     expect(getCachedSettingMock.mock.calls.length).toBeGreaterThan(0);
     expect(screen.getByLabelText('Active')).toBeChecked();
-    expect(screen.getByLabelText('Path')).toHaveValue(mockSettings.sidecar.logging.filepath);
+    expect(screen.getByLabelText('Path')).toHaveValue(mockSettings.logging_filepath);
   });
 
   it('should save (setCached, flush) with edited values on save', async () => {
@@ -77,7 +62,7 @@ describe('GeneralSettingsPane component', () => {
     await user.click(screen.getByLabelText('Active'));
     await user.type(screen.getByLabelText('Path'), '-Updated-2');
     expect(screen.getByLabelText('Active')).not.toBeChecked();
-    expect(screen.getByLabelText('Path')).toHaveValue(`${mockSettings.sidecar.logging.filepath}-Updated-2`);
+    expect(screen.getByLabelText('Path')).toHaveValue(`${mockSettings.logging_filepath}-Updated-2`);
     expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
 
     // Submit

--- a/yarn.lock
+++ b/yarn.lock
@@ -6838,7 +6838,6 @@ __metadata:
     react-popper: ^2.3.0
     react-resizable-panels: ^0.0.51
     tailwindcss: ^3.3.2
-    tauri-settings: ^0.3.2
     tiptap-markdown: ^0.7.2
     turndown: ^7.1.2
     typescript: ^4.9.5
@@ -7533,13 +7532,6 @@ __metadata:
     mkdirp: ^1.0.3
     yallist: ^4.0.0
   checksum: f23832fceeba7578bf31907aac744ae21e74a66f4a17a9e94507acf460e48f6db598c7023882db33bab75b80e027c21f276d405e4a0322d58f51c7088d428268
-  languageName: node
-  linkType: hard
-
-"tauri-settings@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "tauri-settings@npm:0.3.2"
-  checksum: 9c108deaad1a18ed9f1bd4262602efdae6d4d0a18f7eb0859c64f30f9247816a4cc463a731e601dd521670d8090387bbad5bee6fc28f9db0a21d9a620b2d04be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This solves the problem with optional fields in `SettingsSchema` in TypeScript.

In general I think we should avoid specifying default values in Pydantic models that are part of the HTTP API because the semantics are unclear. If you have something like:

```py
class Settings(RefStudioModel):
    a: str = 'alice'
    b: str = 'bob'

@settings_api.put("/")
async def update_settings(req: SettingsSchema) -> SettingsSchema:
    ...
```

Then if the users hits the PUT endpoint with `{"a": "archer"}`, presumably their intention is to just set "a" to "archer" and not also set "b" to "bob".

Highlights:

- I "flattened" the settings schema like we talked about last week. The new model is `FlatSettingsSchema` and it has no `Optional` fields or fields with default values.
- I found [this decorator][1] to be the best way to make an all-optional version of a Pydantic model. This is like `Partial<T>` in TypeScript. I used this to define a `FlatSettingsSchemaPatch` model. This might be a useful pattern going forward. But if the update type is something more complicated (say you want to drop an `id` field that can't be updated) then maybe just writing out the two models explicitly is the way to go.
- Since the `settings.json` format has changed, I wrote a migration function.
- With a flat settings structure, the `getDotNotation` from `tauri-settings` isn't useful anymore and we can replace it with something much simpler. In fact, we can get rid of `tauri-settings` altogether! 🎉 

[1]: https://stackoverflow.com/a/74296358/388951