### PR TITLE
feat: export references behaviour for web (and desktop)

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -90,7 +90,6 @@ async function makeWebRequest<ResponsePayload = unknown, RequestPayload = unknow
   payload: RequestPayload | undefined,
   responseParser: ResponseParser,
 ) {
-  console.log(`WEB FETCH REQUEST: ${method} ${path}`);
   const headers: HeadersInit =
     payload instanceof FormData
       ? {}

--- a/src/io/filesystem.ts
+++ b/src/io/filesystem.ts
@@ -1,4 +1,3 @@
-import { save } from '@tauri-apps/api/dialog';
 import type { FileEntry as TauriFileEntry } from '@tauri-apps/api/fs';
 import { JSONContent } from '@tiptap/core';
 
@@ -14,9 +13,9 @@ import {
 import { EditorContent } from '../atoms/types/EditorContent';
 import { FileEntry, FileFileEntry } from '../atoms/types/FileEntry';
 import { serializeReferences } from '../features/textEditor/components/tipTapNodes/refStudioDocument/serialization/serializeReferences';
-import { notifyError } from '../notifications/notifications';
+import { notifyError, notifyInfo } from '../notifications/notifications';
 import { ReferenceItem } from '../types/ReferenceItem';
-import { desktopDir, join, sep } from '../wrappers/tauri-wrapper';
+import { desktopDir, sep } from '../wrappers/tauri-wrapper';
 import { FILE2_CONTENT, FILE3_CONTENT, INITIAL_CONTENT } from './filesystem.sample-content';
 
 const UPLOADS_DIR = 'uploads';
@@ -226,28 +225,15 @@ export async function renameFile(relativePath: string, newRelativePath: string):
 type RenameFileResult = Promise<{ success: false } | { success: true; newPath: string }>;
 
 // #####################################################################################
-// Export Operations: references, markdown
+// Export Operations: references
 // #####################################################################################
 export async function exportReferences(references: ReferenceItem[]) {
-  if (import.meta.env.VITE_IS_WEB) {
-    throw new Error('Not implemented');
-  }
-
   try {
-    const exportsDir = getExportsDir();
-
     const serializedReferences = serializeReferences(references);
-
-    const defaultPath = await join(exportsDir, `references.${serializedReferences.extension}`);
-
-    const filePath = await save({
-      title: 'Export References',
-      defaultPath,
-      filters: [{ name: serializedReferences.extension, extensions: [serializedReferences.extension] }],
-    });
-    if (filePath) {
-      return writeProjectTextFile(currentProjectId, filePath, serializedReferences.textContent);
-    }
+    const exportPath = makeExportsPath(`references.${serializedReferences.extension}`);
+    await writeFileContent(exportPath, serializedReferences.textContent);
+    notifyInfo('References exported', `Exported ${references.length} references to ${exportPath}`);
+    return exportPath;
   } catch (err) {
     console.error('Error', err);
   }

--- a/src/wrappers/EventsListener.tsx
+++ b/src/wrappers/EventsListener.tsx
@@ -10,6 +10,7 @@ import {
 import {
   activePaneAtom,
   closeAllEditorsAtom,
+  closeEditorFromAllPanesAtom,
   closeEditorFromPaneAtom,
   moveEditorToPaneAtom,
 } from '../atoms/editorActions';
@@ -18,6 +19,7 @@ import { fileExplorerEntryPathBeingRenamed } from '../atoms/fileExplorerActions'
 import { useActiveEditorContentAtoms } from '../atoms/hooks/useActiveEditorContentAtoms';
 import { projectIdAtom } from '../atoms/projectState';
 import { getReferencesAtom, removeReferencesAtom } from '../atoms/referencesState';
+import { buildEditorIdFromPath } from '../atoms/types/EditorData';
 import { PaneEditorId } from '../atoms/types/PaneGroup';
 import { emitEvent, RefStudioEventPayload } from '../events';
 import { useListenEvent } from '../hooks/useListenEvent';
@@ -113,7 +115,16 @@ function useRemoveReferencesListener() {
 
 function useExportReferencesListener() {
   const references = useAtomValue(getReferencesAtom);
-  return () => void exportReferences(references);
+  const closeEditorFromAllPanes = useSetAtom(closeEditorFromAllPanesAtom);
+  const openFilePath = useSetAtom(openFilePathAtom);
+  return async () => {
+    const exportedFilePath = await exportReferences(references);
+    if (exportedFilePath) {
+      const editorId = buildEditorIdFromPath(exportedFilePath);
+      closeEditorFromAllPanes(editorId);
+      openFilePath(exportedFilePath);
+    }
+  };
 }
 
 function useDeleteFileListener() {

--- a/src/wrappers/tauri-api-stubs/path.ts
+++ b/src/wrappers/tauri-api-stubs/path.ts
@@ -5,6 +5,3 @@ import * as tauriPath from '@tauri-apps/api/path';
 export const desktopDir: typeof tauriPath.desktopDir = () => Promise.resolve('/Users/refstudio/Desktop/');
 
 export const sep: typeof tauriPath.sep = '/';
-
-// NOTE: might need to resolve ".." and leading "/"
-export const join: typeof tauriPath.join = (...args) => Promise.resolve(args.join(sep));

--- a/src/wrappers/tauri-wrapper.ts
+++ b/src/wrappers/tauri-wrapper.ts
@@ -17,7 +17,6 @@ export const invoke = import.meta.env.VITE_IS_WEB ? invokeStub : tauriInvoke;
 
 // @tauri-apps/api/path
 export const desktopDir = import.meta.env.VITE_IS_WEB ? stubPath.desktopDir : tauriPath.desktopDir;
-export const join = import.meta.env.VITE_IS_WEB ? stubPath.join : tauriPath.join;
 export const sep = import.meta.env.VITE_IS_WEB ? stubPath.sep : tauriPath.sep;
 
 // @tauri-apps/api/event


### PR DESCRIPTION
This closes #456 by exporting the references (.bib) to the exports folder inside the project. It will also close and open the exported file to provide user feedback.

![image](https://github.com/refstudio/refstudio/assets/174127/50f2926f-c7f7-4865-beb6-b993aa63f618)


Note: We need to close and open the file because otherwise the editor content won't update.