### PR TITLE
fix: prevent panel from uncollapsing when sidebar is disabled

### DIFF
--- a/src/application/sidebar/LeftSidePanelWrapper.tsx
+++ b/src/application/sidebar/LeftSidePanelWrapper.tsx
@@ -81,7 +81,15 @@ export function LeftSidePanelWrapper({ disabled }: { disabled?: boolean }) {
         collapsible
         order={1}
         ref={leftPanelRef}
-        onCollapse={(collapsed) => setIsPanelCollapsed(collapsed)}
+        onCollapse={(collapsed) => {
+          if (!disabled) {
+            setIsPanelCollapsed(collapsed);
+          } else if (!collapsed) {
+            // When the sidebar is disabled, the panel should be collapsed
+            // If the panel tries to update its state (because of layout stored in local storage), we prevent the update
+            leftPanelRef.current?.collapse();
+          }
+        }}
       >
         {activePanel === 'Explorer' && <ExplorerPanel />}
         {activePanel === 'References' && <ReferencesPanel />}

--- a/src/application/sidebar/RightSidePanelWrapper.tsx
+++ b/src/application/sidebar/RightSidePanelWrapper.tsx
@@ -58,7 +58,15 @@ export function RightSidePanelWrapper({ disabled }: { disabled?: boolean }) {
         collapsible
         order={3}
         ref={rightPanelRef}
-        onCollapse={(collapsed) => setIsPanelCollapsed(collapsed)}
+        onCollapse={(collapsed) => {
+          if (!disabled) {
+            setIsPanelCollapsed(collapsed);
+          } else if (!collapsed) {
+            // When the sidebar is disabled, the panel should be collapsed
+            // If the panel tries to update its state (because of layout stored in local storage), we prevent the update
+            rightPanelRef.current?.collapse();
+          }
+        }}
       >
         {activePanel === 'Rewriter' && <RewriterPanel />}
         {activePanel === 'Chatbot' && <ChatbotPanel />}


### PR DESCRIPTION
**Problem**
Resizable panels' layout is stored in local storage. When starting the app with sidebars uncollapsed, the library will force them to be uncollapsed, even if the sidebar should be disabled.

<img width="1512" alt="Screenshot 2023-09-06 at 12 42 30" src="https://github.com/refstudio/refstudio/assets/58954208/1a5e931e-464c-4800-8d86-32e1459dba1d">

**Solution**
Prevent the automatic uncollapse action performed by the library when the sidebar is disabled.

<img width="1512" alt="Screenshot 2023-09-06 at 12 43 33" src="https://github.com/refstudio/refstudio/assets/58954208/ae17379f-9fdc-4af2-b5f4-bac0f72a70c6">


Fixes #486