### PR TITLE
feat: Add missing api response types

### DIFF
--- a/python/api.schema.json
+++ b/python/api.schema.json
@@ -117,6 +117,44 @@
       ],
       "title": "Chunk"
     },
+    "CreateFileResponse": {
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResponseStatus"
+        },
+        "message": {
+          "type": "string"
+        },
+        "filepath": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "status",
+        "message"
+      ],
+      "title": "CreateFileResponse"
+    },
+    "DeleteFileResponse": {
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResponseStatus"
+        },
+        "message": {
+          "type": "string"
+        },
+        "filepath": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "status",
+        "message"
+      ],
+      "title": "DeleteFileResponse"
+    },
     "DeleteRequest": {
       "properties": {
         "reference_ids": {
@@ -328,6 +366,46 @@
       ],
       "title": "ProjectCreateRequest"
     },
+    "ProjectCreateResponse": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "path"
+      ],
+      "title": "ProjectCreateResponse"
+    },
+    "ProjectDeleteResponse": {
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResponseStatus"
+        },
+        "message": {
+          "type": "string"
+        },
+        "project_id": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "status",
+        "message",
+        "project_id"
+      ],
+      "title": "ProjectDeleteResponse"
+    },
     "ProjectDetailsResponse": {
       "properties": {
         "id": {
@@ -369,6 +447,37 @@
         "contents"
       ],
       "title": "ProjectFileTreeResponse"
+    },
+    "ProjectStorageItem": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "path"
+      ],
+      "title": "ProjectStorageItem"
+    },
+    "ProjectStorageResponse": {
+      "properties": {
+        "projects": {
+          "additionalProperties": {
+            "$ref": "#/definitions/ProjectStorageItem"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "required": [
+        "projects"
+      ],
+      "title": "ProjectStorageResponse"
     },
     "Reference": {
       "properties": {
@@ -582,6 +691,18 @@
         "results"
       ],
       "title": "SearchResponse"
+    },
+    "StatusResponse": {
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResponseStatus"
+        }
+      },
+      "type": "object",
+      "required": [
+        "status"
+      ],
+      "title": "StatusResponse"
     },
     "TextCompletionChoice": {
       "properties": {

--- a/python/api.schema.json
+++ b/python/api.schema.json
@@ -117,44 +117,6 @@
       ],
       "title": "Chunk"
     },
-    "CreateFileResponse": {
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/ResponseStatus"
-        },
-        "message": {
-          "type": "string"
-        },
-        "filepath": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "required": [
-        "status",
-        "message"
-      ],
-      "title": "CreateFileResponse"
-    },
-    "DeleteFileResponse": {
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/ResponseStatus"
-        },
-        "message": {
-          "type": "string"
-        },
-        "filepath": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "required": [
-        "status",
-        "message"
-      ],
-      "title": "DeleteFileResponse"
-    },
     "DeleteRequest": {
       "properties": {
         "reference_ids": {
@@ -351,6 +313,22 @@
       "title": "IngestStatus",
       "description": "An enumeration."
     },
+    "ProjectBase": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "title": "ProjectBase"
+    },
     "ProjectCreateRequest": {
       "properties": {
         "project_name": {
@@ -366,46 +344,6 @@
       ],
       "title": "ProjectCreateRequest"
     },
-    "ProjectCreateResponse": {
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "required": [
-        "id",
-        "name",
-        "path"
-      ],
-      "title": "ProjectCreateResponse"
-    },
-    "ProjectDeleteResponse": {
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/ResponseStatus"
-        },
-        "message": {
-          "type": "string"
-        },
-        "project_id": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "required": [
-        "status",
-        "message",
-        "project_id"
-      ],
-      "title": "ProjectDeleteResponse"
-    },
     "ProjectDetailsResponse": {
       "properties": {
         "id": {
@@ -413,16 +351,12 @@
         },
         "name": {
           "type": "string"
-        },
-        "path": {
-          "type": "string"
         }
       },
       "type": "object",
       "required": [
         "id",
-        "name",
-        "path"
+        "name"
       ],
       "title": "ProjectDetailsResponse"
     },
@@ -448,36 +382,20 @@
       ],
       "title": "ProjectFileTreeResponse"
     },
-    "ProjectStorageItem": {
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "required": [
-        "name",
-        "path"
-      ],
-      "title": "ProjectStorageItem"
-    },
-    "ProjectStorageResponse": {
+    "ProjectListResponse": {
       "properties": {
         "projects": {
-          "additionalProperties": {
-            "$ref": "#/definitions/ProjectStorageItem"
+          "items": {
+            "$ref": "#/definitions/ProjectBase"
           },
-          "type": "object"
+          "type": "array"
         }
       },
       "type": "object",
       "required": [
         "projects"
       ],
-      "title": "ProjectStorageResponse"
+      "title": "ProjectListResponse"
     },
     "Reference": {
       "properties": {
@@ -696,6 +614,10 @@
       "properties": {
         "status": {
           "$ref": "#/definitions/ResponseStatus"
+        },
+        "message": {
+          "type": "string",
+          "default": ""
         }
       },
       "type": "object",

--- a/python/openapi.json
+++ b/python/openapi.json
@@ -118,6 +118,44 @@
         "title": "Chunk",
         "type": "object"
       },
+      "CreateFileResponse": {
+        "properties": {
+          "filepath": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResponseStatus"
+          }
+        },
+        "required": [
+          "status",
+          "message"
+        ],
+        "title": "CreateFileResponse",
+        "type": "object"
+      },
+      "DeleteFileResponse": {
+        "properties": {
+          "filepath": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResponseStatus"
+          }
+        },
+        "required": [
+          "status",
+          "message"
+        ],
+        "title": "DeleteFileResponse",
+        "type": "object"
+      },
       "DeleteRequest": {
         "properties": {
           "all": {
@@ -329,6 +367,46 @@
         "title": "ProjectCreateRequest",
         "type": "object"
       },
+      "ProjectCreateResponse": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "path"
+        ],
+        "title": "ProjectCreateResponse",
+        "type": "object"
+      },
+      "ProjectDeleteResponse": {
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResponseStatus"
+          }
+        },
+        "required": [
+          "status",
+          "message",
+          "project_id"
+        ],
+        "title": "ProjectDeleteResponse",
+        "type": "object"
+      },
       "ProjectDetailsResponse": {
         "properties": {
           "id": {
@@ -369,6 +447,37 @@
           "contents"
         ],
         "title": "ProjectFileTreeResponse",
+        "type": "object"
+      },
+      "ProjectStorageItem": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "path"
+        ],
+        "title": "ProjectStorageItem",
+        "type": "object"
+      },
+      "ProjectStorageResponse": {
+        "properties": {
+          "projects": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ProjectStorageItem"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "projects"
+        ],
+        "title": "ProjectStorageResponse",
         "type": "object"
       },
       "Reference": {
@@ -582,6 +691,18 @@
           "results"
         ],
         "title": "SearchResponse",
+        "type": "object"
+      },
+      "StatusResponse": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/ResponseStatus"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "StatusResponse",
         "type": "object"
       },
       "TextCompletionChoice": {
@@ -872,7 +993,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteFileResponse"
+                }
               }
             },
             "description": "Successful Response"
@@ -1026,7 +1149,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/CreateFileResponse"
+                }
               }
             },
             "description": "Successful Response"
@@ -1074,7 +1199,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
               }
             },
             "description": "Successful Response"
@@ -1094,7 +1221,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectStorageResponse"
+                }
               }
             },
             "description": "Successful Response"
@@ -1122,7 +1251,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectCreateResponse"
+                }
               }
             },
             "description": "Successful Response"
@@ -1163,7 +1294,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectDeleteResponse"
+                }
               }
             },
             "description": "Successful Response"

--- a/python/openapi.json
+++ b/python/openapi.json
@@ -118,44 +118,6 @@
         "title": "Chunk",
         "type": "object"
       },
-      "CreateFileResponse": {
-        "properties": {
-          "filepath": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "status": {
-            "$ref": "#/components/schemas/ResponseStatus"
-          }
-        },
-        "required": [
-          "status",
-          "message"
-        ],
-        "title": "CreateFileResponse",
-        "type": "object"
-      },
-      "DeleteFileResponse": {
-        "properties": {
-          "filepath": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "status": {
-            "$ref": "#/components/schemas/ResponseStatus"
-          }
-        },
-        "required": [
-          "status",
-          "message"
-        ],
-        "title": "DeleteFileResponse",
-        "type": "object"
-      },
       "DeleteRequest": {
         "properties": {
           "all": {
@@ -352,6 +314,22 @@
         "title": "IngestStatus",
         "type": "string"
       },
+      "ProjectBase": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "ProjectBase",
+        "type": "object"
+      },
       "ProjectCreateRequest": {
         "properties": {
           "project_name": {
@@ -367,46 +345,6 @@
         "title": "ProjectCreateRequest",
         "type": "object"
       },
-      "ProjectCreateResponse": {
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "path": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "path"
-        ],
-        "title": "ProjectCreateResponse",
-        "type": "object"
-      },
-      "ProjectDeleteResponse": {
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "project_id": {
-            "type": "string"
-          },
-          "status": {
-            "$ref": "#/components/schemas/ResponseStatus"
-          }
-        },
-        "required": [
-          "status",
-          "message",
-          "project_id"
-        ],
-        "title": "ProjectDeleteResponse",
-        "type": "object"
-      },
       "ProjectDetailsResponse": {
         "properties": {
           "id": {
@@ -414,15 +352,11 @@
           },
           "name": {
             "type": "string"
-          },
-          "path": {
-            "type": "string"
           }
         },
         "required": [
           "id",
-          "name",
-          "path"
+          "name"
         ],
         "title": "ProjectDetailsResponse",
         "type": "object"
@@ -449,35 +383,19 @@
         "title": "ProjectFileTreeResponse",
         "type": "object"
       },
-      "ProjectStorageItem": {
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "path": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "path"
-        ],
-        "title": "ProjectStorageItem",
-        "type": "object"
-      },
-      "ProjectStorageResponse": {
+      "ProjectListResponse": {
         "properties": {
           "projects": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ProjectStorageItem"
+            "items": {
+              "$ref": "#/components/schemas/ProjectBase"
             },
-            "type": "object"
+            "type": "array"
           }
         },
         "required": [
           "projects"
         ],
-        "title": "ProjectStorageResponse",
+        "title": "ProjectListResponse",
         "type": "object"
       },
       "Reference": {
@@ -695,6 +613,10 @@
       },
       "StatusResponse": {
         "properties": {
+          "message": {
+            "default": "",
+            "type": "string"
+          },
           "status": {
             "$ref": "#/components/schemas/ResponseStatus"
           }
@@ -994,7 +916,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DeleteFileResponse"
+                  "$ref": "#/components/schemas/StatusResponse"
                 }
               }
             },
@@ -1150,7 +1072,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateFileResponse"
+                  "$ref": "#/components/schemas/StatusResponse"
                 }
               }
             },
@@ -1222,7 +1144,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProjectStorageResponse"
+                  "$ref": "#/components/schemas/ProjectListResponse"
                 }
               }
             },
@@ -1252,7 +1174,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProjectCreateResponse"
+                  "$ref": "#/components/schemas/ProjectBase"
                 }
               }
             },
@@ -1295,7 +1217,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProjectDeleteResponse"
+                  "$ref": "#/components/schemas/StatusResponse"
                 }
               }
             },

--- a/python/sidecar/filesystem/router.py
+++ b/python/sidecar/filesystem/router.py
@@ -54,7 +54,7 @@ async def read_file(project_id: str, filepath: Path) -> FileResponse:
 
 
 @router.head("/{project_id}/{filepath:path}", status_code=200)
-async def head_file(project_id: str, filepath: Path):
+async def head_file(project_id: str, filepath: Path) -> None:
     user_id = "user1"
     project_path = get_project_path(user_id, project_id)
     filepath = project_path / filepath

--- a/python/sidecar/filesystem/schemas.py
+++ b/python/sidecar/filesystem/schemas.py
@@ -1,0 +1,13 @@
+from sidecar.typing import RefStudioModel, ResponseStatus
+
+
+class CreateFileResponse(RefStudioModel):
+    status: ResponseStatus
+    message: str
+    filepath: str | None = None
+
+
+class DeleteFileResponse(RefStudioModel):
+    status: ResponseStatus
+    message: str
+    filepath: str | None = None

--- a/python/sidecar/filesystem/schemas.py
+++ b/python/sidecar/filesystem/schemas.py
@@ -1,13 +1,19 @@
-from sidecar.typing import RefStudioModel, ResponseStatus
+from __future__ import annotations
+
+from sidecar.typing import RefStudioModel
 
 
-class CreateFileResponse(RefStudioModel):
-    status: ResponseStatus
-    message: str
-    filepath: str | None = None
+class FileEntryBase(RefStudioModel):
+    name: str
+    path: str
 
 
-class DeleteFileResponse(RefStudioModel):
-    status: ResponseStatus
-    message: str
-    filepath: str | None = None
+class FileEntry(FileEntryBase):
+    file_extension: str
+
+
+class FolderEntry(FileEntryBase):
+    children: list[FileEntry | FolderEntry] = []
+
+
+FolderEntry.update_forward_refs()

--- a/python/sidecar/filesystem/service.py
+++ b/python/sidecar/filesystem/service.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from sidecar.filesystem.schemas import FileEntry, FolderEntry
+
+
+def create_file_entry(path: Path, relative_to: Path) -> FileEntry:
+    return FileEntry(
+        name=path.name,
+        path=str(path.relative_to(relative_to)),
+        file_extension=path.suffix,
+    )
+
+
+def traverse_directory(
+    directory: Path, relative_to: Path, ignore_hidden: bool = True
+) -> list[FileEntry | FolderEntry]:
+    """
+    Traverse a directory recursively and return a list of all files.
+    """
+    contents = []
+    for obj in directory.glob("*"):
+        if ignore_hidden and obj.name.startswith("."):
+            continue
+        if obj.is_dir():
+            contents.append(
+                FolderEntry(
+                    name=obj.name,
+                    path=str(obj.relative_to(relative_to)),
+                    children=traverse_directory(obj, relative_to=relative_to),
+                )
+            )
+        else:
+            contents.append(create_file_entry(obj, relative_to=relative_to))
+    return contents

--- a/python/sidecar/meta/router.py
+++ b/python/sidecar/meta/router.py
@@ -3,6 +3,7 @@ import os
 
 import psutil
 from fastapi import APIRouter
+from sidecar.typing import ResponseStatus, StatusResponse
 
 router = APIRouter(
     prefix="/meta",
@@ -11,12 +12,12 @@ router = APIRouter(
 
 
 @router.get("/status")
-async def status():
-    return {"status": "ok"}
+async def status() -> StatusResponse:
+    return StatusResponse(status=ResponseStatus.OK)
 
 
 @router.post("/shutdown")
-async def shutdown():
+async def shutdown() -> None:
     # See https://stackoverflow.com/a/74757349/388951
     parent_pid = os.getpid()
     parent = psutil.Process(parent_pid)

--- a/python/sidecar/projects/router.py
+++ b/python/sidecar/projects/router.py
@@ -3,14 +3,13 @@ from uuid import uuid4
 from fastapi import APIRouter
 from sidecar.projects import service
 from sidecar.projects.schemas import (
+    ProjectBase,
     ProjectCreateRequest,
-    ProjectCreateResponse,
-    ProjectDeleteResponse,
     ProjectDetailsResponse,
     ProjectFileTreeResponse,
-    ProjectStorageResponse,
+    ProjectListResponse,
 )
-from sidecar.typing import ResponseStatus
+from sidecar.typing import ResponseStatus, StatusResponse
 
 router = APIRouter(
     prefix="/projects",
@@ -19,25 +18,28 @@ router = APIRouter(
 
 
 @router.get("/")
-async def list_projects() -> ProjectStorageResponse:
+async def list_projects() -> ProjectListResponse:
     """
     Returns a list of projects for the current user
     """
     user_id = "user1"
-    return service.read_project_path_storage(user_id)
+    projects = []
+    for proj in service.get_projects_for_user(user_id):
+        projects.append(ProjectBase(**proj.dict()))
+    return ProjectListResponse(projects=projects)
 
 
 @router.post("/")
-async def create_project(req: ProjectCreateRequest) -> ProjectCreateResponse:
+async def create_project(req: ProjectCreateRequest) -> ProjectBase:
     """
     Creates a project, and a directory in the filesystem
     """
     user_id = "user1"
     project_id = str(uuid4())
-    project_item = service.create_project(
+    project = service.create_project(
         user_id, project_id, req.project_name, req.project_path
     )
-    return ProjectCreateResponse(id=project_id, **project_item.dict())
+    return ProjectBase(id=project.id, name=project.name)
 
 
 @router.get("/{project_id}")
@@ -46,11 +48,12 @@ async def get_project(project_id: str) -> ProjectDetailsResponse:
     Returns details about a project
     """
     user_id = "user1"
-    return service.get_project_details(user_id, project_id)
+    project = service.get_project(user_id, project_id)
+    return ProjectDetailsResponse(**project.dict())
 
 
 @router.delete("/{project_id}")
-async def delete_project(project_id: str) -> ProjectDeleteResponse:
+async def delete_project(project_id: str) -> StatusResponse:
     """
     Deletes a project directory and all files in it
     """
@@ -58,16 +61,8 @@ async def delete_project(project_id: str) -> ProjectDeleteResponse:
     try:
         service.delete_project(user_id, project_id)
     except KeyError:
-        return ProjectDeleteResponse(
-            status=ResponseStatus.ERROR,
-            message="Project not found",
-            project_id=project_id,
-        )
-    return ProjectDeleteResponse(
-        status=ResponseStatus.OK,
-        message="Project deleted",
-        project_id=project_id,
-    )
+        return StatusResponse(status=ResponseStatus.ERROR, message="Project not found")
+    return StatusResponse(status=ResponseStatus.OK)
 
 
 @router.get("/{project_id}/files")

--- a/python/sidecar/projects/router.py
+++ b/python/sidecar/projects/router.py
@@ -4,9 +4,13 @@ from fastapi import APIRouter
 from sidecar.projects import service
 from sidecar.projects.schemas import (
     ProjectCreateRequest,
+    ProjectCreateResponse,
+    ProjectDeleteResponse,
     ProjectDetailsResponse,
     ProjectFileTreeResponse,
+    ProjectStorageResponse,
 )
+from sidecar.typing import ResponseStatus
 
 router = APIRouter(
     prefix="/projects",
@@ -15,31 +19,25 @@ router = APIRouter(
 
 
 @router.get("/")
-async def list_projects():
+async def list_projects() -> ProjectStorageResponse:
     """
     Returns a list of projects for the current user
     """
     user_id = "user1"
-    projects_dict = service.read_project_path_storage(user_id)
-    return projects_dict
+    return service.read_project_path_storage(user_id)
 
 
 @router.post("/")
-async def create_project(req: ProjectCreateRequest):
+async def create_project(req: ProjectCreateRequest) -> ProjectCreateResponse:
     """
     Creates a project, and a directory in the filesystem
     """
     user_id = "user1"
     project_id = str(uuid4())
-    project_path = service.create_project(
+    project_item = service.create_project(
         user_id, project_id, req.project_name, req.project_path
     )
-    return {
-        project_id: {
-            "project_name": req.project_name,
-            "project_path": project_path,
-        }
-    }
+    return ProjectCreateResponse(id=project_id, **project_item.dict())
 
 
 @router.get("/{project_id}")
@@ -52,7 +50,7 @@ async def get_project(project_id: str) -> ProjectDetailsResponse:
 
 
 @router.delete("/{project_id}")
-async def delete_project(project_id: str):
+async def delete_project(project_id: str) -> ProjectDeleteResponse:
     """
     Deletes a project directory and all files in it
     """
@@ -60,16 +58,16 @@ async def delete_project(project_id: str):
     try:
         service.delete_project(user_id, project_id)
     except KeyError:
-        return {
-            "status": "error",
-            "message": "Project not found",
-            "project_id": project_id,
-        }
-    return {
-        "status": "success",
-        "message": "Project deleted",
-        "project_id": project_id,
-    }
+        return ProjectDeleteResponse(
+            status=ResponseStatus.ERROR,
+            message="Project not found",
+            project_id=project_id,
+        )
+    return ProjectDeleteResponse(
+        status=ResponseStatus.OK,
+        message="Project deleted",
+        project_id=project_id,
+    )
 
 
 @router.get("/{project_id}/files")

--- a/python/sidecar/projects/schemas.py
+++ b/python/sidecar/projects/schemas.py
@@ -1,25 +1,27 @@
-from __future__ import annotations
-
-from sidecar.typing import RefStudioModel, ResponseStatus
-
-
-class FileEntryBase(RefStudioModel):
-    name: str
-    path: str
+from sidecar.filesystem.schemas import FileEntry, FolderEntry
+from sidecar.typing import RefStudioModel
 
 
-class FileEntry(FileEntryBase):
-    file_extension: str
-
-
-class FolderEntry(FileEntryBase):
-    children: list[FileEntry | FolderEntry] = []
-
-
-class ProjectDetailsResponse(RefStudioModel):
+class ProjectBase(RefStudioModel):
     id: str
     name: str
+
+
+class Project(ProjectBase):
     path: str
+
+
+class ProjectStore(RefStudioModel):
+    projects: dict[str, Project]
+
+
+class ProjectDetailsResponse(ProjectBase):
+    # simple pass for now, but we'll eventually extend this
+    pass
+
+
+class ProjectListResponse(RefStudioModel):
+    projects: list[ProjectBase]
 
 
 class ProjectFileTreeResponse(RefStudioModel):
@@ -34,27 +36,3 @@ class ProjectCreateRequest(RefStudioModel):
     The path to the project directory. Only necessary for Desktop.
     For web, the project is stored in a private directory on the server.
     """
-
-
-class ProjectCreateResponse(RefStudioModel):
-    id: str
-    name: str
-    path: str
-
-
-class ProjectDeleteResponse(RefStudioModel):
-    status: ResponseStatus
-    message: str
-    project_id: str
-
-
-class ProjectStorageItem(RefStudioModel):
-    name: str
-    path: str
-
-
-class ProjectStorageResponse(RefStudioModel):
-    projects: dict[str, ProjectStorageItem]
-
-
-FolderEntry.update_forward_refs()

--- a/python/sidecar/projects/schemas.py
+++ b/python/sidecar/projects/schemas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sidecar.typing import RefStudioModel
+from sidecar.typing import RefStudioModel, ResponseStatus
 
 
 class FileEntryBase(RefStudioModel):
@@ -34,6 +34,27 @@ class ProjectCreateRequest(RefStudioModel):
     The path to the project directory. Only necessary for Desktop.
     For web, the project is stored in a private directory on the server.
     """
+
+
+class ProjectCreateResponse(RefStudioModel):
+    id: str
+    name: str
+    path: str
+
+
+class ProjectDeleteResponse(RefStudioModel):
+    status: ResponseStatus
+    message: str
+    project_id: str
+
+
+class ProjectStorageItem(RefStudioModel):
+    name: str
+    path: str
+
+
+class ProjectStorageResponse(RefStudioModel):
+    projects: dict[str, ProjectStorageItem]
 
 
 FolderEntry.update_forward_refs()

--- a/python/sidecar/projects/service.py
+++ b/python/sidecar/projects/service.py
@@ -6,8 +6,6 @@ from sidecar.config import WEB_STORAGE_URL
 from sidecar.filesystem.service import traverse_directory
 from sidecar.projects.schemas import (
     Project,
-    ProjectBase,
-    ProjectDetailsResponse,
     ProjectFileTreeResponse,
     ProjectStore,
 )

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -37,6 +37,7 @@ class ResponseStatus(StrEnum):
 
 class StatusResponse(RefStudioModel):
     status: ResponseStatus
+    message: str = ""
 
 
 class CliCommands(RefStudioModel):

--- a/python/sidecar/typing.py
+++ b/python/sidecar/typing.py
@@ -35,6 +35,10 @@ class ResponseStatus(StrEnum):
     ERROR = "error"
 
 
+class StatusResponse(RefStudioModel):
+    status: ResponseStatus
+
+
 class CliCommands(RefStudioModel):
     serve: tuple[None, None]
     """Start an HTTP server"""

--- a/python/tests/ai/test_router.py
+++ b/python/tests/ai/test_router.py
@@ -5,6 +5,7 @@ from sidecar import config
 from sidecar.ai.chat import Chat
 from sidecar.ai.rewrite import Rewriter
 from sidecar.api import api
+from sidecar.projects import service as projects_service
 from sidecar.projects.service import create_project
 
 from ..helpers import _copy_fixture_to_temp_dir
@@ -98,7 +99,7 @@ def test_ai_chat_is_ok(monkeypatch, mock_call_model_is_ok, tmp_path, fixtures_di
     user_id = "user1"
     project_id = "project1"
 
-    monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
+    monkeypatch.setattr(projects_service, "WEB_STORAGE_URL", tmp_path)
     project = create_project(user_id, project_id, project_name="foo")
     mocked_path = Path(project.path) / ".storage" / "references.json"
 

--- a/python/tests/ai/test_router.py
+++ b/python/tests/ai/test_router.py
@@ -99,8 +99,8 @@ def test_ai_chat_is_ok(monkeypatch, mock_call_model_is_ok, tmp_path, fixtures_di
     project_id = "project1"
 
     monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
-    project_path = create_project(user_id, project_id, project_name="foo")
-    mocked_path = project_path / ".storage" / "references.json"
+    project = create_project(user_id, project_id, project_name="foo")
+    mocked_path = Path(project.path) / ".storage" / "references.json"
 
     # copy references.json to mocked storage path
     test_file = f"{fixtures_dir}/data/references.json"

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -15,7 +15,7 @@ def fixtures_dir():
 
 
 @pytest.fixture
-def setup_project_path_storage(monkeypatch, tmp_path):
+def setup_project_storage(monkeypatch, tmp_path):
     user_id = "user1"
     project_id = "project1"
     project_name = "project1name"

--- a/python/tests/filesystem/test_router.py
+++ b/python/tests/filesystem/test_router.py
@@ -28,11 +28,7 @@ def test_create_file(monkeypatch, tmp_path, fixtures_dir):
         )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "status": "ok",
-        "message": "File uploaded",
-        "filepath": str(filepath),
-    }
+    assert response.json() == {"status": "ok", "message": ""}
 
     # check that the file was created
     assert filepath.exists()
@@ -87,11 +83,7 @@ def test_delete_file(monkeypatch, tmp_path, fixtures_dir):
     response = client.delete(f"/api/fs/{project_id}/{filename}")
 
     assert response.status_code == 200
-    assert response.json() == {
-        "status": "ok",
-        "message": "File deleted",
-        "filepath": str(filepath),
-    }
+    assert response.json() == {"status": "ok", "message": ""}
 
     # check that the file was deleted
     assert not filepath.exists()

--- a/python/tests/filesystem/test_router.py
+++ b/python/tests/filesystem/test_router.py
@@ -1,23 +1,25 @@
+from pathlib import Path
+
 from fastapi.testclient import TestClient
-from sidecar import config
 from sidecar.api import api
+from sidecar.projects import service
 from sidecar.projects.service import create_project
 
 client = TestClient(api)
 
 
 def test_create_file(monkeypatch, tmp_path, fixtures_dir):
-    monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
+    monkeypatch.setattr(service, "WEB_STORAGE_URL", tmp_path)
 
     # create a project
     user_id = "user1"
     project_id = "project1"
     project_name = "project1name"
-    project_path = create_project(user_id, project_id, project_name)
+    project = create_project(user_id, project_id, project_name)
 
     # create a file
     filename = "uploads/test.pdf"
-    filepath = project_path / filename
+    filepath = Path(project.path) / filename
 
     with open(f"{fixtures_dir}/pdf/grobid-fails.pdf", "rb") as f:
         response = client.put(
@@ -27,7 +29,7 @@ def test_create_file(monkeypatch, tmp_path, fixtures_dir):
 
     assert response.status_code == 200
     assert response.json() == {
-        "status": "success",
+        "status": "ok",
         "message": "File uploaded",
         "filepath": str(filepath),
     }
@@ -37,17 +39,17 @@ def test_create_file(monkeypatch, tmp_path, fixtures_dir):
 
 
 def test_read_file(monkeypatch, tmp_path, fixtures_dir):
-    monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
+    monkeypatch.setattr(service, "WEB_STORAGE_URL", tmp_path)
 
     # create a project
     user_id = "user1"
     project_id = "project1"
     project_name = "project1name"
-    project_path = create_project(user_id, project_id, project_name)
+    project = create_project(user_id, project_id, project_name)
 
     # create a file
     filename = "uploads/test.pdf"
-    filepath = project_path / filename
+    filepath = Path(project.path) / filename
 
     with open(f"{fixtures_dir}/pdf/grobid-fails.pdf", "rb") as f:
         response = client.put(
@@ -63,17 +65,17 @@ def test_read_file(monkeypatch, tmp_path, fixtures_dir):
 
 
 def test_delete_file(monkeypatch, tmp_path, fixtures_dir):
-    monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
+    monkeypatch.setattr(service, "WEB_STORAGE_URL", tmp_path)
 
     # create a project
     user_id = "user1"
     project_id = "project1"
     project_name = "project1name"
-    project_path = create_project(user_id, project_id, project_name)
+    project = create_project(user_id, project_id, project_name)
 
     # create a file
     filename = "uploads/test.pdf"
-    filepath = project_path / filename
+    filepath = Path(project.path) / filename
 
     with open(f"{fixtures_dir}/pdf/grobid-fails.pdf", "rb") as f:
         response = client.put(
@@ -86,7 +88,7 @@ def test_delete_file(monkeypatch, tmp_path, fixtures_dir):
 
     assert response.status_code == 200
     assert response.json() == {
-        "status": "success",
+        "status": "ok",
         "message": "File deleted",
         "filepath": str(filepath),
     }

--- a/python/tests/projects/test_router.py
+++ b/python/tests/projects/test_router.py
@@ -8,29 +8,22 @@ from sidecar.projects import service
 client = TestClient(api)
 
 
-def test_http_list_projects(monkeypatch, tmp_path):
+def test_http_list_projects(monkeypatch, tmp_path, setup_project_storage):
     monkeypatch.setattr(service, "WEB_STORAGE_URL", tmp_path)
 
-    user_id = "user1"
     project_id = "project1"
     project_name = "project1name"
 
     response = client.get("/api/projects")
 
     assert response.status_code == 200
-    assert response.json() == {"projects": {}}
-
-    service.create_project(user_id, project_id, project_name)
-
-    response = client.get("/api/projects")
-    assert response.status_code == 200
     expected = {
-        "projects": {
-            project_id: {
+        "projects": [
+            {
+                "id": project_id,
                 "name": project_name,
-                "path": str(tmp_path / user_id / project_id),
             }
-        }
+        ]
     }
     assert response.json() == expected
 
@@ -45,31 +38,26 @@ def test_create_project(monkeypatch, tmp_path):
     response = client.post("/api/projects", json=request)
 
     project_id = response.json()["id"]
-    project_path = response.json()["path"]
 
     assert response.status_code == 200
     assert response.json() == {
         "id": project_id,
         "name": project_name,
-        "path": str(tmp_path / user_id / project_path),
     }
-    assert Path(project_path).exists()
 
     # should create project with random uuid4
     assert isinstance(UUID(project_id), UUID)
 
-    storage = service.read_project_path_storage(user_id)
+    storage = service.read_project_storage(user_id)
     assert project_id in storage.dict()["projects"]
 
 
-def test_get_project(monkeypatch, tmp_path):
+def test_get_project(monkeypatch, tmp_path, setup_project_storage):
     monkeypatch.setattr(service, "WEB_STORAGE_URL", tmp_path)
 
     # create a project
-    user_id = "user1"
     project_id = "project1"
     project_name = "project1name"
-    project = service.create_project(user_id, project_id, project_name)
 
     # get the project
     response = client.get(f"/api/projects/{project_id}")
@@ -78,7 +66,6 @@ def test_get_project(monkeypatch, tmp_path):
     assert response.json() == {
         "id": project_id,
         "name": project_name,
-        "path": project.path,
     }
 
 
@@ -97,12 +84,11 @@ def test_delete_project(monkeypatch, tmp_path):
     assert response.status_code == 200
     assert response.json() == {
         "status": "ok",
-        "message": "Project deleted",
-        "project_id": project_id,
+        "message": "",
     }
 
     # check that the project was deleted
     assert not Path(project.path).exists()
 
-    storage = service.read_project_path_storage(user_id)
+    storage = service.read_project_storage(user_id)
     assert project_id not in storage

--- a/python/tests/references/test_router.py
+++ b/python/tests/references/test_router.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 from fastapi.testclient import TestClient
-from sidecar import config
 from sidecar.api import api
-from sidecar.projects.service import create_project, delete_project
+from sidecar.projects import service as projects_service
+from sidecar.projects.service import create_project
 from sidecar.references.storage import JsonStorage
 
 from ..helpers import _copy_fixture_to_temp_dir
@@ -15,10 +15,8 @@ def test_list_references_should_return_empty_list(monkeypatch, tmp_path):
     user_id = "user1"
     project_id = "project1"
 
-    monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
+    monkeypatch.setattr(projects_service, "WEB_STORAGE_URL", tmp_path)
 
-    # make sure we start with an empty project
-    _ = delete_project(user_id, project_id)
     _ = create_project(user_id, project_id, project_name="foo")
 
     # .storage/references.json does not exist as no references have been ingested
@@ -31,7 +29,7 @@ def test_list_references_should_return_references(monkeypatch, tmp_path, fixture
     user_id = "user1"
     project_id = "project1"
 
-    monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
+    monkeypatch.setattr(projects_service, "WEB_STORAGE_URL", tmp_path)
     project = create_project(user_id, project_id, project_name="foo")
     mocked_path = Path(project.path) / ".storage" / "references.json"
 
@@ -54,7 +52,7 @@ def test_get_reference(monkeypatch, tmp_path, fixtures_dir):
     user_id = "user1"
     project_id = "project1"
 
-    monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
+    monkeypatch.setattr(projects_service, "WEB_STORAGE_URL", tmp_path)
     project = create_project(user_id, project_id, project_name="foo")
     mocked_path = Path(project.path) / ".storage" / "references.json"
 
@@ -79,7 +77,7 @@ def test_references_update(monkeypatch, tmp_path, fixtures_dir):
     user_id = "user1"
     project_id = "project1"
 
-    monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
+    monkeypatch.setattr(projects_service, "WEB_STORAGE_URL", tmp_path)
     project = create_project(user_id, project_id, project_name="foo")
     mocked_path = Path(project.path) / ".storage" / "references.json"
 
@@ -115,7 +113,7 @@ def test_references_bulk_delete(monkeypatch, tmp_path, fixtures_dir):
     user_id = "user1"
     project_id = "project1"
 
-    monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
+    monkeypatch.setattr(projects_service, "WEB_STORAGE_URL", tmp_path)
     project = create_project(user_id, project_id, project_name="foo")
     mocked_path = Path(project.path) / ".storage" / "references.json"
 

--- a/python/tests/references/test_router.py
+++ b/python/tests/references/test_router.py
@@ -32,8 +32,8 @@ def test_list_references_should_return_references(monkeypatch, tmp_path, fixture
     project_id = "project1"
 
     monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
-    project_path = create_project(user_id, project_id, project_name="foo")
-    mocked_path = project_path / ".storage" / "references.json"
+    project = create_project(user_id, project_id, project_name="foo")
+    mocked_path = Path(project.path) / ".storage" / "references.json"
 
     # copy references.json to mocked storage path
     test_file = f"{fixtures_dir}/data/references.json"
@@ -55,8 +55,8 @@ def test_get_reference(monkeypatch, tmp_path, fixtures_dir):
     project_id = "project1"
 
     monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
-    project_path = create_project(user_id, project_id, project_name="foo")
-    mocked_path = project_path / ".storage" / "references.json"
+    project = create_project(user_id, project_id, project_name="foo")
+    mocked_path = Path(project.path) / ".storage" / "references.json"
 
     # copy references.json to mocked storage path
     test_file = f"{fixtures_dir}/data/references.json"
@@ -80,8 +80,8 @@ def test_references_update(monkeypatch, tmp_path, fixtures_dir):
     project_id = "project1"
 
     monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
-    project_path = create_project(user_id, project_id, project_name="foo")
-    mocked_path = project_path / ".storage" / "references.json"
+    project = create_project(user_id, project_id, project_name="foo")
+    mocked_path = Path(project.path) / ".storage" / "references.json"
 
     # copy references.json to mocked storage path
     test_file = f"{fixtures_dir}/data/references.json"
@@ -116,8 +116,8 @@ def test_references_bulk_delete(monkeypatch, tmp_path, fixtures_dir):
     project_id = "project1"
 
     monkeypatch.setattr(config, "WEB_STORAGE_URL", tmp_path)
-    project_path = create_project(user_id, project_id, project_name="foo")
-    mocked_path = project_path / ".storage" / "references.json"
+    project = create_project(user_id, project_id, project_name="foo")
+    mocked_path = Path(project.path) / ".storage" / "references.json"
 
     # copy references.json to mocked storage path
     test_file = f"{fixtures_dir}/data/references.json"

--- a/scripts/reset_refstudio.sh
+++ b/scripts/reset_refstudio.sh
@@ -28,9 +28,18 @@ if [ -f "$WEB_STORAGE_URL/user1/settings.json" ]; then
     cp "$WEB_STORAGE_URL/user1/settings.json" "$WEB_STORAGE_URL/user1.settings.json.bak"
 fi
 
+# Create a time-based random ID
+CURRENT_DATE_TIME=$(date +%Y-%m-%d_%H-%M-%S)
+
+# Copy all files from the user1 folder to a temporary location and inform the user about the action
+cp -r "$WEB_STORAGE_URL/user1" "$WEB_STORAGE_URL/user1-$CURRENT_DATE_TIME"
+echo ""
+echo "user1 folder backed up to $WEB_STORAGE_URL/user1.$CURRENT_DATE_TIME"
+
 # Remove all files from the user1 folder
 rm -rf "$WEB_STORAGE_URL/user1"
 
 # Inform the user that the operation was successful for the WEB_STORAGE_URL folder
 echo ""
 echo "RefStudio reset successfully for the $WEB_STORAGE_URL folder"
+

--- a/src/api/api-paths.ts
+++ b/src/api/api-paths.ts
@@ -7,8 +7,6 @@ import {
   ChatResponse,
   ChatResponseChoice,
   Chunk,
-  CreateFileResponse,
-  DeleteFileResponse,
   DeleteRequest,
   DeleteStatusResponse,
   EmptyRequest,
@@ -19,13 +17,11 @@ import {
   HTTPValidationError,
   IngestResponse,
   IngestStatus,
+  ProjectBase,
   ProjectCreateRequest,
-  ProjectCreateResponse,
-  ProjectDeleteResponse,
   ProjectDetailsResponse,
   ProjectFileTreeResponse,
-  ProjectStorageItem,
-  ProjectStorageResponse,
+  ProjectListResponse,
   Reference,
   ReferencePatch,
   ResponseStatus,
@@ -189,18 +185,6 @@ export interface components {
       /** @default [] */
       vector?: number[];
     };
-    /** CreateFileResponse */
-    CreateFileResponse: {
-      filepath?: string;
-      message: string;
-      status: ResponseStatus;
-    };
-    /** DeleteFileResponse */
-    DeleteFileResponse: {
-      filepath?: string;
-      message: string;
-      status: ResponseStatus;
-    };
     /** DeleteRequest */
     DeleteRequest: {
       /** @default false */
@@ -266,43 +250,28 @@ export interface components {
      * @enum {string}
      */
     IngestStatus: 'processing' | 'failure' | 'complete';
+    /** ProjectBase */
+    ProjectBase: {
+      id: string;
+      name: string;
+    };
     /** ProjectCreateRequest */
     ProjectCreateRequest: {
       project_name: string;
       project_path?: string;
     };
-    /** ProjectCreateResponse */
-    ProjectCreateResponse: {
-      id: string;
-      name: string;
-      path: string;
-    };
-    /** ProjectDeleteResponse */
-    ProjectDeleteResponse: {
-      message: string;
-      project_id: string;
-      status: ResponseStatus;
-    };
     /** ProjectDetailsResponse */
     ProjectDetailsResponse: {
       id: string;
       name: string;
-      path: string;
     };
     /** ProjectFileTreeResponse */
     ProjectFileTreeResponse: {
       contents: (FileEntry | FolderEntry)[];
     };
-    /** ProjectStorageItem */
-    ProjectStorageItem: {
-      name: string;
-      path: string;
-    };
-    /** ProjectStorageResponse */
-    ProjectStorageResponse: {
-      projects: {
-        [key: string]: ProjectStorageItem;
-      };
+    /** ProjectListResponse */
+    ProjectListResponse: {
+      projects: ProjectBase[];
     };
     /**
      * Reference
@@ -385,6 +354,8 @@ export interface components {
     };
     /** StatusResponse */
     StatusResponse: {
+      /** @default */
+      message?: string;
       status: ResponseStatus;
     };
     /** TextCompletionChoice */
@@ -548,7 +519,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': CreateFileResponse;
+          'application/json': StatusResponse;
         };
       };
       /** @description Validation Error */
@@ -571,7 +542,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': DeleteFileResponse;
+          'application/json': StatusResponse;
         };
       };
       /** @description Validation Error */
@@ -636,7 +607,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': ProjectStorageResponse;
+          'application/json': ProjectListResponse;
         };
       };
     };
@@ -655,7 +626,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': ProjectCreateResponse;
+          'application/json': ProjectBase;
         };
       };
       /** @description Validation Error */
@@ -705,7 +676,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': ProjectDeleteResponse;
+          'application/json': StatusResponse;
         };
       };
       /** @description Validation Error */

--- a/src/api/api-paths.ts
+++ b/src/api/api-paths.ts
@@ -7,6 +7,8 @@ import {
   ChatResponse,
   ChatResponseChoice,
   Chunk,
+  CreateFileResponse,
+  DeleteFileResponse,
   DeleteRequest,
   DeleteStatusResponse,
   EmptyRequest,
@@ -18,8 +20,12 @@ import {
   IngestResponse,
   IngestStatus,
   ProjectCreateRequest,
+  ProjectCreateResponse,
+  ProjectDeleteResponse,
   ProjectDetailsResponse,
   ProjectFileTreeResponse,
+  ProjectStorageItem,
+  ProjectStorageResponse,
   Reference,
   ReferencePatch,
   ResponseStatus,
@@ -29,6 +35,7 @@ import {
   RewriteResponse,
   S2SearchResult,
   SearchResponse,
+  StatusResponse,
   TextCompletionChoice,
   TextCompletionRequest,
   TextCompletionResponse,
@@ -182,6 +189,18 @@ export interface components {
       /** @default [] */
       vector?: number[];
     };
+    /** CreateFileResponse */
+    CreateFileResponse: {
+      filepath?: string;
+      message: string;
+      status: ResponseStatus;
+    };
+    /** DeleteFileResponse */
+    DeleteFileResponse: {
+      filepath?: string;
+      message: string;
+      status: ResponseStatus;
+    };
     /** DeleteRequest */
     DeleteRequest: {
       /** @default false */
@@ -252,6 +271,18 @@ export interface components {
       project_name: string;
       project_path?: string;
     };
+    /** ProjectCreateResponse */
+    ProjectCreateResponse: {
+      id: string;
+      name: string;
+      path: string;
+    };
+    /** ProjectDeleteResponse */
+    ProjectDeleteResponse: {
+      message: string;
+      project_id: string;
+      status: ResponseStatus;
+    };
     /** ProjectDetailsResponse */
     ProjectDetailsResponse: {
       id: string;
@@ -261,6 +292,17 @@ export interface components {
     /** ProjectFileTreeResponse */
     ProjectFileTreeResponse: {
       contents: (FileEntry | FolderEntry)[];
+    };
+    /** ProjectStorageItem */
+    ProjectStorageItem: {
+      name: string;
+      path: string;
+    };
+    /** ProjectStorageResponse */
+    ProjectStorageResponse: {
+      projects: {
+        [key: string]: ProjectStorageItem;
+      };
     };
     /**
      * Reference
@@ -339,6 +381,10 @@ export interface components {
     SearchResponse: {
       message: string;
       results: S2SearchResult[];
+      status: ResponseStatus;
+    };
+    /** StatusResponse */
+    StatusResponse: {
       status: ResponseStatus;
     };
     /** TextCompletionChoice */
@@ -502,7 +548,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': unknown;
+          'application/json': CreateFileResponse;
         };
       };
       /** @description Validation Error */
@@ -525,7 +571,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': unknown;
+          'application/json': DeleteFileResponse;
         };
       };
       /** @description Validation Error */
@@ -576,7 +622,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': unknown;
+          'application/json': StatusResponse;
         };
       };
     };
@@ -590,7 +636,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': unknown;
+          'application/json': ProjectStorageResponse;
         };
       };
     };
@@ -609,7 +655,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': unknown;
+          'application/json': ProjectCreateResponse;
         };
       };
       /** @description Validation Error */
@@ -659,7 +705,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          'application/json': unknown;
+          'application/json': ProjectDeleteResponse;
         };
       };
       /** @description Validation Error */

--- a/src/api/api-types.ts
+++ b/src/api/api-types.ts
@@ -89,24 +89,6 @@ export interface Chunk {
 }
 /**
  * This interface was referenced by `ApiSchema`'s JSON-Schema
- * via the `definition` "CreateFileResponse".
- */
-export interface CreateFileResponse {
-  status: ResponseStatus;
-  message: string;
-  filepath?: string;
-}
-/**
- * This interface was referenced by `ApiSchema`'s JSON-Schema
- * via the `definition` "DeleteFileResponse".
- */
-export interface DeleteFileResponse {
-  status: ResponseStatus;
-  message: string;
-  filepath?: string;
-}
-/**
- * This interface was referenced by `ApiSchema`'s JSON-Schema
  * via the `definition` "DeleteRequest".
  */
 export interface DeleteRequest {
@@ -218,6 +200,14 @@ export interface Reference {
 }
 /**
  * This interface was referenced by `ApiSchema`'s JSON-Schema
+ * via the `definition` "ProjectBase".
+ */
+export interface ProjectBase {
+  id: string;
+  name: string;
+}
+/**
+ * This interface was referenced by `ApiSchema`'s JSON-Schema
  * via the `definition` "ProjectCreateRequest".
  */
 export interface ProjectCreateRequest {
@@ -226,30 +216,11 @@ export interface ProjectCreateRequest {
 }
 /**
  * This interface was referenced by `ApiSchema`'s JSON-Schema
- * via the `definition` "ProjectCreateResponse".
- */
-export interface ProjectCreateResponse {
-  id: string;
-  name: string;
-  path: string;
-}
-/**
- * This interface was referenced by `ApiSchema`'s JSON-Schema
- * via the `definition` "ProjectDeleteResponse".
- */
-export interface ProjectDeleteResponse {
-  status: ResponseStatus;
-  message: string;
-  project_id: string;
-}
-/**
- * This interface was referenced by `ApiSchema`'s JSON-Schema
  * via the `definition` "ProjectDetailsResponse".
  */
 export interface ProjectDetailsResponse {
   id: string;
   name: string;
-  path: string;
 }
 /**
  * This interface was referenced by `ApiSchema`'s JSON-Schema
@@ -260,20 +231,10 @@ export interface ProjectFileTreeResponse {
 }
 /**
  * This interface was referenced by `ApiSchema`'s JSON-Schema
- * via the `definition` "ProjectStorageItem".
+ * via the `definition` "ProjectListResponse".
  */
-export interface ProjectStorageItem {
-  name: string;
-  path: string;
-}
-/**
- * This interface was referenced by `ApiSchema`'s JSON-Schema
- * via the `definition` "ProjectStorageResponse".
- */
-export interface ProjectStorageResponse {
-  projects: {
-    [k: string]: ProjectStorageItem;
-  };
+export interface ProjectListResponse {
+  projects: ProjectBase[];
 }
 /**
  * ReferencePatch is the input type for updating a Reference's metadata.
@@ -340,6 +301,7 @@ export interface SearchResponse {
  */
 export interface StatusResponse {
   status: ResponseStatus;
+  message?: string;
 }
 /**
  * This interface was referenced by `ApiSchema`'s JSON-Schema

--- a/src/api/api-types.ts
+++ b/src/api/api-types.ts
@@ -89,6 +89,24 @@ export interface Chunk {
 }
 /**
  * This interface was referenced by `ApiSchema`'s JSON-Schema
+ * via the `definition` "CreateFileResponse".
+ */
+export interface CreateFileResponse {
+  status: ResponseStatus;
+  message: string;
+  filepath?: string;
+}
+/**
+ * This interface was referenced by `ApiSchema`'s JSON-Schema
+ * via the `definition` "DeleteFileResponse".
+ */
+export interface DeleteFileResponse {
+  status: ResponseStatus;
+  message: string;
+  filepath?: string;
+}
+/**
+ * This interface was referenced by `ApiSchema`'s JSON-Schema
  * via the `definition` "DeleteRequest".
  */
 export interface DeleteRequest {
@@ -208,6 +226,24 @@ export interface ProjectCreateRequest {
 }
 /**
  * This interface was referenced by `ApiSchema`'s JSON-Schema
+ * via the `definition` "ProjectCreateResponse".
+ */
+export interface ProjectCreateResponse {
+  id: string;
+  name: string;
+  path: string;
+}
+/**
+ * This interface was referenced by `ApiSchema`'s JSON-Schema
+ * via the `definition` "ProjectDeleteResponse".
+ */
+export interface ProjectDeleteResponse {
+  status: ResponseStatus;
+  message: string;
+  project_id: string;
+}
+/**
+ * This interface was referenced by `ApiSchema`'s JSON-Schema
  * via the `definition` "ProjectDetailsResponse".
  */
 export interface ProjectDetailsResponse {
@@ -221,6 +257,23 @@ export interface ProjectDetailsResponse {
  */
 export interface ProjectFileTreeResponse {
   contents: (FileEntry | FolderEntry)[];
+}
+/**
+ * This interface was referenced by `ApiSchema`'s JSON-Schema
+ * via the `definition` "ProjectStorageItem".
+ */
+export interface ProjectStorageItem {
+  name: string;
+  path: string;
+}
+/**
+ * This interface was referenced by `ApiSchema`'s JSON-Schema
+ * via the `definition` "ProjectStorageResponse".
+ */
+export interface ProjectStorageResponse {
+  projects: {
+    [k: string]: ProjectStorageItem;
+  };
 }
 /**
  * ReferencePatch is the input type for updating a Reference's metadata.
@@ -280,6 +333,13 @@ export interface SearchResponse {
   status: ResponseStatus;
   message: string;
   results: S2SearchResult[];
+}
+/**
+ * This interface was referenced by `ApiSchema`'s JSON-Schema
+ * via the `definition` "StatusResponse".
+ */
+export interface StatusResponse {
+  status: ResponseStatus;
 }
 /**
  * This interface was referenced by `ApiSchema`'s JSON-Schema

--- a/src/api/projectsAPI.ts
+++ b/src/api/projectsAPI.ts
@@ -6,15 +6,12 @@ export interface ProjectInfo {
   name: string;
 }
 
-type ProjectsResponse = Record<string, { project_name: string }>;
-type ProjectPostResponse = ProjectsResponse;
-
 // ########################################################################################
 // PROJECT LIFE CYCLE
 // ########################################################################################
 export async function readAllProjects(): Promise<ProjectInfo[]> {
-  const projects = (await apiGetJson('/api/projects/')) as ProjectsResponse;
-  return Object.keys(projects).map((id) => ({ id, name: projects[id].project_name }));
+  const response = await apiGetJson('/api/projects/');
+  return response.projects.map((p) => ({ id: p.id, name: p.name }));
 }
 
 export async function readProjectById(projectId: string): Promise<ProjectInfo> {
@@ -35,21 +32,18 @@ export async function readProjectById(projectId: string): Promise<ProjectInfo> {
  * @returns the project info
  */
 export async function createRemoteProject(projectName: string, projectPath?: string): Promise<ProjectInfo> {
-  const payload = (await apiPost('/api/projects/', {
+  const response = await apiPost('/api/projects/', {
     project_name: projectName,
     project_path: projectPath,
-  })) as ProjectPostResponse;
+  });
 
   if (projectPath && import.meta.env.VITE_IS_WEB) {
     throw new Error('Cannot set the project path when running in the browser.');
   }
 
-  const projectId = Object.keys(payload)[0];
-  const { project_name } = payload[projectId];
-
   return {
-    id: projectId,
-    name: project_name,
+    id: response.id,
+    name: response.name,
   };
 }
 


### PR DESCRIPTION
fixes #510 

@cguedes the following endpoints are still showing up as `unknown`:
- `read_file_api_fs__project_id___filepath__get` -- I suspect this has something to do with this endpoint returning fastapi's `FileResponse` rather than our own definition. I tried wrapping `FileResponse`, but no luck.
- `head_file_api_fs__project_id___filepath__head` -- doesn't return anything
- `shutdown_api_meta_shutdown_post` -- doesn't return anything