### PR TITLE
chore: sidecar enable logging flag is inverted

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
         "request": "launch",
         "module": "uvicorn",
         "cwd": "${workspaceFolder}/python",
-        "args": ["web:api", "--reload"],
+        "args": ["sidecar.api:api", "--reload"],
         "justMyCode": true
       }
     ]

--- a/python/sidecar/config.py
+++ b/python/sidecar/config.py
@@ -24,4 +24,4 @@ formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(messag
 handler.setFormatter(formatter)
 
 logger.addHandler(handler)
-logger.disabled = os.environ.get("SIDECAR_ENABLE_LOGGING", "false").lower() == "true"
+logger.disabled = os.environ.get("SIDECAR_ENABLE_LOGGING", "false").lower() != "true"


### PR DESCRIPTION
This PR fixes #523 and also fixes the VSCode launch.json configuration for "Python: FastAPI"