### PR TITLE
feat: update welcome screen

### DIFF
--- a/src/application/components/OpenEditorsTabPane.tsx
+++ b/src/application/components/OpenEditorsTabPane.tsx
@@ -6,7 +6,7 @@ import { useOpenEditorsDataForPane } from '../../atoms/hooks/useOpenEditorsDataF
 import { EditorContentType } from '../../atoms/types/EditorContent';
 import { EditorId, parseEditorId } from '../../atoms/types/EditorData';
 import { PaneId } from '../../atoms/types/PaneGroup';
-import { TabPane, TabPaneProps } from '../../components/TabPane';
+import { TabPane, TabPaneItem } from '../../components/TabPane';
 import { TABPANE_TAB_MENU_ID } from '../../components/TabPaneTabContextMenu';
 import { emitEvent } from '../../events';
 import { PdfEditorIcon, RefStudioEditorIcon } from './icons';
@@ -29,7 +29,7 @@ export function OpenEditorsTabPane({ paneId }: OpenEditorsTabPaneProps) {
 
   const selectFileInPane = useSetAtom(selectEditorInPaneAtom);
 
-  const items = openEditorsData.map<TabPaneProps<EditorId>['items'][number]>((editorData) => {
+  const items = openEditorsData.map<TabPaneItem<EditorId>>((editorData) => {
     const { type } = parseEditorId(editorData.id);
     return {
       text: editorData.title,

--- a/src/application/components/OpenEditorsTabPane.tsx
+++ b/src/application/components/OpenEditorsTabPane.tsx
@@ -4,10 +4,10 @@ import { selectEditorInPaneAtom } from '../../atoms/editorActions';
 import { useActiveEditorIdForPane } from '../../atoms/hooks/useActiveEditorIdForPane';
 import { useOpenEditorsDataForPane } from '../../atoms/hooks/useOpenEditorsDataForPane';
 import { EditorContentType } from '../../atoms/types/EditorContent';
-import { parseEditorId } from '../../atoms/types/EditorData';
+import { EditorId, parseEditorId } from '../../atoms/types/EditorData';
 import { PaneId } from '../../atoms/types/PaneGroup';
-import { TabPane } from '../../components/TabPane';
-import { TabPaneTabContextMenuProps } from '../../components/TabPaneTabContextMenu';
+import { TabPane, TabPaneProps } from '../../components/TabPane';
+import { TABPANE_TAB_MENU_ID } from '../../components/TabPaneTabContextMenu';
 import { emitEvent } from '../../events';
 import { PdfEditorIcon, RefStudioEditorIcon } from './icons';
 
@@ -29,17 +29,20 @@ export function OpenEditorsTabPane({ paneId }: OpenEditorsTabPaneProps) {
 
   const selectFileInPane = useSetAtom(selectEditorInPaneAtom);
 
-  const items = openEditorsData.map((editorData) => {
+  const items = openEditorsData.map<TabPaneProps<EditorId>['items'][number]>((editorData) => {
     const { type } = parseEditorId(editorData.id);
     return {
       text: editorData.title,
       value: editorData.id,
       isDirty: editorData.isDirty,
       Icon: EDITOR_ICONS[type](),
-      ctxProps: {
-        editorId: editorData.id,
-        paneId,
-      } as TabPaneTabContextMenuProps,
+      contextMenu: {
+        menuId: TABPANE_TAB_MENU_ID,
+        ctxProps: {
+          editorId: editorData.id,
+          paneId,
+        },
+      },
     };
   });
 

--- a/src/application/components/icons.tsx
+++ b/src/application/components/icons.tsx
@@ -8,19 +8,6 @@ export function AddIcon() {
   );
 }
 
-export function SampleIcon() {
-  return (
-    <div className="flex h-6 w-6 items-center justify-center">
-      <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-        <path
-          d="M7 2V4H8V18C8 19.0609 8.42143 20.0783 9.17157 20.8284C9.92172 21.5786 10.9391 22 12 22C13.0609 22 14.0783 21.5786 14.8284 20.8284C15.5786 20.0783 16 19.0609 16 18V4H17V2H7ZM11 16C10.4 16 10 15.6 10 15C10 14.4 10.4 14 11 14C11.6 14 12 14.4 12 15C12 15.6 11.6 16 11 16ZM13 12C12.4 12 12 11.6 12 11C12 10.4 12.4 10 13 10C13.6 10 14 10.4 14 11C14 11.6 13.6 12 13 12ZM14 7H10V4H14V7Z"
-          fill="currentcolor"
-        />
-      </svg>
-    </div>
-  );
-}
-
 export const RefStudioEditorIcon = () => (
   <div className="flex h-6 w-6 items-center justify-center">
     <svg height="20" viewBox="0 0 20 20" width="20" xmlns="http://www.w3.org/2000/svg">

--- a/src/application/components/icons.tsx
+++ b/src/application/components/icons.tsx
@@ -66,3 +66,14 @@ export const EmptyStateIcon = () => (
     </svg>
   </div>
 );
+
+export const WelcomeIcon = () => (
+  <div className="flex h-6 w-6 items-center justify-center">
+    <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M12 2C13.1 2 14 2.9 14 4C14 5.1 13.1 6 12 6C10.9 6 10 5.1 10 4C10 2.9 10.9 2 12 2ZM15.9 8.1C15.5 7.7 14.8 7 13.5 7H11C8.2 7 6 4.8 6 2H4C4 5.2 6.1 7.8 9 8.7V22H11V16H13V22H15V10.1L19 14L20.4 12.6L15.9 8.1Z"
+        fill="currentcolor"
+      />
+    </svg>
+  </div>
+);

--- a/src/application/listeners/projectEventListeners.ts
+++ b/src/application/listeners/projectEventListeners.ts
@@ -49,6 +49,8 @@ export function useFileProjectNewListener() {
 export function useFileProjectNewSampleListener() {
   const sampleProject = useSetAtom(newSampleProjectAtom);
   const createFile = useSetAtom(createFileAtom);
+  const setAllProjects = useSetAtom(allProjectsAtom);
+
   return async () => {
     const projects = await readAllProjects();
     let project = projects.find((p) => p.name === SAMPLE_PROJECT_NAME);
@@ -59,6 +61,9 @@ export function useFileProjectNewSampleListener() {
     createFile();
     notifyInfo('Sample project opened with success');
     persistActiveProjectInSettings(project.id);
+
+    // Update allProjectsAtom
+    setAllProjects(await readAllProjects());
   };
 }
 

--- a/src/application/views/WelcomeView.tsx
+++ b/src/application/views/WelcomeView.tsx
@@ -44,7 +44,7 @@ export function WelcomeView() {
           <EmptyWelcomeView />
         )}
       </div>
-    </div >
+    </div>
   );
 }
 

--- a/src/application/views/WelcomeView.tsx
+++ b/src/application/views/WelcomeView.tsx
@@ -3,38 +3,46 @@ import { useAtomValue } from 'jotai';
 import { allProjectsAtom } from '../../atoms/projectState';
 import { Button } from '../../components/Button';
 import { OpenIcon } from '../../components/icons';
+import { TabPane } from '../../components/TabPane';
 import { emitEvent } from '../../events';
-import { cx } from '../../lib/cx';
-import { AddIcon, EmptyStateIcon, SampleIcon } from '../components/icons';
+import { AddIcon, EmptyStateIcon, WelcomeIcon } from '../components/icons';
 import { ProjectsList } from '../components/ProjectsList';
 
 export function WelcomeView() {
   const projects = useAtomValue(allProjectsAtom);
 
   return (
-    <div
-      className={cx(
-        'h-full w-full p-10',
-        'flex flex-row items-stretch gap-10',
-        'bg-content-area-bg-primary',
-        'cursor-default select-none',
-      )}
-    >
-      <div className="flex w-56 flex-col items-stretch">
-        <WelcomeActions />
+    <div className="flex h-full w-full flex-1 flex-col items-stretch">
+      <div>
+        <TabPane
+          items={[
+            {
+              text: 'Welcome',
+              value: 'welcome',
+              Icon: <WelcomeIcon />,
+            },
+          ]}
+          value="welcome"
+        />
       </div>
-      <div className="w-[1px] bg-welcome-border" />
-      {projects.length > 0 ? (
-        <div className="flex flex-1 flex-col gap-12">
-          <WelcomeTips />
-          <ProjectsList
-            projects={projects}
-            onProjectClick={(project) => () => emitEvent('refstudio://projects/open', { projectId: project.id })}
-          />
-        </div>
-      ) : (
-        <EmptyWelcomeView />
-      )}
+      <div className="flex flex-1 gap-10 bg-content-area-bg-primary p-10">
+        {projects.length > 0 ? (
+          <>
+            <div className="flex w-56 flex-col items-stretch">
+              <WelcomeActions />
+            </div>
+            <div className="w-[1px] bg-welcome-border" />
+            <div className="flex flex-1 flex-col gap-12">
+              <ProjectsList
+                projects={projects}
+                onProjectClick={(project) => emitEvent('refstudio://projects/open', { projectId: project.id })}
+              />
+            </div>
+          </>
+        ) : (
+          <EmptyWelcomeView />
+        )}
+      </div>
     </div>
   );
 }
@@ -47,10 +55,15 @@ function EmptyWelcomeView() {
       </div>
       <div className="flex flex-col items-center justify-center gap-2 self-stretch">
         <div className="text-xl/6 font-semibold text-side-bar-txt-primary">Get Started</div>
-        <div className="text-side-bar-txt-secondary">Create new projects to see them here.</div>
+        <div className="text-side-bar-txt-secondary">Create a new project or try a sample one.</div>
       </div>
       <div className="flex w-64 flex-col items-center justify-center gap-2">
-        <Button fluid size="M" text="Create Project" onClick={() => emitEvent('refstudio://menu/file/project/new')} />
+        <Button
+          fluid
+          size="M"
+          text="Create First Project"
+          onClick={() => emitEvent('refstudio://menu/file/project/new')}
+        />
         <Button
           fluid
           size="M"
@@ -80,33 +93,6 @@ function WelcomeActions() {
           text="Open Project"
           type="secondary"
           onClick={() => emitEvent('refstudio://menu/file/project/open')}
-        />
-      </div>
-    </div>
-  );
-}
-
-function WelcomeTips() {
-  return (
-    <div
-      className={cx(
-        'flex flex-col items-stretch gap-6 p-6 pt-5',
-        'rounded-default bg-card-bg-secondary',
-        'border-t-8 border-t-card-bg-header',
-      )}
-    >
-      <div className="flex flex-col items-start gap-4 text-card-txt-primary">
-        <h1 className="flex-1 text-card-txt-primary">Tip & Tricks</h1>
-        <div className="flex flex-col items-start gap-2">
-          <div className="f text-2xl/6 font-semibold">Are you New to Refstudio?</div>
-          <div>Learn more by playing with a sample project.</div>
-        </div>
-      </div>
-      <div className="flex flex-row items-start gap-2">
-        <Button
-          Action={<SampleIcon />}
-          text="Try Sample Project"
-          onClick={() => emitEvent('refstudio://menu/file/project/new/sample')}
         />
       </div>
     </div>

--- a/src/components/TabPane.tsx
+++ b/src/components/TabPane.tsx
@@ -3,19 +3,25 @@ import { useContextMenu } from 'react-contexify';
 
 import { cx } from '../lib/cx';
 import { TabCloseButton } from './TabCloseButton';
-import { TABPANE_TAB_MENU_ID } from './TabPaneTabContextMenu';
 
-export function TabPane<K extends string>({
-  items,
-  value,
-  onClick,
-  onCloseClick,
-}: {
-  items: { text: string; value: K; ctxProps?: unknown; isDirty?: boolean; Icon?: React.ReactElement }[];
+export interface TabPaneItem<K extends string> {
+  text: string;
+  value: K;
+  isDirty?: boolean;
+  Icon?: React.ReactElement;
+  contextMenu?: {
+    menuId: string;
+    ctxProps: unknown;
+  };
+}
+
+export interface TabPaneProps<K extends string> {
+  items: TabPaneItem<K>[];
   value: K | null;
-  onClick(value: K): void;
-  onCloseClick(value: K): void;
-}) {
+  onClick?: (value: K) => void;
+  onCloseClick?: (value: K) => void;
+}
+export function TabPane<K extends string>({ items, value, onClick, onCloseClick }: TabPaneProps<K>) {
   const activeIndex = useMemo(() => items.findIndex((item) => item.value === value), [items, value]);
 
   return (
@@ -25,7 +31,6 @@ export function TabPane<K extends string>({
     >
       {items.map((item, index) => (
         <TabItem
-          Icon={item.Icon}
           active={activeIndex === index}
           className={cx({
             'border-l border-l-top-bar-border': index > 0,
@@ -33,12 +38,10 @@ export function TabPane<K extends string>({
             'rounded-bl-default border-l-0': activeIndex === index - 1,
             'rounded-br-default': activeIndex === index + 1,
           })}
-          content={item.text}
-          ctxProps={item.ctxProps}
-          isDirty={item.isDirty}
           key={item.value}
-          onClick={() => onClick(item.value)}
-          onCloseClick={() => onCloseClick(item.value)}
+          {...item}
+          onClick={onClick && (() => onClick(item.value))}
+          onCloseClick={onCloseClick && (() => onCloseClick(item.value))}
         />
       ))}
       {items.length > 0 && (
@@ -54,23 +57,26 @@ export function TabPane<K extends string>({
 
 interface TabItemProps {
   active: boolean;
-  ctxProps: unknown;
-  content: React.ReactNode;
+  contextMenu?: {
+    menuId: string;
+    ctxProps: unknown;
+  };
+  text: React.ReactNode;
   className?: string;
   isDirty?: boolean;
   Icon?: React.ReactElement;
-  onClick: () => void;
-  onCloseClick: () => void;
+  onClick?: () => void;
+  onCloseClick?: () => void;
 }
-export function TabItem({ active, content, isDirty, className, ctxProps, Icon, onClick, onCloseClick }: TabItemProps) {
-  const { show } = useContextMenu({ id: TABPANE_TAB_MENU_ID, props: ctxProps });
+export function TabItem({ active, isDirty, className, contextMenu, Icon, text, onClick, onCloseClick }: TabItemProps) {
+  const { show } = useContextMenu();
 
   return (
     <div
       aria-selected={active}
       className={cx(
         'min-w-32 flex max-w-[11.5rem] items-center gap-2 p-2',
-        'cursor-pointer select-none',
+        'cursor-default select-none',
         'group',
         {
           'bg-top-bar-bg-inactive hover:bg-top-bar-bg-active': !active,
@@ -80,14 +86,20 @@ export function TabItem({ active, content, isDirty, className, ctxProps, Icon, o
           'text-btn-ico-top-bar-active': active,
           'text-btn-ico-top-bar-inactive': !active,
         },
+        {
+          'cursor-pointer': !!onClick,
+        },
         className,
       )}
       role="tab"
-      onClick={(e) => {
-        e.preventDefault();
-        onClick();
-      }}
-      onContextMenu={(e) => show({ event: e })}
+      onClick={
+        onClick &&
+        ((e) => {
+          e.preventDefault();
+          onClick();
+        })
+      }
+      onContextMenu={contextMenu && ((e) => show({ event: e, id: contextMenu.menuId, props: contextMenu.ctxProps }))}
     >
       {Icon}
       <span
@@ -96,9 +108,9 @@ export function TabItem({ active, content, isDirty, className, ctxProps, Icon, o
           'text-btn-txt-top-bar-inactive': !active,
         })}
       >
-        {content}
+        {text}
       </span>
-      <TabCloseButton isDirty={isDirty} onClick={onCloseClick} />
+      {onCloseClick ? <TabCloseButton isDirty={isDirty} onClick={onCloseClick} /> : <div className="w-1" />}
     </div>
   );
 }

--- a/src/components/TabPane.tsx
+++ b/src/components/TabPane.tsx
@@ -15,7 +15,7 @@ export interface TabPaneItem<K extends string> {
   };
 }
 
-export interface TabPaneProps<K extends string> {
+interface TabPaneProps<K extends string> {
   items: TabPaneItem<K>[];
   value: K | null;
   onClick?: (value: K) => void;


### PR DESCRIPTION
This removes the left buttons in the empty welcome screen:

<img width="1512" alt="Screenshot 2023-09-06 at 14 19 28" src="https://github.com/refstudio/refstudio/assets/58954208/03f55187-ba65-4c97-a34d-b7e8c3654c05">

This also removes the Tips&Tricks collapsible in the default view:

<img width="1512" alt="Screenshot 2023-09-06 at 14 20 13" src="https://github.com/refstudio/refstudio/assets/58954208/be7ed135-9ab9-4840-b63f-84d72302c0ae">

Finally, this refreshes the `allProjectsAtom` after creating a Sampl project (this had been forgotten when implementing #500)

Closes #475