### PR TITLE
fix: activate venv instead of using poetry run

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -9,6 +9,7 @@ runs:
   - name: Get yarn cache directory path
     id: yarn-cache-dir-path
     run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+    shell: 'bash'
   - name: Load cached dependencies
     id: cached-yarn-dependencies
     uses: actions/cache@v3

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,19 +6,7 @@ runs:
     with:
       node-version: 'lts/*'
       cache: 'yarn'
-  - name: Get yarn cache directory path
-    id: yarn-cache-dir-path
-    run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-    shell: 'bash'
-  - name: Load cached dependencies
-    id: cached-yarn-dependencies
-    uses: actions/cache@v3
-    with:
-      path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-      key: yarn-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-  - name: Install dependencies
-    if: steps.cached-yarn-dependencies.outputs.cache-hit != 'true'
-    run: yarn install --immutable
+  - run: yarn install --immutable
     shell: 'bash'
     env:
       YARN_ENABLE_SCRIPTS: 0

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,7 +6,18 @@ runs:
     with:
       node-version: 'lts/*'
       cache: 'yarn'
-  - run: yarn install --immutable
+  - name: Get yarn cache directory path
+    id: yarn-cache-dir-path
+    run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+  - name: Load cached dependencies
+    id: cached-yarn-dependencies
+    uses: actions/cache@v3
+    with:
+      path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+      key: yarn-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+  - name: Install dependencies
+    if: steps.cached-yarn-dependencies.outputs.cache-hit != 'true'
+    run: yarn install --immutable
     shell: 'bash'
     env:
       YARN_ENABLE_SCRIPTS: 0

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -20,6 +20,7 @@ runs:
       virtualenvs-create: true
       virtualenvs-in-project: true
       installer-parallel: true
+      virtualenvs-path: .venv
   - name: Load cached dependencies
     id: cached-poetry-dependencies
     uses: actions/cache@v3

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -12,7 +12,7 @@ runs:
     uses: actions/cache@v3
     with:
       path: ~/.local
-      key: poetry-0
+      key: poetry-cache-${{ hashFiles('.github/actions/setup-python/action.yml') }}
   - name: Install Poetry
     if: steps.cached-poetry.outputs.cache-hit != 'true'
     uses: snok/install-poetry@v1
@@ -20,7 +20,6 @@ runs:
       virtualenvs-create: true
       virtualenvs-in-project: true
       installer-parallel: true
-      virtualenvs-path: .venv
   - name: Load cached dependencies
     id: cached-poetry-dependencies
     uses: actions/cache@v3

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -20,11 +20,13 @@ runs:
       virtualenvs-create: true
       virtualenvs-in-project: true
       installer-parallel: true
-  - id: cached-poetry-dependencies
+  - name: Load cached dependencies
+    id: cached-poetry-dependencies
     uses: actions/cache@v3
     with:
       path: .venv
       key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-  - if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+  - name: Install dependencies
+    if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
     run: poetry install --no-interaction --no-root
     shell: 'bash'

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -7,7 +7,15 @@ runs:
     with:
       python-version: "3.11"
     id: setup-python
-  - uses: snok/install-poetry@v1
+  - name: Load cached Poetry installation
+    id: cached-poetry
+    uses: actions/cache@v3
+    with:
+      path: ~/.local
+      key: poetry-0
+  - name: Install Poetry
+    if: steps.cached-poetry.outputs.cache-hit != 'true'
+    uses: snok/install-poetry@v1
     with:
       virtualenvs-create: true
       virtualenvs-in-project: true
@@ -19,6 +27,4 @@ runs:
       key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
   - if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
     run: poetry install --no-interaction --no-root
-    shell: 'bash'
-  - run: poetry install --no-interaction
     shell: 'bash'

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -84,9 +84,7 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-python
       - name: PyLint
-        run: |
-          source .venv/bin/activate
-          ruff check ./python
+        run: poetry run ruff check ./python
 
   pytest:
     needs: setup-python
@@ -97,9 +95,7 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-python
       - name: Run tests
-        run: |
-          source .venv/bin/activate
-          pytest python/tests --cov=python --cov-report=xml
+        run: poetry run pytest python/tests --cov=python --cov-report=xml
       - name: Upload python coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -84,7 +84,9 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-python
       - name: PyLint
-        run: poetry run ruff check ./python
+        run: |
+          source .venv/bin/activate
+          ruff check ./python
 
   pytest:
     needs: setup-python
@@ -94,10 +96,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Python
         uses: ./.github/actions/setup-python
-      - name: Install pytest
-        run: pip install pytest
       - name: Run tests
-        run: poetry run pytest python/tests --cov=python --cov-report=xml
+        run: |
+          source .venv/bin/activate
+          pytest python/tests --cov=python --cov-report=xml
       - name: Upload python coverage to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
I think we had some issues with our cache and removing it fixed the failing CI.
This PR is removing the unnecessary installation of pytest via pip (pytest is installed via poetry in setup-python)
This is also improving our CI by caching poetry so that python jobs now take half of the time they use to take:

Before the PR:
<img width="302" alt="Screenshot 2023-09-07 at 15 30 31" src="https://github.com/refstudio/refstudio/assets/58954208/5ec62e5a-a38f-4bf9-97c3-3b05dd4d51de">

After the PR:
<img width="300" alt="Screenshot 2023-09-07 at 15 31 38" src="https://github.com/refstudio/refstudio/assets/58954208/57f60184-17ab-49f5-a59f-a48e89a09821">

