### PR TITLE
chore: ignore openapi-tyepscript in knip config

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -11,9 +11,11 @@ const config: KnipConfig = {
     'src/**/__mocks__/*.ts',
     'src/declarations/*.d.ts',
   ],
-  ignoreBinaries: ['poetry', 'openapi-typescript'],
+  ignoreBinaries: ['poetry'],
   ignoreExportsUsedInFile: true,
   ignoreDependencies: [
+    // Used in scripts/codegen.sh
+    'openapi-typescript',
     // referenced in vite.config.ts (`provider: 'c8'`)
     '@vitest/coverage-c8',
     // referenced in scripts/codegen.sh


### PR DESCRIPTION
Fixes #469 