### PR TITLE
fix: prevent the saving spinner from showing up when it should not

### DIFF
--- a/src/atoms/core/createEditorContentAtoms.ts
+++ b/src/atoms/core/createEditorContentAtoms.ts
@@ -6,7 +6,7 @@ import { refreshFileTreeAtom } from '../fileExplorerActions';
 import { EditorContent } from '../types/EditorContent';
 import { EditorContentAtoms } from '../types/EditorContentAtoms';
 import { EditorId, parseEditorId } from '../types/EditorData';
-import { editorsDataAtom, setEditorDataIsDirtyAtom } from './editorData';
+import { editorsDataAtom, setEditorContentIsBeingSavedAtom, setEditorDataIsDirtyAtom } from './editorData';
 
 export function createEditorContentAtoms(
   editorId: EditorId,
@@ -26,26 +26,30 @@ export function createEditorContentAtoms(
   });
 
   const saveEditorContentAtom = atom(null, async (get, set) => {
-    const editorContent = get(editorBufferAtom);
-    if (editorContent) {
-      switch (editorContent.type) {
-        case 'refstudio': {
-          const currentEditorId = get(editorIdAtom);
-          const { id: path } = parseEditorId(currentEditorId);
+    try {
+      const editorContent = get(editorBufferAtom);
+      if (editorContent) {
+        switch (editorContent.type) {
+          case 'refstudio': {
+            const currentEditorId = get(editorIdAtom);
+            const { id: path } = parseEditorId(currentEditorId);
 
-          const success = await writeFileContent(path, JSON.stringify(editorContent.jsonContent));
-          if (success) {
-            set(setEditorDataIsDirtyAtom, { editorId: currentEditorId, isDirty: false });
-            // Refresh file tree after saving file
-            void set(refreshFileTreeAtom);
+            const success = await writeFileContent(path, JSON.stringify(editorContent.jsonContent));
+            if (success) {
+              set(setEditorDataIsDirtyAtom, { editorId: currentEditorId, isDirty: false });
+              // Refresh file tree after saving file
+              void set(refreshFileTreeAtom);
+            }
+            return;
           }
-          return;
-        }
-        default: {
-          console.error('Save editor - Unsupported editor content type: ', editorContent.type);
-          return;
+          default: {
+            console.error('Save editor - Unsupported editor content type: ', editorContent.type);
+            return;
+          }
         }
       }
+    } finally {
+      set(setEditorContentIsBeingSavedAtom, { editorId: get(editorIdAtom), isContentBeingSaved: false });
     }
   });
 
@@ -54,6 +58,7 @@ export function createEditorContentAtoms(
   const updateEditorContentBufferAtom = atom(null, (get, set, payload: EditorContent) => {
     set(editorBufferAtom, payload);
     set(setEditorDataIsDirtyAtom, { editorId: get(editorIdAtom), isDirty: true });
+    set(setEditorContentIsBeingSavedAtom, { editorId: get(editorIdAtom), isContentBeingSaved: true });
 
     // Debounced auto-save of editor content
     if (saveTimeoutId) {

--- a/src/atoms/core/createEditorContentAtoms.ts
+++ b/src/atoms/core/createEditorContentAtoms.ts
@@ -60,7 +60,7 @@ export function createEditorContentAtoms(
       clearTimeout(saveTimeoutId);
     }
     saveTimeoutId = setTimeout(() => {
-      const editorData = get(editorsDataAtom).get(editorId);
+      const editorData = get(editorsDataAtom).get(get(editorIdAtom));
       if (!editorData) {
         console.log('Editor data not found, cannot save editor content');
         return;

--- a/src/atoms/core/editorData.ts
+++ b/src/atoms/core/editorData.ts
@@ -44,6 +44,25 @@ export const setEditorDataIsDirtyAtom = atom(
   },
 );
 
+/** Update the `isContentBeingSaved` flag of the given editor */
+export const setEditorContentIsBeingSavedAtom = atom(
+  null,
+  (get, set, { editorId, isContentBeingSaved }: { editorId: EditorId; isContentBeingSaved: boolean }) => {
+    const updatedEditorsData = new Map(get(editorsDataAtom));
+
+    const editorData = updatedEditorsData.get(editorId);
+
+    /* c8 ignore next 4 */
+    if (!editorData) {
+      console.warn('Editor is not open ', editorId);
+      return;
+    }
+
+    updatedEditorsData.set(editorId, { ...editorData, isContentBeingSaved });
+    set(editorsDataAtom, updatedEditorsData);
+  },
+);
+
 interface RenameEditorDataPayload {
   editorId: EditorId;
   newEditorId: EditorId;

--- a/src/atoms/hooks/__tests__/useAnyEditorDataIsDirty.test.ts
+++ b/src/atoms/hooks/__tests__/useAnyEditorDataIsDirty.test.ts
@@ -7,7 +7,7 @@ import { editorsContentStateAtom } from '../../core/editorContent';
 import { editorsDataAtom } from '../../core/editorData';
 import { EditorContentAtoms } from '../../types/EditorContentAtoms';
 import { buildEditorId, EditorId } from '../../types/EditorData';
-import { useAnyEditorDataIsDirty } from '../useAnyEditorDataIsDirty';
+import { useSomeEditorIsBeingSaved } from '../useSomeEditorIsBeingSaved';
 
 describe('useAnyEditorDataIsDirty', () => {
   let store: ReturnType<typeof createStore>;
@@ -32,12 +32,12 @@ describe('useAnyEditorDataIsDirty', () => {
   });
 
   it('should return false when no editor is dirty', () => {
-    const { current } = runHookWithJotaiProvider(useAnyEditorDataIsDirty, store);
+    const { current } = runHookWithJotaiProvider(useSomeEditorIsBeingSaved, store);
     expect(current).toBeFalsy();
   });
 
   it('should return true when one editor is edited', async () => {
-    const hookResult = runHookWithJotaiProvider(useAnyEditorDataIsDirty, store);
+    const hookResult = runHookWithJotaiProvider(useSomeEditorIsBeingSaved, store);
 
     expect(hookResult.current).toBeFalsy();
 

--- a/src/atoms/hooks/useSomeEditorIsBeingSaved.ts
+++ b/src/atoms/hooks/useSomeEditorIsBeingSaved.ts
@@ -5,11 +5,11 @@ import { useCallback } from 'react';
 import { editorsDataAtom } from '../core/editorData';
 
 /** Returns true if any open editor is dirty */
-export function useAnyEditorDataIsDirty(): boolean {
+export function useSomeEditorIsBeingSaved(): boolean {
   return useAtomValue(
     selectAtom(
       editorsDataAtom,
-      useCallback((editorsData) => Array.from(editorsData.values()).some((editor) => editor.isDirty), []),
+      useCallback((editorsData) => Array.from(editorsData.values()).some((editor) => editor.isContentBeingSaved), []),
     ),
   );
 }

--- a/src/atoms/types/EditorData.ts
+++ b/src/atoms/types/EditorData.ts
@@ -8,6 +8,7 @@ export interface EditorData {
   id: EditorId;
   title: string;
   isDirty?: boolean;
+  isContentBeingSaved?: boolean;
 }
 
 export function parseEditorId(editorId: EditorId): { type: EditorContentType; id: string } {

--- a/src/features/textEditor/footer/FooterSavingFilesItem.tsx
+++ b/src/features/textEditor/footer/FooterSavingFilesItem.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import { VscCheck, VscCloud, VscRefresh } from 'react-icons/vsc';
 
-import { useAnyEditorDataIsDirty } from '../../../atoms/hooks/useAnyEditorDataIsDirty';
+import { useSomeEditorIsBeingSaved } from '../../../atoms/hooks/useSomeEditorIsBeingSaved';
 import { FooterItem } from '../../../components/footer/FooterItem';
 
 export function FooterSavingFilesItem() {
   const [showSaved, setShowSaved] = useState(false);
-  const someDirty = useAnyEditorDataIsDirty();
+  const someDirty = useSomeEditorIsBeingSaved();
 
   useEffect(() => {
     // Note: We know this will show the "All files saved" info in the first run. That's ok.

--- a/src/features/textEditor/footer/__tests__/FooterSavingFilesItem.test.tsx
+++ b/src/features/textEditor/footer/__tests__/FooterSavingFilesItem.test.tsx
@@ -1,17 +1,17 @@
 import { createStore } from 'jotai';
 
-import { useAnyEditorDataIsDirty } from '../../../../atoms/hooks/useAnyEditorDataIsDirty';
+import { useSomeEditorIsBeingSaved } from '../../../../atoms/hooks/useSomeEditorIsBeingSaved';
 import { screen, setupWithJotaiProvider } from '../../../../test/test-utils';
 import { FooterSavingFilesItem } from '../FooterSavingFilesItem';
 
-vi.mock('../../../../atoms/hooks/useAnyEditorDataIsDirty');
+vi.mock('../../../../atoms/hooks/useSomeEditorIsBeingSaved');
 
 describe('FooterSavingFilesItem', () => {
   let store: ReturnType<typeof createStore>;
 
   beforeEach(() => {
     store = createStore();
-    vi.mocked(useAnyEditorDataIsDirty).mockReturnValue(false);
+    vi.mocked(useSomeEditorIsBeingSaved).mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -24,7 +24,7 @@ describe('FooterSavingFilesItem', () => {
   });
 
   it('should display "Saving..." when some file is dirty', () => {
-    vi.mocked(useAnyEditorDataIsDirty).mockReturnValue(true);
+    vi.mocked(useSomeEditorIsBeingSaved).mockReturnValue(true);
 
     setupWithJotaiProvider(<FooterSavingFilesItem />, store);
     expect(screen.getByText('Saving...')).toBeInTheDocument();


### PR DESCRIPTION
**Problems**
- We were using `isDirty` flag to determine whether some files were being saved. However a new file is dirty but is not being saved.
- The debounced saving function was using the `editorId` instead of the atom. So after renaming a file, the id that was used was outdated.

**Solutions**
- Create a `isContentBeingSaved` flag in EditorData. The flag is set to `true` when updating the buffer and set to `false` after saving (even if the save operation failed)
- Use the `EditorIdAtom` in the debounced save function

Fixes #564