### PR TITLE
fix: margin between sibling list items

### DIFF
--- a/src/features/textEditor/components/tipTapNodes/notionBlock/NotionBlock.css
+++ b/src/features/textEditor/components/tipTapNodes/notionBlock/NotionBlock.css
@@ -111,15 +111,10 @@
 }
 
 .node-notionBlock + .node-notionBlock {
-  @apply mt-6;
+  @apply mt-2;
 }
 
 /* Add space between a parent notion block and its first child */
 .node-notionBlock .node-notionBlock:first-of-type {
-  @apply mt-2;
-}
-
-/* Space between sibling list items */
-.node-notionBlock:has(> * > .list-item) + .node-notionBlock:has(> * > .list-item) {
   @apply mt-2;
 }

--- a/src/features/textEditor/components/tipTapNodes/notionBlock/NotionBlock.css
+++ b/src/features/textEditor/components/tipTapNodes/notionBlock/NotionBlock.css
@@ -119,14 +119,7 @@
   @apply mt-2;
 }
 
-/* No space between sibling unordered list items */
-.node-notionBlock:has(.content > div > .unordered-list-item)
-  + .node-notionBlock:has(.content > div > .unordered-list-item) {
-  @apply mt-0;
-}
-
-/* No space between sibling ordered list items */
-.node-notionBlock:has(.content > div > .ordered-list-item)
-  + .node-notionBlock:has(.content > div > .ordered-list-item) {
-  @apply mt-0;
+/* Space between sibling list items */
+.node-notionBlock:has(> * > .list-item) + .node-notionBlock:has(> * > .list-item) {
+  @apply mt-2;
 }

--- a/src/features/textEditor/components/tipTapNodes/notionBlock/NotionBlock.tsx
+++ b/src/features/textEditor/components/tipTapNodes/notionBlock/NotionBlock.tsx
@@ -12,7 +12,15 @@ interface NotionBlockProps {
 export function NotionBlock({ node }: NotionBlockProps) {
   return (
     <NodeViewWrapper>
-      <div className={cx('notion-block', { collapsed: node.attrs.type === 'collapsible' && !!node.attrs.collapsed })}>
+      <div
+        className={cx('notion-block', {
+          collapsed: node.attrs.type === 'collapsible' && !!node.attrs.collapsed,
+          'list-item':
+            node.attrs.type === 'collapsible' ||
+            node.attrs.type === 'unorderedList' ||
+            node.attrs.type === 'orderedList',
+        })}
+      >
         <div className="drag-handle" contentEditable="false" data-drag-handle />
         <NodeViewContent className="content" />
       </div>


### PR DESCRIPTION
There were 2 issues:
 - The spacing between list items was 0 instead of being the same as the spacing between a parent node and its child, resulting in a weird shifting behaviour when indenting/un-indenting an item in a list
 - The spacing between list items was different from the spacing between collapsible nodes.

The first issue was a bug and has been fixed. The second one was more or less intended: the design specifies that there should be 24px between each node:

<img width="767" alt="image" src="https://github.com/refstudio/refstudio/assets/58954208/ce50914b-851a-401e-865e-f0845df33da0">

I have changed that to make collapsible nodes considered as list items (which makes sense because that is how we export them in markdown). However, the default spacing remains 24px, which means that turning a regular node into a collapsible node still results in things moving up and down:

https://github.com/refstudio/refstudio/assets/58954208/3d1fb8b3-7379-40f3-b8aa-b4db6c4cf89e

On notion, the spacing is the same between every kind of node, except headings. So the question is do we want to do the same and remove this 24px spacing we have @hammer?

Fixes #481