### PR TITLE
Port a few more endpoints to the typed API

### DIFF
--- a/python/api.schema.json
+++ b/python/api.schema.json
@@ -494,22 +494,6 @@
       "type": "object",
       "title": "S2SearchResult"
     },
-    "SearchRequest": {
-      "properties": {
-        "query": {
-          "type": "string"
-        },
-        "limit": {
-          "type": "integer",
-          "default": 10
-        }
-      },
-      "type": "object",
-      "required": [
-        "query"
-      ],
-      "title": "SearchRequest"
-    },
     "SearchResponse": {
       "properties": {
         "status": {

--- a/python/api.schema.json
+++ b/python/api.schema.json
@@ -547,6 +547,21 @@
       ],
       "title": "Body_create_file__project_id___filepath__put"
     },
+    "ProjectCreateRequest": {
+      "properties": {
+        "project_name": {
+          "type": "string"
+        },
+        "project_path": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "project_name"
+      ],
+      "title": "ProjectCreateRequest"
+    },
     "FlatSettingsSchema": {
       "properties": {
         "current_directory": {

--- a/python/api.schema.json
+++ b/python/api.schema.json
@@ -79,6 +79,12 @@
       ],
       "title": "DeleteStatusResponse"
     },
+    "EmptyRequest": {
+      "properties": {},
+      "type": "object",
+      "title": "EmptyRequest",
+      "description": "Use this to indicate that a request only accepts an empty object ({})"
+    },
     "HTTPValidationError": {
       "properties": {
         "detail": {
@@ -91,6 +97,25 @@
       },
       "type": "object",
       "title": "HTTPValidationError"
+    },
+    "IngestResponse": {
+      "properties": {
+        "project_name": {
+          "type": "string"
+        },
+        "references": {
+          "items": {
+            "$ref": "#/definitions/Reference"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "project_name",
+        "references"
+      ],
+      "title": "IngestResponse"
     },
     "IngestStatus": {
       "type": "string",

--- a/python/openapi.json
+++ b/python/openapi.json
@@ -469,22 +469,6 @@
         "title": "S2SearchResult",
         "type": "object"
       },
-      "SearchRequest": {
-        "properties": {
-          "limit": {
-            "default": 10,
-            "type": "integer"
-          },
-          "query": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "query"
-        ],
-        "title": "SearchRequest",
-        "type": "object"
-      },
       "SearchResponse": {
         "properties": {
           "message": {
@@ -1438,18 +1422,28 @@
       }
     },
     "/api/search/s2": {
-      "post": {
-        "operationId": "http_search_s2_s2_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SearchRequest"
-              }
+      "get": {
+        "operationId": "http_search_s2_s2_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "required": true,
+            "schema": {
+              "title": "Query",
+              "type": "string"
             }
           },
-          "required": true
-        },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "title": "Limit"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {

--- a/python/openapi.json
+++ b/python/openapi.json
@@ -1053,6 +1053,16 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmptyRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {

--- a/python/openapi.json
+++ b/python/openapi.json
@@ -264,6 +264,21 @@
         "title": "IngestStatus",
         "type": "string"
       },
+      "ProjectCreateRequest": {
+        "properties": {
+          "project_name": {
+            "type": "string"
+          },
+          "project_path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "project_name"
+        ],
+        "title": "ProjectCreateRequest",
+        "type": "object"
+      },
       "Reference": {
         "description": "A reference for an academic paper / PDF",
         "properties": {
@@ -985,33 +1000,13 @@
         "summary": "List Projects"
       },
       "post": {
-        "description": "Creates a project directory in the filesystem\n\nParameters\n----------\nproject_name : str\n    The name of the project\nproject_path : str\n    The path to the project directory. Only necessary for Desktop.\n    For web, the project is stored in a private directory on the server.",
+        "description": "Creates a project, and a directory in the filesystem",
         "operationId": "create_project__post",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "project_name",
-            "required": true,
-            "schema": {
-              "title": "Project Name",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "project_path",
-            "required": false,
-            "schema": {
-              "title": "Project Path",
-              "type": "string"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/EmptyRequest"
+                "$ref": "#/components/schemas/ProjectCreateRequest"
               }
             }
           },

--- a/python/openapi.json
+++ b/python/openapi.json
@@ -153,6 +153,12 @@
         "title": "DeleteStatusResponse",
         "type": "object"
       },
+      "EmptyRequest": {
+        "description": "Use this to indicate that a request only accepts an empty object ({})",
+        "properties": {},
+        "title": "EmptyRequest",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -164,6 +170,25 @@
           }
         },
         "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "IngestResponse": {
+        "properties": {
+          "project_name": {
+            "type": "string"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "project_name",
+          "references"
+        ],
+        "title": "IngestResponse",
         "type": "object"
       },
       "IngestStatus": {
@@ -1219,11 +1244,23 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmptyRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/IngestResponse"
+                }
               }
             },
             "description": "Successful Response"

--- a/python/sidecar/http.py
+++ b/python/sidecar/http.py
@@ -13,11 +13,11 @@ from sidecar.typing import (
     ChatResponse,
     DeleteRequest,
     DeleteStatusResponse,
+    EmptyRequest,
     IngestRequest,
     IngestResponse,
     Reference,
     ReferencePatch,
-    RefStudioModel,
     RewriteRequest,
     RewriteResponse,
     SearchRequest,
@@ -101,7 +101,7 @@ async def list_references(project_id: str) -> list[Reference]:
 
 
 @references_api.post("/{project_id}")
-async def ingest_references(project_id: str, payload: RefStudioModel) -> IngestResponse:
+async def ingest_references(project_id: str, payload: EmptyRequest) -> IngestResponse:
     """
     Ingests references from PDFs in the project uploads directory
     """
@@ -334,4 +334,5 @@ async def get_settings() -> SettingsSchema:
 @settings_api.put("/")
 async def update_settings(req: SettingsSchema) -> SettingsSchema:
     user_id = "user1"
+    return settings.update_settings_for_user(user_id, req)
     return settings.update_settings_for_user(user_id, req)

--- a/python/sidecar/http.py
+++ b/python/sidecar/http.py
@@ -23,7 +23,6 @@ from sidecar.typing import (
     ReferencePatch,
     RewriteRequest,
     RewriteResponse,
-    SearchRequest,
     SearchResponse,
     TextCompletionRequest,
     TextCompletionResponse,
@@ -45,9 +44,9 @@ meta_api = FastAPI()
 
 # Search API
 # --------------
-@search_api.post("/s2")
-async def http_search_s2(req: SearchRequest) -> SearchResponse:
-    response = search.search_s2(req)
+@search_api.get("/s2")
+async def http_search_s2(query: str, limit=10) -> SearchResponse:
+    response = search.search_s2(query, limit)
     return response
 
 

--- a/python/sidecar/http.py
+++ b/python/sidecar/http.py
@@ -14,8 +14,10 @@ from sidecar.typing import (
     DeleteRequest,
     DeleteStatusResponse,
     IngestRequest,
+    IngestResponse,
     Reference,
     ReferencePatch,
+    RefStudioModel,
     RewriteRequest,
     RewriteResponse,
     SearchRequest,
@@ -99,7 +101,7 @@ async def list_references(project_id: str) -> list[Reference]:
 
 
 @references_api.post("/{project_id}")
-async def ingest_references(project_id: str):
+async def ingest_references(project_id: str, payload: RefStudioModel) -> IngestResponse:
     """
     Ingests references from PDFs in the project uploads directory
     """

--- a/python/sidecar/http.py
+++ b/python/sidecar/http.py
@@ -18,6 +18,7 @@ from sidecar.typing import (
     FlatSettingsSchemaPatch,
     IngestRequest,
     IngestResponse,
+    ProjectCreateRequest,
     Reference,
     ReferencePatch,
     RewriteRequest,
@@ -169,28 +170,18 @@ async def list_projects():
 
 
 @project_api.post("/")
-async def create_project(
-    payload: EmptyRequest, project_name: str, project_path: str = None
-):
+async def create_project(req: ProjectCreateRequest):
     """
-    Creates a project directory in the filesystem
-
-    Parameters
-    ----------
-    project_name : str
-        The name of the project
-    project_path : str
-        The path to the project directory. Only necessary for Desktop.
-        For web, the project is stored in a private directory on the server.
+    Creates a project, and a directory in the filesystem
     """
     user_id = "user1"
     project_id = str(uuid4())
     project_path = projects.create_project(
-        user_id, project_id, project_name, project_path
+        user_id, project_id, req.project_name, req.project_path
     )
     return {
         project_id: {
-            "project_name": project_name,
+            "project_name": req.project_name,
             "project_path": project_path,
         }
     }

--- a/python/sidecar/http.py
+++ b/python/sidecar/http.py
@@ -168,7 +168,9 @@ async def list_projects():
 
 
 @project_api.post("/")
-async def create_project(project_name: str, project_path: str = None):
+async def create_project(
+    payload: EmptyRequest, project_name: str, project_path: str = None
+):
     """
     Creates a project directory in the filesystem
 

--- a/python/sidecar/search.py
+++ b/python/sidecar/search.py
@@ -8,7 +8,7 @@ import logging
 from semanticscholar import SemanticScholar
 
 from .stopwords import stopwords
-from .typing import ResponseStatus, S2SearchResult, SearchRequest, SearchResponse
+from .typing import ResponseStatus, S2SearchResult, SearchResponse
 
 logger = logging.getLogger(__name__)
 
@@ -103,9 +103,7 @@ class Searcher:
         )
 
 
-def search_s2(request: SearchRequest):
-    query = request.query
-    limit = request.limit
+def search_s2(query: str, limit: int = 10) -> SearchResponse:
     searcher = Searcher()
     response = searcher.search_func(query, limit=limit)
     return response

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -29,6 +29,12 @@ class RefStudioModel(BaseModel):
                 prop.pop("title", None)
 
 
+class EmptyRequest(RefStudioModel):
+    """Use this to indicate that a request only accepts an empty object ({})"""
+
+    pass
+
+
 class ResponseStatus(StrEnum):
     OK = "ok"
     ERROR = "error"

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -223,6 +223,16 @@ class OpenAISettings(RefStudioModel):
     temperature: float = 0.7
 
 
+class ProjectCreateRequest(RefStudioModel):
+    project_name: str
+    """The name of the project"""
+    project_path: str = None
+    """
+    The path to the project directory. Only necessary for Desktop.
+    For web, the project is stored in a private directory on the server.
+    """
+
+
 class ProjectSettings(RefStudioModel):
     current_directory: str = ""
 

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -380,7 +380,7 @@ def test_create_project(monkeypatch, tmp_path):
     monkeypatch.setattr(projects.settings, "WEB_STORAGE_URL", tmp_path)
 
     params = {"project_name": "project1name"}
-    response = project_client.post("/", params=params)
+    response = project_client.post("/", params=params, json={})
 
     project_id = list(response.json().keys())[0]
     assert response.status_code == 200

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -319,8 +319,8 @@ def test_ai_chat_missing_required_request_params(
 def test_search_s2_is_ok(monkeypatch, mock_search_paper):
     monkeypatch.setattr(search.Searcher, "search_func", mock_search_paper)
 
-    request = {"query": "any-query-string-you-like"}
-    response = search_client.post("/s2", json=request)
+    params = {"query": "any-query-string-you-like"}
+    response = search_client.get("/s2", params=params)
 
     assert response.status_code == 200
     assert response.json() == {
@@ -379,8 +379,8 @@ def test_http_list_projects(monkeypatch, tmp_path):
 def test_create_project(monkeypatch, tmp_path):
     monkeypatch.setattr(projects.settings, "WEB_STORAGE_URL", tmp_path)
 
-    params = {"project_name": "project1name"}
-    response = project_client.post("/", params=params, json={})
+    request = {"project_name": "project1name"}
+    response = project_client.post("/", json=request)
 
     project_id = list(response.json().keys())[0]
     assert response.status_code == 200

--- a/python/tests/test_search.py
+++ b/python/tests/test_search.py
@@ -1,11 +1,10 @@
 from sidecar import search
-from sidecar.typing import SearchRequest
 
 
 def test_search(monkeypatch, mock_search_paper):
     monkeypatch.setattr(search.Searcher, "search_func", mock_search_paper)
 
-    response = search.search_s2(SearchRequest(query="any-query-string-you-like"))
+    response = search.search_s2(query="any-query-string-you-like")
     output = response.dict()
 
     assert len(output["results"]) == 2

--- a/src/api/__tests__/ingestion.ingest.test.ts
+++ b/src/api/__tests__/ingestion.ingest.test.ts
@@ -19,7 +19,7 @@ describe('ingestion.ingest', () => {
 
     await runPDFIngestion(PROJECT_ID);
     expect(universalPost).toHaveBeenCalledTimes(1);
-    expect(universalPost).toHaveBeenCalledWith(`/api/references/${PROJECT_ID}`);
+    expect(universalPost).toHaveBeenCalledWith(`/api/references/${PROJECT_ID}`, {});
   });
 
   it('Should map empty IngestResponse[] to empty ReferenceItem[]', async () => {

--- a/src/api/__tests__/typed-api.test.ts
+++ b/src/api/__tests__/typed-api.test.ts
@@ -1,5 +1,5 @@
-import { universalGet, universalPost } from '../api';
-import { apiGetJson, apiPost } from '../typed-api';
+import { universalGet } from '../api';
+import { apiGetJson } from '../typed-api';
 
 vi.mock('../api');
 
@@ -17,43 +17,21 @@ describe('Typed API', () => {
     expect(universalGet).toHaveBeenCalledWith('/api/fs/abc/foo/bar.txt', undefined);
   });
 
-  it('should issue POST requests with query parameters', async () => {
-    vi.mocked(universalPost).mockResolvedValueOnce({
-      abc: { project_name: 'abc', project_path: '/path/to/project' },
-    });
-    const response = await apiPost(
-      '/api/projects/',
-      {
-        query: {
-          project_name: 'abc',
-        },
+  it('should issue GET requests with query parameters', async () => {
+    await apiGetJson('/api/search/s2', {
+      query: {
+        query: 'text',
       },
-      // TODO: update request body type for this endpoint
-      {} as unknown as never,
-    );
-    expect(response).toEqual({
-      abc: { project_name: 'abc', project_path: '/path/to/project' },
     });
-    expect(universalPost).toHaveBeenCalledWith('/api/projects/?project_name=abc', {});
+    expect(universalGet).toHaveBeenCalledWith('/api/search/s2?query=text', undefined);
   });
 
   it('should escape query parameters', async () => {
-    vi.mocked(universalPost).mockResolvedValueOnce({
-      'a&b/c': { project_name: 'a&b/c', project_path: '/path/to/project' },
-    });
-    const response = await apiPost(
-      '/api/projects/',
-      {
-        query: {
-          project_name: 'a&b/c',
-        },
+    await apiGetJson('/api/search/s2', {
+      query: {
+        query: 'joe & ana',
       },
-      // TODO: update request body type for this endpoint
-      {} as unknown as never,
-    );
-    expect(response).toEqual({
-      'a&b/c': { project_name: 'a&b/c', project_path: '/path/to/project' },
     });
-    expect(universalPost).toHaveBeenCalledWith('/api/projects/?project_name=a%26b%2Fc', {});
+    expect(universalGet).toHaveBeenCalledWith('/api/search/s2?query=joe+%26+ana', undefined);
   });
 });

--- a/src/api/api-paths.ts
+++ b/src/api/api-paths.ts
@@ -639,6 +639,11 @@ export interface operations {
         project_path?: string;
       };
     };
+    requestBody: {
+      content: {
+        'application/json': EmptyRequest;
+      };
+    };
     responses: {
       /** @description Successful Response */
       200: {

--- a/src/api/api-paths.ts
+++ b/src/api/api-paths.ts
@@ -9,7 +9,9 @@ import {
   Chunk,
   DeleteRequest,
   DeleteStatusResponse,
+  EmptyRequest,
   HTTPValidationError,
+  IngestResponse,
   IngestStatus,
   LoggingSettings,
   OpenAISettings,
@@ -198,10 +200,20 @@ export interface components {
       message: string;
       status: ResponseStatus;
     };
+    /**
+     * EmptyRequest
+     * @description Use this to indicate that a request only accepts an empty object ({})
+     */
+    EmptyRequest: Record<string, never>;
     /** HTTPValidationError */
     HTTPValidationError: {
       /** Detail */
       detail?: ValidationError[];
+    };
+    /** IngestResponse */
+    IngestResponse: {
+      project_name: string;
+      references: Reference[];
     };
     /**
      * IngestStatus
@@ -749,11 +761,16 @@ export interface operations {
         project_id: string;
       };
     };
+    requestBody: {
+      content: {
+        'application/json': EmptyRequest;
+      };
+    };
     responses: {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': unknown;
+          'application/json': IngestResponse;
         };
       };
       /** @description Validation Error */

--- a/src/api/api-paths.ts
+++ b/src/api/api-paths.ts
@@ -15,6 +15,7 @@ import {
   HTTPValidationError,
   IngestResponse,
   IngestStatus,
+  ProjectCreateRequest,
   Reference,
   ReferencePatch,
   ResponseStatus,
@@ -76,15 +77,7 @@ export interface paths {
     get: operations['list_projects__get'];
     /**
      * Create Project
-     * @description Creates a project directory in the filesystem
-     *
-     * Parameters
-     * ----------
-     * project_name : str
-     *     The name of the project
-     * project_path : str
-     *     The path to the project directory. Only necessary for Desktop.
-     *     For web, the project is stored in a private directory on the server.
+     * @description Creates a project, and a directory in the filesystem
      */
     post: operations['create_project__post'];
   };
@@ -238,6 +231,11 @@ export interface components {
      * @enum {string}
      */
     IngestStatus: 'processing' | 'failure' | 'complete';
+    /** ProjectCreateRequest */
+    ProjectCreateRequest: {
+      project_name: string;
+      project_path?: string;
+    };
     /**
      * Reference
      * @description A reference for an academic paper / PDF
@@ -579,26 +577,12 @@ export interface operations {
   };
   /**
    * Create Project
-   * @description Creates a project directory in the filesystem
-   *
-   * Parameters
-   * ----------
-   * project_name : str
-   *     The name of the project
-   * project_path : str
-   *     The path to the project directory. Only necessary for Desktop.
-   *     For web, the project is stored in a private directory on the server.
+   * @description Creates a project, and a directory in the filesystem
    */
   create_project__post: {
-    parameters: {
-      query: {
-        project_name: string;
-        project_path?: string;
-      };
-    };
     requestBody: {
       content: {
-        'application/json': EmptyRequest;
+        'application/json': ProjectCreateRequest;
       };
     };
     responses: {

--- a/src/api/api-paths.ts
+++ b/src/api/api-paths.ts
@@ -24,7 +24,6 @@ import {
   RewriteRequest,
   RewriteResponse,
   S2SearchResult,
-  SearchRequest,
   SearchResponse,
   TextCompletionChoice,
   TextCompletionRequest,
@@ -123,7 +122,7 @@ export interface paths {
   };
   '/api/search/s2': {
     /** Http Search S2 */
-    post: operations['http_search_s2_s2_post'];
+    get: operations['http_search_s2_s2_get'];
   };
   '/api/settings/': {
     /** Get Settings */
@@ -308,12 +307,6 @@ export interface components {
       title?: string;
       venue?: string;
       year?: number;
-    };
-    /** SearchRequest */
-    SearchRequest: {
-      /** @default 10 */
-      limit?: number;
-      query: string;
     };
     /** SearchResponse */
     SearchResponse: {
@@ -829,10 +822,11 @@ export interface operations {
     };
   };
   /** Http Search S2 */
-  http_search_s2_s2_post: {
-    requestBody: {
-      content: {
-        'application/json': SearchRequest;
+  http_search_s2_s2_get: {
+    parameters: {
+      query: {
+        query: string;
+        limit?: unknown;
       };
     };
     responses: {

--- a/src/api/api-types.ts
+++ b/src/api/api-types.ts
@@ -260,6 +260,14 @@ export interface BodyCreateFile_ProjectId__Filepath_Put {
 }
 /**
  * This interface was referenced by `ApiSchema`'s JSON-Schema
+ * via the `definition` "ProjectCreateRequest".
+ */
+export interface ProjectCreateRequest {
+  project_name: string;
+  project_path?: string;
+}
+/**
+ * This interface was referenced by `ApiSchema`'s JSON-Schema
  * via the `definition` "FlatSettingsSchema".
  */
 export interface FlatSettingsSchema {

--- a/src/api/api-types.ts
+++ b/src/api/api-types.ts
@@ -71,6 +71,13 @@ export interface DeleteStatusResponse {
   message: string;
 }
 /**
+ * Use this to indicate that a request only accepts an empty object ({})
+ *
+ * This interface was referenced by `ApiSchema`'s JSON-Schema
+ * via the `definition` "EmptyRequest".
+ */
+export interface EmptyRequest {}
+/**
  * This interface was referenced by `ApiSchema`'s JSON-Schema
  * via the `definition` "HTTPValidationError".
  */
@@ -85,6 +92,14 @@ export interface ValidationError {
   loc: Location;
   msg: Message;
   type: ErrorType;
+}
+/**
+ * This interface was referenced by `ApiSchema`'s JSON-Schema
+ * via the `definition` "IngestResponse".
+ */
+export interface IngestResponse {
+  project_name: string;
+  references: Reference[];
 }
 /**
  * A reference for an academic paper / PDF

--- a/src/api/api-types.ts
+++ b/src/api/api-types.ts
@@ -236,14 +236,6 @@ export interface S2SearchResult {
 }
 /**
  * This interface was referenced by `ApiSchema`'s JSON-Schema
- * via the `definition` "SearchRequest".
- */
-export interface SearchRequest {
-  query: string;
-  limit?: number;
-}
-/**
- * This interface was referenced by `ApiSchema`'s JSON-Schema
  * via the `definition` "SearchResponse".
  */
 export interface SearchResponse {

--- a/src/api/ingestion.ts
+++ b/src/api/ingestion.ts
@@ -1,10 +1,8 @@
 import { makeUploadPath } from '../io/filesystem';
 import { ReferenceItem } from '../types/ReferenceItem';
-import { universalGet } from './api';
-import { DeleteStatusResponse } from './api-types';
 import { callSidecar } from './sidecar';
-import { apiPatch, apiPost } from './typed-api';
-import { IngestResponse, Reference } from './types';
+import { apiGetJson, apiPatch, apiPost } from './typed-api';
+import { Reference } from './types';
 
 function parsePdfIngestionResponse(references: Reference[]): ReferenceItem[] {
   return references.map((reference) => ({
@@ -25,17 +23,24 @@ function parsePdfIngestionResponse(references: Reference[]): ReferenceItem[] {
 }
 
 export async function runPDFIngestion(projectId: string): Promise<ReferenceItem[]> {
-  // const ingestResponse = await universalPost<IngestResponse>(`/api/references/${projectId}`);
-  const ingestResponse = (await apiPost('/api/references/{project_id}', {
-    path: { project_id: projectId },
-  })) as IngestResponse;
+  const ingestResponse = await apiPost(
+    '/api/references/{project_id}',
+    {
+      path: { project_id: projectId },
+    },
+    {},
+  );
   return parsePdfIngestionResponse(ingestResponse.references);
 }
 
 export async function removeReferences(ids: string[], projectId: string) {
-  const status = await universalPost<DeleteStatusResponse>(`/api/references/${projectId}/bulk_delete`, {
-    reference_ids: ids,
-  });
+  const status = await apiPost(
+    '/api/references/{project_id}/bulk_delete',
+    { path: { project_id: projectId } },
+    {
+      reference_ids: ids,
+    },
+  );
   if (status.status !== 'ok') {
     throw new Error(status.message);
   }
@@ -76,7 +81,7 @@ export async function updateReference(projectId: string, referenceId: string, pa
 }
 
 export async function getIngestedReferences(projectId: string): Promise<ReferenceItem[]> {
-  const references = await universalGet<Reference[]>(`/api/references/${projectId}`);
+  const references = await apiGetJson('/api/references/{project_id}', { path: { project_id: projectId } });
   return parsePdfIngestionResponse(references);
 }
 

--- a/src/api/projectsAPI.ts
+++ b/src/api/projectsAPI.ts
@@ -38,11 +38,10 @@ export async function readProjectById(projectId: string): Promise<ProjectInfo> {
 }
 
 export async function createRemoteProject(projectName: string, projectPath?: string): Promise<ProjectInfo> {
-  const payload = (await apiPost(
-    '/api/projects/',
-    { query: { project_name: projectName, project_path: projectPath } },
-    {},
-  )) as ProjectPostResponse;
+  const payload = (await apiPost('/api/projects/', {
+    project_name: projectName,
+    project_path: projectPath,
+  })) as ProjectPostResponse;
 
   const projectId = Object.keys(payload)[0];
   const { project_path, project_name } = payload[projectId];

--- a/src/api/typed-api.ts
+++ b/src/api/typed-api.ts
@@ -1,6 +1,6 @@
 /** Type-safe access to the RefStudio HTTP APIs. */
 
-import { universalGet, universalPost } from './api';
+import { universalDelete, universalGet, universalPatch, universalPost, universalPut } from './api';
 import type { paths } from './api-paths';
 
 type LowerMethod = 'get' | 'post' | 'put' | 'delete' | 'patch';
@@ -78,7 +78,6 @@ function completePath(path: string, params: RouteParameters) {
 export async function apiGetJson<Path extends PathsForMethod<'get'>>(pathSpec: Path, ...args: PathArgs<Path, 'get'>) {
   const options = (args as unknown[])[0] as RouteParameters | undefined;
   const path = options ? completePath(pathSpec, options) : pathSpec;
-  console.log('apiGetJSON', pathSpec, path);
   type ResponseType = JsonResponseFor<Path, 'get'>;
   return universalGet<ResponseType>(path, undefined);
 }
@@ -96,7 +95,55 @@ export async function apiPost<Path extends PathsForMethod<'post'>>(
   const safeArgs = args as unknown as [params: RouteParameters, body: unknown] | [body: unknown];
   const [options, body] = safeArgs.length === 2 ? safeArgs : [undefined, ...safeArgs];
   const path = options ? completePath(pathSpec, options) : pathSpec;
-  console.log('apiPostJSON', pathSpec, path);
   type ResponseType = JsonResponseFor<Path, 'post'>;
   return universalPost<ResponseType>(path, body);
+}
+
+/**
+ * Issue a PUT request with a JSON payload to a RefStudio API endpoint.
+ *
+ * If the endpoint takes path parameters or search parameters, then that will be the second argument.
+ * The last argument (2nd or 3rd argument) is the request body.
+ */
+export async function apiPut<Path extends PathsForMethod<'put'>>(
+  pathSpec: Path,
+  ...args: [...params: PathArgs<Path, 'put'>, body: JsonRequestBodyFor<Path, 'put'>]
+) {
+  const safeArgs = args as unknown as [params: RouteParameters, body: unknown] | [body: unknown];
+  const [options, body] = safeArgs.length === 2 ? safeArgs : [undefined, ...safeArgs];
+  const path = options ? completePath(pathSpec, options) : pathSpec;
+  type ResponseType = JsonResponseFor<Path, 'post'>;
+  return universalPut<ResponseType>(path, body);
+}
+
+/**
+ * Issue a PATCH request with a JSON payload to a RefStudio API endpoint.
+ *
+ * If the endpoint takes path parameters or search parameters, then that will be the second argument.
+ * The last argument (2nd or 3rd argument) is the request body.
+ */
+export async function apiPatch<Path extends PathsForMethod<'patch'>>(
+  pathSpec: Path,
+  ...args: [...params: PathArgs<Path, 'patch'>, body: JsonRequestBodyFor<Path, 'patch'>]
+) {
+  const safeArgs = args as unknown as [params: RouteParameters, body: unknown] | [body: unknown];
+  const [options, body] = safeArgs.length === 2 ? safeArgs : [undefined, ...safeArgs];
+  const path = options ? completePath(pathSpec, options) : pathSpec;
+  type ResponseType = JsonResponseFor<Path, 'patch'>;
+  return universalPatch<ResponseType>(path, body);
+}
+
+/**
+ * Issue a DELETE request to a RefStudio API endpoint.
+ *
+ * If the endpoint has path parameters or allows search parameters, then this will take a second argument.
+ */
+export async function apiDelete<Path extends PathsForMethod<'delete'>>(
+  pathSpec: Path,
+  ...args: PathArgs<Path, 'delete'>
+) {
+  const options = (args as unknown[])[0] as RouteParameters | undefined;
+  const path = options ? completePath(pathSpec, options) : pathSpec;
+  type ResponseType = JsonResponseFor<Path, 'delete'>;
+  return universalDelete<ResponseType>(path, undefined);
 }

--- a/src/api/typed-api.ts
+++ b/src/api/typed-api.ts
@@ -1,6 +1,6 @@
 /** Type-safe access to the RefStudio HTTP APIs. */
 
-import { universalDelete, universalGet, universalPatch, universalPost, universalPut } from './api';
+import { universalDelete, universalGet, universalPatch, universalPost } from './api';
 import type { paths } from './api-paths';
 
 type LowerMethod = 'get' | 'post' | 'put' | 'delete' | 'patch';
@@ -97,23 +97,6 @@ export async function apiPost<Path extends PathsForMethod<'post'>>(
   const path = options ? completePath(pathSpec, options) : pathSpec;
   type ResponseType = JsonResponseFor<Path, 'post'>;
   return universalPost<ResponseType>(path, body);
-}
-
-/**
- * Issue a PUT request with a JSON payload to a RefStudio API endpoint.
- *
- * If the endpoint takes path parameters or search parameters, then that will be the second argument.
- * The last argument (2nd or 3rd argument) is the request body.
- */
-export async function apiPut<Path extends PathsForMethod<'put'>>(
-  pathSpec: Path,
-  ...args: [...params: PathArgs<Path, 'put'>, body: JsonRequestBodyFor<Path, 'put'>]
-) {
-  const safeArgs = args as unknown as [params: RouteParameters, body: unknown] | [body: unknown];
-  const [options, body] = safeArgs.length === 2 ? safeArgs : [undefined, ...safeArgs];
-  const path = options ? completePath(pathSpec, options) : pathSpec;
-  type ResponseType = JsonResponseFor<Path, 'post'>;
-  return universalPut<ResponseType>(path, body);
 }
 
 /**


### PR DESCRIPTION
I filled in the FastAPI / Pydantic schemas in a few places. Note that POST requests need a JSON payload with this system. If we want to support empty payloads, we'll need to add some more logic in `typed-api.ts`.