### PR TITLE
feat: open project dialog for web (and desktop)

### DIFF
--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -18,6 +18,7 @@ import { EventsListener } from '../wrappers/EventsListener';
 import { CommandPalette } from './commands/CommandPalette';
 import { MainPanel } from './components/MainPanel';
 import { CreateProjectModal } from './CreateProjectModal';
+import { SelectProjectModal } from './SelectProjectModal';
 import { LeftSidePanelWrapper } from './sidebar/LeftSidePanelWrapper';
 import { RightSidePanelWrapper } from './sidebar/RightSidePanelWrapper';
 import { WebMenuShortcuts } from './WebMenuShortcuts';
@@ -100,7 +101,7 @@ function ProjectModals() {
   return (
     <>
       <CreateProjectModal />
-      {/* <OpenProjectModal /> */}
+      <SelectProjectModal />
     </>
   );
 }

--- a/src/application/CreateProjectModal.tsx
+++ b/src/application/CreateProjectModal.tsx
@@ -29,7 +29,7 @@ export function CreateProjectModal() {
 
   return (
     <Modal className="w-[1150px] max-w-[calc(30vw-100px)]" open={isVisible} onClose={() => dismissModal()}>
-      <div className="flex w-full flex-col  bg-white">
+      <div className="flex w-full flex-col bg-white">
         <div className="border-b-2 p-2 font-bold">Project Name</div>
         <div className="p-2">
           <p>What is the name you want to use for this project?</p>

--- a/src/application/SelectProjectModal.tsx
+++ b/src/application/SelectProjectModal.tsx
@@ -1,0 +1,63 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { Fragment } from 'react';
+
+import { ProjectInfo, readAllProjects } from '../api/projectsAPI';
+import { selectProjectModalAtoms } from '../atoms/projectState';
+import { Modal } from '../components/Modal';
+import { cx } from '../lib/cx';
+import { RefStudioEditorIcon } from './components/icons';
+
+export function SelectProjectModal() {
+  const isVisible = useAtomValue(selectProjectModalAtoms.visibleAtom);
+  const closeModal = useSetAtom(selectProjectModalAtoms.closeAtom);
+  const dismissModal = useSetAtom(selectProjectModalAtoms.dismissAtom);
+
+  return (
+    <Modal className="max-h-[50vh] w-[1150px] max-w-[calc(40vw-100px)]" open={isVisible} onClose={() => dismissModal()}>
+      <div className="flex w-full flex-col bg-white">
+        <div className="border-b-2 p-2 font-bold">Select one project to open</div>
+        <div className="overflow-auto p-2">
+          <RecentProjectsList onSelected={(id) => closeModal(id)} />
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function RecentProjectsList({ onSelected }: { onSelected: (projectId: string) => void }) {
+  const { data: projects } = useQuery({ queryKey: ['recent-projects'], queryFn: readAllProjects });
+
+  return (
+    <div className="flex flex-col items-stretch gap-4 overflow-y-hidden">
+      {projects && (
+        <div className="flex flex-col items-stretch gap-2 overflow-y-scroll">
+          {projects.map((project, index) => (
+            <Fragment key={project.id}>
+              {index > 0 && <div className="h-[1px] shrink-0 bg-welcome-border" />}
+              <ProjectItem project={project} onClick={onSelected} />
+            </Fragment>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProjectItem({ project, onClick }: { project: ProjectInfo; onClick: (projectId: string) => void }) {
+  return (
+    <div
+      className={cx(
+        'flex cursor-pointer items-center gap-2 p-2 pr-3',
+        'rounded-default hover:bg-btn-bg-side-bar-item-hover',
+        'text-btn-txt-side-bar-item-primary',
+      )}
+      onClick={() => onClick(project.id)}
+    >
+      <div className="text-btn-ico-content">
+        <RefStudioEditorIcon />
+      </div>
+      {project.name}
+    </div>
+  );
+}

--- a/src/application/listeners/projectEventListeners.ts
+++ b/src/application/listeners/projectEventListeners.ts
@@ -8,7 +8,6 @@ import {
   closeProjectAtom,
   createProjectModalAtoms,
   isProjectOpenAtom,
-  newProjectAtom,
   newSampleProjectAtom,
   openProjectAtom,
   selectProjectModalAtoms,
@@ -21,7 +20,7 @@ import { saveCachedSettings, setCachedSetting } from '../../settings/settingsMan
 export const SAMPLE_PROJECT_NAME = 'RefStudio Sample';
 
 export function useFileProjectNewListener() {
-  const newProject = useSetAtom(newProjectAtom);
+  const openProject = useSetAtom(openProjectAtom);
   const createFile = useSetAtom(createFileAtom);
   const openCreateProjectModal = useSetAtom(createProjectModalAtoms.openAtom);
 
@@ -35,7 +34,7 @@ export function useFileProjectNewListener() {
       return;
     }
 
-    await newProject(projectInfo.id, projectInfo.path, projectInfo.name);
+    await openProject(projectInfo.id, projectInfo.path, projectInfo.name);
     createFile();
     notifyInfo('New project created with success');
     persistActiveProjectInSettings(projectInfo.id);

--- a/src/atoms/__tests__/projectState.test.ts
+++ b/src/atoms/__tests__/projectState.test.ts
@@ -4,7 +4,7 @@ import { setCurrentFileSystemProjectId } from '../../io/filesystem';
 import { DebugAtomModuleType } from '../debugAtom';
 import { closeAllEditorsAtom } from '../editorActions';
 import { refreshFileTreeAtom } from '../fileExplorerActions';
-import { closeProjectAtom, isProjectOpenAtom, newProjectAtom, projectNameAtom } from '../projectState';
+import { closeProjectAtom, isProjectOpenAtom, openProjectAtom, projectNameAtom } from '../projectState';
 import { clearAllReferencesAtom, loadReferencesAtom } from '../referencesState';
 
 vi.mock('../../io/filesystem');
@@ -42,12 +42,8 @@ describe('projectState', () => {
     vi.clearAllMocks();
   });
 
-  it('should start with project closed', () => {
-    expect(store.get(isProjectOpenAtom)).toBeFalsy();
-  });
-
-  it('should set project id, load references and refresh files, when new project is created', async () => {
-    await store.set(newProjectAtom, 'project-id', 'project-path', 'project-name');
+  it('should set project id, load references and refresh files, when new project is open', async () => {
+    await store.set(openProjectAtom, 'project-id', 'project-path', 'project-name');
     expect(store.get(isProjectOpenAtom)).toBeTruthy();
     expect(store.get(projectNameAtom)).toBe('project-name');
     expect(setCurrentFileSystemProjectId).toHaveBeenCalledWith('project-id');
@@ -57,7 +53,7 @@ describe('projectState', () => {
   });
 
   it('should close open project', async () => {
-    await store.set(newProjectAtom, 'project-id', 'project-path', 'project-name');
+    await store.set(openProjectAtom, 'project-id', 'project-path', 'project-name');
     expect(store.get(isProjectOpenAtom)).toBeTruthy();
 
     await store.set(closeProjectAtom);
@@ -67,7 +63,7 @@ describe('projectState', () => {
   });
 
   it('should close all open editors and clear all references on close', async () => {
-    await store.set(newProjectAtom, 'project-id', 'project-path', 'project-name');
+    await store.set(openProjectAtom, 'project-id', 'project-path', 'project-name');
     await store.set(closeProjectAtom);
     expect(store.get(closeAllEditorsAtom)).toHaveBeenCalled();
     expect(store.get(clearAllReferencesAtom)).toHaveBeenCalled();

--- a/src/atoms/projectState.ts
+++ b/src/atoms/projectState.ts
@@ -22,6 +22,7 @@ export const projectNameAtom: Atom<string> = currentProjectNameAtom;
 export const projectIdAtom: Atom<string> = currentProjectIdAtom;
 
 export const createProjectModalAtoms = createModalAtoms<string>();
+export const selectProjectModalAtoms = createModalAtoms<string>();
 
 export const newProjectAtom = atom(null, async (_, set, projectId: string, path: string, name: string) => {
   // Close current project before create new

--- a/src/atoms/projectState.ts
+++ b/src/atoms/projectState.ts
@@ -24,20 +24,6 @@ export const projectIdAtom: Atom<string> = currentProjectIdAtom;
 export const createProjectModalAtoms = createModalAtoms<string>();
 export const selectProjectModalAtoms = createModalAtoms<string>();
 
-export const newProjectAtom = atom(null, async (_, set, projectId: string, path: string, name: string) => {
-  // Close current project before create new
-  await set(closeProjectAtom);
-
-  // Create empty project
-  setCurrentFileSystemProjectId(projectId);
-  set(currentProjectIdAtom, projectId);
-  set(currentProjectPathAtom, path);
-  set(currentProjectNameAtom, name);
-
-  await set(loadReferencesAtom, projectId);
-  await set(refreshFileTreeAtom);
-});
-
 export const openProjectAtom = atom(null, async (_, set, projectId: string, path: string, name: string) => {
   // Close current project before create new
   await set(closeProjectAtom);

--- a/src/io/__tests__/filesystem.test.ts
+++ b/src/io/__tests__/filesystem.test.ts
@@ -164,6 +164,13 @@ describe('filesystem', () => {
         isFolder: false,
       });
     });
+
+    it('should not call projectAPI if no project is open, and return []', async () => {
+      setCurrentFileSystemProjectId('');
+      const files = await readAllProjectFiles();
+      expect(readProjectFiles).not.toHaveBeenCalled();
+      expect(files).toHaveLength(0);
+    });
   });
 
   // #####################################################################################

--- a/src/io/filesystem.ts
+++ b/src/io/filesystem.ts
@@ -104,6 +104,10 @@ export async function ensureSampleProjectFiles(projectId: string) {
 }
 
 export async function readAllProjectFiles() {
+  if (!currentProjectId) {
+    return [];
+  }
+
   console.log('reading file structure from web');
   const entries = await readProjectFiles(currentProjectId);
   return Promise.all(entries.map(convertTauriFileEntryToFileEntry));


### PR DESCRIPTION
This closes #447 

Adds a new modal to select the project from a list of projects.


This PR also:
* Remove `newProjectAtom` and use `openProjectAtom` to both new and open actions. 