### PR TITLE
feat: apply max width to editor instead of content only

### DIFF
--- a/src/application/components/MainPanel.tsx
+++ b/src/application/components/MainPanel.tsx
@@ -68,7 +68,7 @@ const MainPanelPane = memo(({ paneId }: MainPanelPaneProps) => {
           <div className="grow-0">
             <OpenEditorsTabPane paneId={paneId} />
           </div>
-          <div className="flex w-full grow overflow-hidden bg-content-area-bg-primary px-10 pt-10">
+          <div className="flex w-full grow justify-center overflow-hidden bg-content-area-bg-primary px-10 pt-10">
             {activeEditorAtoms ? <MainPaneViewContent activeEditorAtoms={activeEditorAtoms} /> : <EmptyView />}
           </div>
         </>

--- a/src/features/textEditor/components/TipTapEditor.css
+++ b/src/features/textEditor/components/TipTapEditor.css
@@ -1,5 +1,5 @@
 .editor-container {
-  @apply flex h-full w-full flex-col;
+  @apply flex h-full w-full max-w-[45rem] flex-col;
   @apply overflow-hidden rounded-default shadow-default;
 }
 
@@ -19,7 +19,7 @@
 }
 
 .tiptap-editor > div {
-  @apply w-full max-w-[45rem];
+  @apply w-full;
 }
 
 .tiptap-editor h2 {


### PR DESCRIPTION
This applies the max-width to the text editor, and not the content only, to make the left indent fixed

<img width="1512" alt="Screenshot 2023-09-11 at 10 22 16" src="https://github.com/refstudio/refstudio/assets/58954208/33188a51-5440-4bd7-b7be-2b26a8189b4b">

Closes #528 and #482