### PR TITLE
fix: sidebar shadow and folder collapsing animation

### DIFF
--- a/src/application/components/SideBar.css
+++ b/src/application/components/SideBar.css
@@ -1,5 +1,5 @@
 .side-bar {
-  @apply flex select-none flex-col;
+  @apply z-sidebar flex select-none flex-col bg-side-bar-bg-primary;
 }
 
 .side-bar .icon {

--- a/src/application/sidebar/FileExplorer.tsx
+++ b/src/application/sidebar/FileExplorer.tsx
@@ -16,7 +16,7 @@ import { cx } from '../../lib/cx';
 import { isNonNullish } from '../../lib/isNonNullish';
 import { FILE_EXPLORER_FILE_MENU_ID } from './fileExplorerContextMenu/FileExplorerFileContextMenu';
 import { useFileExplorerContextMenu } from './fileExplorerContextMenu/useFileExplorerContextMenu';
-import { ArrowDownIcon, ArrowRightIcon } from './icons';
+import { ArrowRightIcon } from './icons';
 
 export function FileExplorer() {
   const rootFileExplorerEntry = useAtomValue(fileExplorerAtom);
@@ -56,7 +56,11 @@ export function FolderNode({ folder }: FolderNodeProps) {
         className={cx('flex cursor-pointer select-none items-start gap-1 self-stretch')}
         onClick={() => setCollapsed((currentState) => !currentState)}
       >
-        <div className="text-btn-ico-side-bar-item">{collapsed ? <ArrowRightIcon /> : <ArrowDownIcon />}</div>
+        <div
+          className={cx('text-btn-ico-side-bar-item transition duration-100 ease-in-out', { 'rotate-90': !collapsed })}
+        >
+          <ArrowRightIcon />
+        </div>
         <h2 className="overflow-hidden overflow-ellipsis whitespace-nowrap">{folder.name}</h2>
       </div>
       {!collapsed && (

--- a/src/application/sidebar/LeftSidePanelWrapper.tsx
+++ b/src/application/sidebar/LeftSidePanelWrapper.tsx
@@ -47,7 +47,10 @@ export function LeftSidePanelWrapper() {
     <>
       <SideBar
         activePane={primaryPaneCollapsed ? null : primaryPane}
-        className={cx({ 'border-r border-r-side-bar-border': !primaryPaneCollapsed })}
+        className={cx({
+          'border-r border-r-side-bar-border': !primaryPaneCollapsed,
+          'shadow-default': primaryPaneCollapsed,
+        })}
         footerItems={[
           // TODO: Implement Keybinds screen
           {
@@ -67,7 +70,13 @@ export function LeftSidePanelWrapper() {
         ]}
         onItemClick={handleSideBarClick}
       />
-      <Panel collapsible order={1} ref={leftPanelRef} onCollapse={(collapsed) => setPrimaryPaneCollapsed(collapsed)}>
+      <Panel
+        className="z-sidebar-panel shadow-default"
+        collapsible
+        order={1}
+        ref={leftPanelRef}
+        onCollapse={(collapsed) => setPrimaryPaneCollapsed(collapsed)}
+      >
         {primaryPane === 'Explorer' && <ExplorerPanel />}
         {primaryPane === 'References' && <ReferencesPanel />}
       </Panel>

--- a/src/application/sidebar/RightSidePanelWrapper.tsx
+++ b/src/application/sidebar/RightSidePanelWrapper.tsx
@@ -41,13 +41,22 @@ export function RightSidePanelWrapper() {
   return (
     <>
       <VerticalResizeHandle transparent />
-      <Panel collapsible order={3} ref={rightPanelRef} onCollapse={(collapsed) => setSecondaryPaneCollapsed(collapsed)}>
+      <Panel
+        className="z-sidebar-panel shadow-default"
+        collapsible
+        order={3}
+        ref={rightPanelRef}
+        onCollapse={(collapsed) => setSecondaryPaneCollapsed(collapsed)}
+      >
         {secondaryPane === 'Rewriter' && <RewriterPanel />}
         {secondaryPane === 'Chatbot' && <ChatbotPanel />}
       </Panel>
       <SideBar
         activePane={secondaryPaneCollapsed ? null : secondaryPane}
-        className={cx({ 'border-l border-l-side-bar-border': !secondaryPaneCollapsed })}
+        className={cx({
+          'border-l border-l-side-bar-border': !secondaryPaneCollapsed,
+          'shadow-default': secondaryPaneCollapsed,
+        })}
         items={[
           { pane: 'Rewriter', Icon: <PenIcon /> },
           { pane: 'Chatbot', Icon: <BotIcon /> },

--- a/src/application/sidebar/icons.tsx
+++ b/src/application/sidebar/icons.tsx
@@ -39,17 +39,6 @@ export const ReferencesIcon = () => (
   </div>
 );
 
-export const ArrowDownIcon = () => (
-  <div className="flex h-6 w-6 shrink-0 items-center justify-center self-center">
-    <svg height="8" viewBox="0 0 12 8" width="12" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M1.41 0.290039L6 4.88004L10.59 0.290039L12 1.71004L6 7.71004L0 1.71004L1.41 0.290039Z"
-        fill="currentcolor"
-      />
-    </svg>
-  </div>
-);
-
 export const ArrowRightIcon = () => (
   <div className="flex h-6 w-6 shrink-0 items-center justify-center self-center">
     <svg height="12" viewBox="0 0 8 12" width="8" xmlns="http://www.w3.org/2000/svg">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -191,6 +191,8 @@ export default {
         notifications: 88888,
         'drop-zone': 55555,
         'resize-handle': 44444,
+        sidebar: 11,
+        'sidebar-panel': 10,
       },
     },
   },


### PR DESCRIPTION
This adds the shadow box for sidebars and adds a transition animation on the arrow when collapsing/uncollapsing a folder in the explorer

Closes #467