### PR TITLE
Add support for Ollama, Palm, Claude-2, Cohere, Llama2, CodeLlama (100+LLMs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.9, <3.12"  # pyinstaller requires Python <3.12
 grobid-tei-xml = "^0.1.3"
 grobid-client-python = "^0.0.5"
 openai = "^0.27.7"
+litellm = "^0.1.500"
 python-dotenv = "^1.0.0"
 pydantic = "^1.10.9"
 rank-bm25 = "^0.2.2"

--- a/python/sidecar/ai/chat.py
+++ b/python/sidecar/ai/chat.py
@@ -1,6 +1,7 @@
 import os
 
 import openai
+import litellm
 from sidecar import config
 from sidecar.ai.prompts import create_prompt_for_chat, prepare_chunks_for_prompt
 from sidecar.ai.ranker import BM25Ranker
@@ -87,7 +88,7 @@ class Chat:
         logger.info(
             f"Calling OpenAI chat API with the following input message(s): {messages}"
         )
-        response = openai.ChatCompletion.create(
+        response = litellm.completion(
             model=self.model,
             messages=messages,
             n=n_choices,  # number of completions to generate

--- a/python/sidecar/ai/rewrite.py
+++ b/python/sidecar/ai/rewrite.py
@@ -2,6 +2,7 @@ import os
 import re
 
 import openai
+import litellm
 from sidecar.ai.prompts import (
     create_prompt_for_rewrite,
     create_prompt_for_text_completion,
@@ -213,7 +214,7 @@ class Rewriter:
         logger.info(
             f"Calling OpenAI chat API with the following input message(s): {messages}"
         )
-        response = openai.ChatCompletion.create(
+        response = litellm.completion(
             model=self.model,
             messages=messages,
             n=self.n_choices,  # number of completions to generate


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 

Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```