### PR TITLE
 Adopt the new active_project_id in the client code

### DIFF
--- a/src/AppStartup.tsx
+++ b/src/AppStartup.tsx
@@ -41,7 +41,7 @@ export function AppStartup() {
 
         if (isMounted()) {
           setInitialized(true);
-          const projectId = getCachedSetting('current_directory'); // TODO: Open project using project ID
+          const projectId = getCachedSetting('active_project_id');
           if (projectId) {
             const projectInfo = await readProjectById(projectId);
             await openProject(projectId, projectInfo.path, projectInfo.name);

--- a/src/application/listeners/projectEventListeners.ts
+++ b/src/application/listeners/projectEventListeners.ts
@@ -109,9 +109,8 @@ export function useFileProjectCloseListener() {
   };
 }
 
-// TODO: This method needs to be refactored to have use a project id instead of a path
 function persistActiveProjectInSettings(id: string) {
-  setCachedSetting('current_directory', id);
+  setCachedSetting('active_project_id', id);
   void saveCachedSettings();
 }
 


### PR DESCRIPTION
This is part of #445 

After this, we can implement the 3rd task of: 
-  Remove the deprecated current_directory setting from the backend API