### PR TITLE
feat: add empty welcome view

### DIFF
--- a/src/AppStartup.tsx
+++ b/src/AppStartup.tsx
@@ -38,16 +38,19 @@ export function AppStartup() {
 
         notifyInfo('Application Startup');
         await initSettings();
-        const projects = await readAllProjects();
+
+        const projectId = getCachedSetting('active_project_id');
+        const [projectInfo, projects] = await Promise.all([
+          projectId ? await readProjectById(projectId) : null,
+          readAllProjects(),
+        ]);
 
         await invoke('close_splashscreen');
 
         if (isMounted()) {
           setInitialized(true);
           setAllProjects(projects);
-          const projectId = getCachedSetting('active_project_id');
-          if (projectId) {
-            const projectInfo = await readProjectById(projectId);
+          if (projectInfo) {
             await openProject(projectId, projectInfo.path, projectInfo.name);
           }
           notifyInfo('Application Initialized');

--- a/src/AppStartup.tsx
+++ b/src/AppStartup.tsx
@@ -1,10 +1,10 @@
 import { useSetAtom } from 'jotai';
 import { useState } from 'react';
 
-import { readProjectById } from './api/projectsAPI';
+import { readAllProjects, readProjectById } from './api/projectsAPI';
 import { useRefStudioServerOnDesktop } from './api/server';
 import { App } from './application/App';
-import { openProjectAtom } from './atoms/projectState';
+import { allProjectsAtom, openProjectAtom } from './atoms/projectState';
 import { useAsyncEffect } from './hooks/useAsyncEffect';
 import { noop } from './lib/noop';
 import { notifyErr, notifyInfo } from './notifications/notifications';
@@ -20,6 +20,7 @@ if (import.meta.env.DEV) {
 export function AppStartup() {
   const [initialized, setInitialized] = useState(false);
   const openProject = useSetAtom(openProjectAtom);
+  const setAllProjects = useSetAtom(allProjectsAtom);
 
   const isServerRunning = useRefStudioServerOnDesktop();
   console.log('isServerRunning=', isServerRunning);
@@ -37,10 +38,13 @@ export function AppStartup() {
 
         notifyInfo('Application Startup');
         await initSettings();
+        const projects = await readAllProjects();
+
         await invoke('close_splashscreen');
 
         if (isMounted()) {
           setInitialized(true);
+          setAllProjects(projects);
           const projectId = getCachedSetting('active_project_id');
           if (projectId) {
             const projectInfo = await readProjectById(projectId);

--- a/src/__tests__/AppStartup.test.tsx
+++ b/src/__tests__/AppStartup.test.tsx
@@ -16,6 +16,9 @@ vi.mock('../application/App', () => {
 vi.mock('../api/server', () => ({
   useRefStudioServerOnDesktop: () => true,
 }));
+vi.mock('../api/projectsAPI', () => ({
+  readAllProjects: () => Promise.resolve([]),
+}));
 
 describe('AppStartup', () => {
   afterEach(() => {

--- a/src/application/components/ProjectsList.tsx
+++ b/src/application/components/ProjectsList.tsx
@@ -6,7 +6,7 @@ import { RefStudioEditorIcon } from './icons';
 
 interface ProjectsListProps {
   projects: ProjectInfo[];
-  onProjectClick: (projectId: ProjectInfo) => void;
+  onProjectClick: (project: ProjectInfo) => void;
 }
 export function ProjectsList({ projects, onProjectClick }: ProjectsListProps) {
   return (

--- a/src/application/components/ProjectsList.tsx
+++ b/src/application/components/ProjectsList.tsx
@@ -31,6 +31,7 @@ function ProjectItem({ project, onClick }: { project: ProjectInfo; onClick: () =
         'rounded-default hover:bg-btn-bg-side-bar-item-hover',
         'text-btn-txt-side-bar-item-primary',
       )}
+      role="menuitem"
       onClick={onClick}
     >
       <div className="text-btn-ico-content">

--- a/src/application/components/ProjectsList.tsx
+++ b/src/application/components/ProjectsList.tsx
@@ -1,0 +1,39 @@
+import { Fragment } from 'react';
+
+import { ProjectInfo } from '../../api/projectsAPI';
+import { emitEvent } from '../../events';
+import { cx } from '../../lib/cx';
+import { RefStudioEditorIcon } from './icons';
+
+export function ProjectsList({ projects }: { projects: ProjectInfo[] }) {
+  return (
+    <div className="flex flex-col items-stretch gap-4 overflow-y-hidden">
+      <h1>Recent Projects</h1>
+      <div className="flex flex-col items-stretch gap-2 overflow-y-scroll">
+        {projects.map((project, index) => (
+          <Fragment key={project.id}>
+            {index > 0 && <div className="h-[1px] shrink-0 bg-welcome-border" />}
+            <ProjectItem project={project} />
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}
+function ProjectItem({ project }: { project: ProjectInfo }) {
+  return (
+    <div
+      className={cx(
+        'flex cursor-pointer items-center gap-2 p-2 pr-3',
+        'rounded-default hover:bg-btn-bg-side-bar-item-hover',
+        'text-btn-txt-side-bar-item-primary',
+      )}
+      onClick={() => emitEvent('refstudio://projects/open', { projectId: project.id })}
+    >
+      <div className="text-btn-ico-content">
+        <RefStudioEditorIcon />
+      </div>
+      {project.name}
+    </div>
+  );
+}

--- a/src/application/components/ProjectsList.tsx
+++ b/src/application/components/ProjectsList.tsx
@@ -1,11 +1,14 @@
 import { Fragment } from 'react';
 
 import { ProjectInfo } from '../../api/projectsAPI';
-import { emitEvent } from '../../events';
 import { cx } from '../../lib/cx';
 import { RefStudioEditorIcon } from './icons';
 
-export function ProjectsList({ projects }: { projects: ProjectInfo[] }) {
+interface ProjectsListProps {
+  projects: ProjectInfo[];
+  onProjectClick: (projectId: ProjectInfo) => void;
+}
+export function ProjectsList({ projects, onProjectClick }: ProjectsListProps) {
   return (
     <div className="flex flex-col items-stretch gap-4 overflow-y-hidden">
       <h1>Recent Projects</h1>
@@ -13,14 +16,14 @@ export function ProjectsList({ projects }: { projects: ProjectInfo[] }) {
         {projects.map((project, index) => (
           <Fragment key={project.id}>
             {index > 0 && <div className="h-[1px] shrink-0 bg-welcome-border" />}
-            <ProjectItem project={project} />
+            <ProjectItem project={project} onClick={() => onProjectClick(project)} />
           </Fragment>
         ))}
       </div>
     </div>
   );
 }
-function ProjectItem({ project }: { project: ProjectInfo }) {
+function ProjectItem({ project, onClick }: { project: ProjectInfo; onClick: () => void }) {
   return (
     <div
       className={cx(
@@ -28,7 +31,7 @@ function ProjectItem({ project }: { project: ProjectInfo }) {
         'rounded-default hover:bg-btn-bg-side-bar-item-hover',
         'text-btn-txt-side-bar-item-primary',
       )}
-      onClick={() => emitEvent('refstudio://projects/open', { projectId: project.id })}
+      onClick={onClick}
     >
       <div className="text-btn-ico-content">
         <RefStudioEditorIcon />

--- a/src/application/components/__tests__/ProjectsList.test.tsx
+++ b/src/application/components/__tests__/ProjectsList.test.tsx
@@ -1,0 +1,29 @@
+import { noop } from '../../../lib/noop';
+import { render, screen, setup } from '../../../test/test-utils';
+import { ProjectsList } from '../ProjectsList';
+import { PROJECTS } from './test-fixtures';
+
+describe('ProjectsList', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the list of projects', () => {
+    render(<ProjectsList projects={PROJECTS} onProjectClick={noop} />);
+
+    expect(screen.getAllByRole('menuitem')).toHaveLength(PROJECTS.length);
+    PROJECTS.forEach((project) => {
+      expect(screen.getByText(project.name)).toBeInTheDocument();
+    });
+  });
+
+  it('should call handler with the project clicked on', async () => {
+    const fn = vi.fn();
+    const { user } = setup(<ProjectsList projects={PROJECTS} onProjectClick={fn} />);
+
+    await user.click(screen.getByText(PROJECTS[1].name));
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith(PROJECTS[1]);
+  });
+});

--- a/src/application/components/__tests__/test-fixtures.ts
+++ b/src/application/components/__tests__/test-fixtures.ts
@@ -1,0 +1,14 @@
+import { ProjectInfo } from '../../../api/projectsAPI';
+
+export const PROJECTS: ProjectInfo[] = [
+  {
+    id: 'dbbfed40-9159-49b9-98bb-7cf3dd3370f1',
+    path: 'any/path/to/project1',
+    name: 'Project 1',
+  },
+  {
+    id: 'b59c34ee-4c9e-11ee-be56-0242ac120002',
+    path: 'any/path/to/project2',
+    name: 'Project 2',
+  },
+];

--- a/src/application/components/icons.tsx
+++ b/src/application/components/icons.tsx
@@ -46,3 +46,23 @@ export const PdfEditorIcon = () => (
     </svg>
   </div>
 );
+
+export const EmptyStateIcon = () => (
+  <div className="flex h-12 w-12 items-center justify-center">
+    <svg height="48" viewBox="0 0 49 48" width="49" xmlns="http://www.w3.org/2000/svg">
+      <g clipPath="url(#clip0_1250_4005)">
+        <path d="M32.9999 30H36.9999V48H32.9999V30Z" fill="currentcolor" />
+        <path d="M25.9999 41V37H43.9999V41H25.9999Z" fill="currentcolor" />
+        <path d="M3.99991 3V45L21.5 45V41H8.00001V7H29V27L32.9999 27V13V12V7.5V3H3.99991Z" fill="currentcolor" />
+        <path d="M48.4999 16L32.9999 7.5V12L43.4999 17.5L37.9999 27L40.9999 29L48.4999 16Z" fill="currentcolor" />
+        <path d="M11.9999 10.5H24.9999V14.5H11.9999V10.5Z" fill="currentcolor" />
+        <path d="M11.9999 18H20.4999V22H11.9999V18Z" fill="currentcolor" />
+      </g>
+      <defs>
+        <clipPath id="clip0_1250_4005">
+          <rect fill="white" height="48" transform="translate(0.5)" width="48" />
+        </clipPath>
+      </defs>
+    </svg>
+  </div>
+);

--- a/src/application/listeners/projectEventListeners.ts
+++ b/src/application/listeners/projectEventListeners.ts
@@ -5,6 +5,7 @@ import { createRemoteProject, ProjectInfo, readAllProjects, readProjectById } fr
 import { CreateModalResult } from '../../atoms/core/createModalAtoms';
 import { createFileAtom } from '../../atoms/fileEntryActions';
 import {
+  allProjectsAtom,
   closeProjectAtom,
   createProjectModalAtoms,
   isProjectOpenAtom,
@@ -22,6 +23,7 @@ export const SAMPLE_PROJECT_NAME = 'RefStudio Sample';
 export function useFileProjectNewListener() {
   const newProject = useSetAtom(newProjectAtom);
   const createFile = useSetAtom(createFileAtom);
+  const setAllProjects = useSetAtom(allProjectsAtom);
   const openCreateProjectModal = useSetAtom(createProjectModalAtoms.openAtom);
 
   return async () => {
@@ -38,6 +40,9 @@ export function useFileProjectNewListener() {
     createFile();
     notifyInfo('New project created with success');
     persistActiveProjectInSettings(projectInfo.id);
+
+    // Update allProjectsAtom
+    setAllProjects(await readAllProjects());
   };
 }
 

--- a/src/application/views/WelcomeView.tsx
+++ b/src/application/views/WelcomeView.tsx
@@ -1,19 +1,21 @@
-import { useQuery } from '@tanstack/react-query';
-import { Fragment } from 'react';
+import { useAtomValue } from 'jotai';
 
-import { ProjectInfo, readAllProjects } from '../../api/projectsAPI';
+import { allProjectsAtom } from '../../atoms/projectState';
 import { Button } from '../../components/Button';
 import { OpenIcon } from '../../components/icons';
 import { emitEvent } from '../../events';
 import { cx } from '../../lib/cx';
-import { AddIcon, RefStudioEditorIcon, SampleIcon } from '../components/icons';
+import { AddIcon, EmptyStateIcon, SampleIcon } from '../components/icons';
+import { ProjectsList } from '../components/ProjectsList';
 
 export function WelcomeView() {
+  const projects = useAtomValue(allProjectsAtom);
+
   return (
     <div
       className={cx(
         'h-full w-full p-10',
-        'flex flex-row items-start gap-10',
+        'flex flex-row items-stretch gap-10',
         'bg-content-area-bg-primary',
         'cursor-default select-none',
       )}
@@ -21,10 +23,38 @@ export function WelcomeView() {
       <div className="flex w-56 flex-col items-stretch">
         <WelcomeActions />
       </div>
-      <div className="w-[1px] self-stretch bg-welcome-border" />
-      <div className="flex flex-1 flex-col gap-12 self-stretch">
-        <WelcomeTips />
-        <RecentProjectsList />
+      <div className="w-[1px] bg-welcome-border" />
+      {projects.length > 0 ? (
+        <div className="flex flex-1 flex-col gap-12">
+          <WelcomeTips />
+          <ProjectsList projects={projects} />
+        </div>
+      ) : (
+        <EmptyWelcomeView />
+      )}
+    </div>
+  );
+}
+
+function EmptyWelcomeView() {
+  return (
+    <div className="flex flex-1 cursor-default select-none flex-col items-center justify-center gap-6">
+      <div className="text-empty-state-ico-empty">
+        <EmptyStateIcon />
+      </div>
+      <div className="flex flex-col items-center justify-center gap-2 self-stretch">
+        <div className="text-xl/6 font-semibold text-side-bar-txt-primary">Get Started</div>
+        <div className="text-side-bar-txt-secondary">Create new projects to see them here.</div>
+      </div>
+      <div className="flex w-64 flex-col items-center justify-center gap-2">
+        <Button fluid size="M" text="Create Project" onClick={() => emitEvent('refstudio://menu/file/project/new')} />
+        <Button
+          fluid
+          size="M"
+          text="Try Sample Project"
+          type="secondary"
+          onClick={() => emitEvent('refstudio://menu/file/project/new/sample')}
+        />
       </div>
     </div>
   );
@@ -76,44 +106,6 @@ function WelcomeTips() {
           onClick={() => emitEvent('refstudio://menu/file/project/new/sample')}
         />
       </div>
-    </div>
-  );
-}
-
-function RecentProjectsList() {
-  const { data: projects } = useQuery({ queryKey: ['recent-projects'], queryFn: readAllProjects });
-
-  return (
-    <div className="flex flex-col items-stretch gap-4 overflow-y-hidden">
-      <h1>Recent Projects</h1>
-      {projects && (
-        <div className="flex flex-col items-stretch gap-2 overflow-y-scroll">
-          {projects.map((project, index) => (
-            <Fragment key={project.id}>
-              {index > 0 && <div className="h-[1px] shrink-0 bg-welcome-border" />}
-              <ProjectItem project={project} />
-            </Fragment>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function ProjectItem({ project }: { project: ProjectInfo }) {
-  return (
-    <div
-      className={cx(
-        'flex cursor-pointer items-center gap-2 p-2 pr-3',
-        'rounded-default hover:bg-btn-bg-side-bar-item-hover',
-        'text-btn-txt-side-bar-item-primary',
-      )}
-      onClick={() => emitEvent('refstudio://projects/open', { projectId: project.id })}
-    >
-      <div className="text-btn-ico-content">
-        <RefStudioEditorIcon />
-      </div>
-      {project.name}
     </div>
   );
 }

--- a/src/application/views/WelcomeView.tsx
+++ b/src/application/views/WelcomeView.tsx
@@ -27,7 +27,10 @@ export function WelcomeView() {
       {projects.length > 0 ? (
         <div className="flex flex-1 flex-col gap-12">
           <WelcomeTips />
-          <ProjectsList projects={projects} />
+          <ProjectsList
+            projects={projects}
+            onProjectClick={(project) => () => emitEvent('refstudio://projects/open', { projectId: project.id })}
+          />
         </div>
       ) : (
         <EmptyWelcomeView />

--- a/src/atoms/projectState.ts
+++ b/src/atoms/projectState.ts
@@ -1,5 +1,6 @@
 import { Atom, atom } from 'jotai';
 
+import { ProjectInfo } from '../api/projectsAPI';
 import { ensureSampleProjectFiles, setCurrentFileSystemProjectId } from '../io/filesystem';
 import { createModalAtoms } from './core/createModalAtoms';
 import { closeAllEditorsAtom } from './editorActions';
@@ -20,6 +21,8 @@ export const isProjectOpenAtom = atom((get) => get(currentProjectPathAtom) !== '
 export const projectPathAtom: Atom<string> = currentProjectPathAtom;
 export const projectNameAtom: Atom<string> = currentProjectNameAtom;
 export const projectIdAtom: Atom<string> = currentProjectIdAtom;
+
+export const allProjectsAtom = atom<ProjectInfo[]>([]);
 
 export const createProjectModalAtoms = createModalAtoms<string>();
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -193,6 +193,7 @@ export default {
         'welcome-border': 'rgb(var(--grayscale-20) / <alpha-value>)',
         'editor-selection': 'rgb(196 220 246 / <alpha-value>)',
         'radio-active': 'rgb(--primary-50 / <alpha-value>)',
+        'empty-state-ico-empty': 'rgb(var(--grayscale-40) / <alpha-value>)',
       },
       boxShadow: {
         default: '0px 0px 24px 0px rgba(0, 0, 0, 0.04)',


### PR DESCRIPTION
This implements the empty view for the welcome screen (when the user has no project)
This loads the list of projects in an atom during app startup, so that the list is already available when displaying the welcome view

<img width="1512" alt="image" src="https://github.com/refstudio/refstudio/assets/58954208/32e3b90c-6355-466f-8644-7d13d18f1a19">

Closes #499