### PR TITLE
feat: implement design for empty references panel

### DIFF
--- a/src/application/views/WelcomeView.tsx
+++ b/src/application/views/WelcomeView.tsx
@@ -37,11 +37,13 @@ function WelcomeActions() {
       <div className="flex flex-col items-center gap-2 self-stretch">
         <Button
           Action={<AddIcon />}
+          fluid
           text="Create Project"
           onClick={() => emitEvent('refstudio://menu/file/project/new')}
         />
         <Button
           Action={<OpenIcon />}
+          fluid
           text="Open Project"
           type="secondary"
           onClick={() => emitEvent('refstudio://menu/file/project/open')}
@@ -68,13 +70,11 @@ function WelcomeTips() {
         </div>
       </div>
       <div className="flex flex-row items-start gap-2">
-        <div className="shrink">
-          <Button
-            Action={<SampleIcon />}
-            text="Try Sample Project"
-            onClick={() => emitEvent('refstudio://menu/file/project/new/sample')}
-          />
-        </div>
+        <Button
+          Action={<SampleIcon />}
+          text="Try Sample Project"
+          onClick={() => emitEvent('refstudio://menu/file/project/new/sample')}
+        />
       </div>
     </div>
   );

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -5,6 +5,7 @@ interface ButtonProps {
   actionPosition?: 'left' | 'right';
   className?: string;
   disabled?: boolean;
+  fluid?: boolean;
   size?: 'S' | 'M';
   text: string;
   type?: 'primary' | 'secondary';
@@ -15,6 +16,7 @@ export function Button({
   actionPosition = 'left',
   className,
   disabled,
+  fluid,
   size = 'S',
   text,
   type = 'primary',
@@ -24,7 +26,10 @@ export function Button({
   return (
     <button
       className={cx(
-        'flex w-full items-center gap-2 rounded-default px-2 py-2',
+        'flex items-center gap-2 rounded-default px-2 py-2',
+        {
+          'w-full': fluid,
+        },
         {
           'justify-center px-5 py-3': size === 'M',
         },

--- a/src/features/components/RewriteOptionsView.tsx
+++ b/src/features/components/RewriteOptionsView.tsx
@@ -84,6 +84,7 @@ export function RewriteOptionsView({
         Action={isFetching ? <SpinnerIcon /> : undefined}
         actionPosition="right"
         disabled={selection.length === 0}
+        fluid
         size="M"
         text="Rewrite"
         onClick={() => !isFetching && rewriteSelection()}

--- a/src/features/references/components/icons.tsx
+++ b/src/features/references/components/icons.tsx
@@ -18,3 +18,14 @@ export const ExportIcon = () => (
     </svg>
   </div>
 );
+
+export const DragAndDropIcon = () => (
+  <div className="flex h-12 w-12 shrink-0 items-center justify-center">
+    <svg height="48" viewBox="0 0 48 48" width="48" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M10 6H6V10H10V6ZM38 14H42V26H38V18H18V38H26V42H14V14H38ZM14 6H18V10H14V6ZM10 14H6V18H10V14ZM6 22H10V26H6V22ZM10 30H6V34H10V30ZM22 6H26V10H22V6ZM34 6H30V10H34V6ZM30 34V30H42V34H38V38H34V42H30V34ZM38 38V42H42V38H38Z"
+        fill="currentcolor"
+      />
+    </svg>
+  </div>
+);

--- a/src/features/references/sidebar/ReferencesList.tsx
+++ b/src/features/references/sidebar/ReferencesList.tsx
@@ -17,7 +17,11 @@ export function ReferencesList({
   };
 
   return (
-    <ul className="flex flex-col items-start gap-2 self-stretch" data-testid={ReferencesList.name} role="list">
+    <ul
+      className="flex flex-col items-start gap-2 self-stretch overflow-y-auto"
+      data-testid={ReferencesList.name}
+      role="list"
+    >
       {references.map((reference) => (
         <li
           className={cx(

--- a/src/features/references/sidebar/ReferencesPanel.tsx
+++ b/src/features/references/sidebar/ReferencesPanel.tsx
@@ -73,14 +73,14 @@ export function ReferencesPanel() {
       ]}
       title="References"
     >
-      <div className="flex flex-1 flex-col items-start gap-4 self-stretch p-4 pt-2">
-        <SearchBar placeholder="Filter author/title..." onChange={handleFilterChanged} />
-        <ReferencesList
-          references={visibleReferences}
-          onAuthorClicked={handleAuthorClicked}
-          onRefClicked={handleRefClicked}
-        />
-      </div>
+        <div className="flex flex-1 flex-col items-start gap-4 self-stretch overflow-hidden p-4 pt-2">
+          <SearchBar placeholder="Filter author/title..." onChange={handleFilterChanged} />
+          <ReferencesList
+            references={visibleReferences}
+            onAuthorClicked={handleAuthorClicked}
+            onRefClicked={handleRefClicked}
+          />
+        </div>
     </PanelWrapper>
   );
 }

--- a/src/features/references/sidebar/ReferencesPanel.tsx
+++ b/src/features/references/sidebar/ReferencesPanel.tsx
@@ -3,11 +3,13 @@ import { useEffect, useState } from 'react';
 
 import { openReferenceAtom, openReferencePdfAtom, openReferencesAtom } from '../../../atoms/editorActions';
 import { getReferencesAtom } from '../../../atoms/referencesState';
+import { Button } from '../../../components/Button';
 import { PanelWrapper } from '../../../components/PanelWrapper';
 import { SearchBar } from '../../../components/SearchBar';
 import { emitEvent } from '../../../events';
+import { cx } from '../../../lib/cx';
 import { Author, ReferenceItem } from '../../../types/ReferenceItem';
-import { ExportIcon, TableIcon } from '../components/icons';
+import { DragAndDropIcon, ExportIcon, TableIcon } from '../components/icons';
 import { ReferencesList } from './ReferencesList';
 
 export function ReferencesPanel() {
@@ -73,6 +75,7 @@ export function ReferencesPanel() {
       ]}
       title="References"
     >
+      {references.length > 0 ? (
         <div className="flex flex-1 flex-col items-start gap-4 self-stretch overflow-hidden p-4 pt-2">
           <SearchBar placeholder="Filter author/title..." onChange={handleFilterChanged} />
           <ReferencesList
@@ -81,6 +84,26 @@ export function ReferencesPanel() {
             onRefClicked={handleRefClicked}
           />
         </div>
+      ) : (
+        <div
+          className={cx(
+            'flex flex-col items-stretch justify-center px-4 pb-[4.5rem]',
+            'flex-1 self-stretch',
+            'cursor-default select-none',
+          )}
+        >
+          <div className="flex flex-col items-center justify-center gap-4">
+            <div className="text-side-bar-ico-empty">
+              <DragAndDropIcon />
+            </div>
+            <div className="flex flex-col items-stretch justify-center gap-2 self-stretch">
+              <h2 className="text-center text-xl/6 text-side-bar-txt-primary">No References</h2>
+              <div className="text-center text-side-bar-txt-secondary">Drag or choose your first reference here.</div>
+            </div>
+            <Button text="Browse Reference" onClick={() => emitEvent('refstudio://menu/references/upload')} />
+          </div>
+        </div>
+      )}
     </PanelWrapper>
   );
 }

--- a/src/features/references/sidebar/__tests__/ReferencesPanel.test.tsx
+++ b/src/features/references/sidebar/__tests__/ReferencesPanel.test.tsx
@@ -31,10 +31,22 @@ describe('ReferencesPanel', () => {
     expect(vi.mocked(emitEvent)).toBeCalledWith<[RefStudioEventName]>('refstudio://menu/references/open');
   });
 
+  it('should display empty No Reference when the list is empty', () => {
+    setupWithJotaiProvider(<ReferencesPanel />);
+
+    expect(screen.getByText('No References')).toBeInTheDocument();
+  });
+
+  it('should trigger refstudio://menu/references/upload on click', async () => {
+    const { user } = setupWithJotaiProvider(<ReferencesPanel />);
+    await user.click(screen.getByText('Browse Reference'));
+    expect(vi.mocked(emitEvent)).toBeCalledWith<[RefStudioEventName]>('refstudio://menu/references/upload');
+  });
+
   it('should display ReferencesList with references', () => {
     setupWithJotaiProvider(<ReferencesPanel />, store);
 
-    expect(screen.queryByText(/welcome to your refstudio references library/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('No References')).not.toBeInTheDocument();
     expect(screen.getByText(ref1.title)).toBeInTheDocument();
     expect(screen.getByText(ref2.title)).toBeInTheDocument();
   });

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -138,6 +138,7 @@ export default {
           primary: 'rgb(var(--grayscale-00) / <alpha-value>)',
           secondary: 'rgb(var(--grayscale-20) / <alpha-value>)',
         },
+        'side-bar-ico-empty': 'rgb(var(--grayscale-40) / <alpha-value>)',
         'card-txt-header': 'rgb(var(--grayscale-00) / <alpha-value>)',
         'card-border-header': 'rgb(var(--primary-90) / <alpha-value>)',
         'card-border': {


### PR DESCRIPTION
This implements the design for the references panel when no reference has been ingested

<img width="1512" alt="image" src="https://github.com/refstudio/refstudio/assets/58954208/dbe16501-9cb7-480f-818e-fcaae1e5e8bb">

Closes #474