### PR TITLE
feat: Update FileNameInput component with latest colors and design

### DIFF
--- a/src/components/FileNameInput.tsx
+++ b/src/components/FileNameInput.tsx
@@ -45,8 +45,9 @@ export function FileNameInput({ fileName, isNameValid, onCancel, onSubmit }: Fil
 
   return (
     <input
-      className={cx('w-full border border-blue-400 outline-none', {
-        'border-red-600': !isValueValid,
+      className={cx('w-full rounded border border-solid p-1 pl-2 outline-none', {
+        'border-input-border-active': isValueValid,
+        'border-input-border-error': !isValueValid,
       })}
       ref={focusAndSelect}
       role="textbox"

--- a/src/features/ai/settings/OpenAiSettingsPane.tsx
+++ b/src/features/ai/settings/OpenAiSettingsPane.tsx
@@ -68,7 +68,7 @@ export function OpenAiSettingsPane({ config }: SettingsPaneProps) {
       </div>
       <div className="flex flex-col items-start gap-2">
         <div className="flex flex-row gap-1">
-          <h2 className="t text-modal-txt-primary">Chat Model</h2>
+          <h2 className="text-modal-txt-primary">Chat Model</h2>
           <ChatModelTooltip />
         </div>
         <Input
@@ -78,7 +78,7 @@ export function OpenAiSettingsPane({ config }: SettingsPaneProps) {
         />
       </div>
       <div className="flex flex-col items-start gap-2">
-        <h2 className="t text-modal-txt-primary">Speech Type</h2>
+        <h2 className="text-modal-txt-primary">Speech Type</h2>
         <Dropdown
           aria-label="manner"
           data-testid={REWRITE_MANNER_TEST_ID}

--- a/src/features/components/RewriteWidget.tsx
+++ b/src/features/components/RewriteWidget.tsx
@@ -64,8 +64,8 @@ export function RewriteWidget({
   return (
     <div className={cx('flex flex-col gap-4 px-4', className)}>
       <div className="flex flex-col">
-        <div className="border border-b-0 border-primary bg-slate-50 p-4">{selection}</div>
-        <div className="flex w-full flex-wrap items-center justify-between gap-2 rounded-b-xl border border-t border-primary bg-primary/50 ">
+        <div className="border-primary border border-b-0 bg-slate-50 p-4">{selection}</div>
+        <div className="border-primary bg-primary/50 flex w-full flex-wrap items-center justify-between gap-2 rounded-b-xl border border-t ">
           <div className="flex items-center gap-1 whitespace-nowrap">
             <select
               aria-label="manner"
@@ -110,23 +110,23 @@ export function RewriteWidget({
       {!isFetching && !!error && <span className="bg-red-50 p-4">{String(error)}</span>}
       {!isFetching && rewrite?.ok === false && <span className="bg-red-50 p-4">{rewrite.message}</span>}
       {rewrite?.ok && (
-        <div className="flex flex-col rounded-xl rounded-t-none border-primary bg-primary/50">
+        <div className="border-primary bg-primary/50 flex flex-col rounded-xl rounded-t-none">
           <div className="m-1 flex items-center justify-between p-2">
             <div>
               <strong>Rewrite Choices</strong>
-              <small className="block text-muted">
+              <small className="text-muted block">
                 Showing rewrite option {selectedChoiceIndex + 1} of {rewrite.choices.length}.
               </small>
             </div>
-            <div className="flex items-center gap-1 text-primary-hover">
+            <div className="text-primary-hover flex items-center gap-1">
               <VscChevronLeft
-                className="cursor-pointer border border-primary hover:bg-primary-hover hover:text-primary"
+                className="border-primary hover:bg-primary-hover hover:text-primary cursor-pointer border"
                 size={20}
                 title="previous choice"
                 onClick={() => setSelectedChoiceIndex(decRotate(selectedChoiceIndex, rewrite.choices))}
               />
               <VscChevronRight
-                className="cursor-pointer border border-primary hover:bg-primary-hover hover:text-primary"
+                className="border-primary hover:bg-primary-hover hover:text-primary cursor-pointer border"
                 size={20}
                 title="next choice"
                 onClick={() => setSelectedChoiceIndex(incRotate(selectedChoiceIndex, rewrite.choices))}

--- a/src/features/references/editor/ReferenceView.css
+++ b/src/features/references/editor/ReferenceView.css
@@ -16,5 +16,4 @@
 .reference-details th {
   @apply py-3;
   @apply text-left;
-  @apply bg-primary;
 }

--- a/src/features/textEditor/components/tipTapNodes/citation/CitationNode.ts
+++ b/src/features/textEditor/components/tipTapNodes/citation/CitationNode.ts
@@ -102,7 +102,7 @@ const citationPlugin = new Plugin<CitationPluginState>({
             const parentNode = document.createElement('span');
 
             parentNode.innerHTML = '; ';
-            parentNode.style.color = 'hsl(var(--color-muted))';
+            parentNode.style.color = 'rgb(var(--grayscale-60))';
 
             return parentNode;
           },

--- a/src/features/textEditor/components/tipTapNodes/notionBlock/plugins/collapsiblePlaceholderPlugin.ts
+++ b/src/features/textEditor/components/tipTapNodes/notionBlock/plugins/collapsiblePlaceholderPlugin.ts
@@ -47,7 +47,7 @@ function createEmptyCollapsiblePlaceholderWidget(pos: number) {
   return Decoration.widget(pos, () => {
     const placeholder = document.createElement('div');
     placeholder.innerHTML = 'Empty collapsible. Click or drop blocks inside.';
-    placeholder.style.color = 'hsl(var(--color-muted))';
+    placeholder.style.color = 'rgb(var(--grayscale-60))';
     placeholder.classList.add('empty-collapsible-placeholder');
 
     return placeholder;

--- a/src/features/textEditor/components/tipTapNodes/notionBlock/plugins/placeholderPlugin.ts
+++ b/src/features/textEditor/components/tipTapNodes/notionBlock/plugins/placeholderPlugin.ts
@@ -20,7 +20,7 @@ export const placeholderPlugin = new Plugin({
           () => {
             const t = document.createElement('span');
             t.innerHTML = 'You can start writing here';
-            t.style.color = 'hsl(var(--color-muted))';
+            t.style.color = 'rgb(var(--grayscale-60))';
             return t;
           },
           { side: 1 },

--- a/src/features/textEditor/components/tipTapNodes/sentenceCompletion/SentenceCompletion.ts
+++ b/src/features/textEditor/components/tipTapNodes/sentenceCompletion/SentenceCompletion.ts
@@ -90,10 +90,10 @@ const sentenceCompletionPlugin = new Plugin<SentenceCompletionState>({
           const parentNode = document.createElement('span');
 
           parentNode.innerHTML = suggestionText;
-          parentNode.style.color = 'hsl(var(--color-muted))';
+          parentNode.style.color = 'rgb(var(--grayscale-60))';
 
           if (currentState.status === 'error') {
-            parentNode.style.color = 'hsl(var(--color-error))';
+            parentNode.style.color = 'rgb(var(--semantic-error-50))';
           }
 
           return parentNode;

--- a/src/index.css
+++ b/src/index.css
@@ -5,12 +5,6 @@
 @layer base {
   :root {
     /* https://tailwindcss.com/docs/customizing-colors#using-css-variables */
-    --color-primary: 151deg 54% 69%;
-    --color-primary-hover: 152deg 54% 48%;
-    --color-secondary: 193deg 37% 69%;
-    --color-secondary-hover: 193deg 37% 48%;
-    --color-muted: 218deg 11% 65%;
-    --color-error: 0deg 84% 60%;
     --grayscale-00: 255 255 255;
     --grayscale-10: 249 250 252;
     --grayscale-20: 239 241 244;
@@ -24,19 +18,18 @@
     --primary-10: 220 234 250;
     --primary-50: 36 62 93;
     --primary-90: 29 51 77;
+    --semantic-error-10: 255 232 230;
+    --semantic-error-50: 219 40 40;
+    --semantic-warning-10: 255 248 219;
+    --semantic-warning-50: 181 129 5;
+    --semantic-success-10: 229 249 231;
+    --semantic-success-50: 30 188 48;
+    --semantic-info-10: 225 247 247;
+    --semantic-info-50: 17 155 173;
   }
 }
 
 @layer components {
-  .btn-primary {
-    @apply cursor-pointer rounded-xl bg-primary;
-    @apply px-4 py-0.5;
-    @apply hover:bg-primary-hover hover:text-white;
-  }
-  .btn-primary[disabled] {
-    @apply pointer-events-none opacity-50;
-  }
-
   /* Displays a box (top right) with a debug note */
   .debug-widget {
     @apply relative before:absolute before:right-4 before:top-4 before:hidden before:bg-yellow-100 before:p-2 hover:before:block hover:before:content-['Just_for_Debug!'];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,17 +6,6 @@ export default {
   theme: {
     extend: {
       colors: {
-        // Using modern `hsl`
-        primary: {
-          DEFAULT: 'hsl(var(--color-primary) / <alpha-value>)',
-          hover: 'hsl(var(--color-primary-hover) / <alpha-value>)',
-        },
-        secondary: {
-          DEFAULT: 'hsl(var(--color-secondary) / <alpha-value>)',
-          hover: 'hsl(var(--color-secondary-hover) / <alpha-value>)',
-        },
-        muted: 'hsl(var(--color-muted) / <alpha-value>)',
-        error: 'hsl(var(--color-error) / <alpha-value>)',
         'resizer-bg': {
           hover: 'rgb(var(--grayscale-40) / <alpha-value>)',
           default: 'rgb(var(--grayscale-20) / <alpha-value>)',
@@ -103,9 +92,10 @@ export default {
           disabled: 'rgb(var(--grayscale-40) / <alpha-value>)',
         },
         'input-border': {
-          active: 'rgb(var(--primary-50) / <alpha-value>)',
+          active: 'rgb(var(--grayscale-50) / <alpha-value>)',
           disabled: 'rgb(var(--grayscale-20) / <alpha-value>)',
           default: 'rgb(var(--grayscale-20) / <alpha-value>)',
+          error: 'rgb(var(--semantic-error-50) / <alpha-value>)',
         },
         'input-bg': {
           disabled: 'rgb(var(--grayscale-20) / <alpha-value>)',
@@ -231,7 +221,6 @@ export default {
 function autocompleteCustomComponentsPlugin() {
   return plugin(function ({ addComponents }) {
     addComponents({
-      '.btn-primary': {},
       '.debug-widget': {},
     });
   });


### PR DESCRIPTION
This updates the input for file names (when renaming) with the new semantic colors.
This adds all semantic colors as CSS variables
And this also removes old CSS and tailwind variables.
NB: The RewriteWidget component still uses some of the removed tailwind classes, but the component will be removed in #514 

https://github.com/refstudio/refstudio/assets/58954208/a1427abf-3229-48e4-998b-fa32997fea38

Closes #530