### PR TITLE
feat: add min width to sidebars

### DIFF
--- a/src/application/sidebar/LeftSidePanelWrapper.tsx
+++ b/src/application/sidebar/LeftSidePanelWrapper.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ImperativePanelHandle, Panel } from 'react-resizable-panels';
+import { useWindowSize } from 'usehooks-ts';
 
 import { VerticalResizeHandle } from '../../components/VerticalResizeHandle';
 import { emitEvent } from '../../events';
@@ -16,6 +17,9 @@ export function LeftSidePanelWrapper({ disabled }: { disabled?: boolean }) {
   const leftPanelRef = useRef<ImperativePanelHandle>(null);
   const [isPanelCollapsed, setIsPanelCollapsed] = useState(disabled);
   const [activePanel, setActivePanel] = useState<PrimarySideBarPanel>('Explorer');
+
+  const size = useWindowSize();
+  const minWidth = useMemo(() => (256 / size.width) * 100, [size.width]);
 
   const handleSideBarClick = useCallback(
     (clickedPane: PrimarySideBarPanel) => {
@@ -86,6 +90,7 @@ export function LeftSidePanelWrapper({ disabled }: { disabled?: boolean }) {
       <Panel
         className="z-sidebar-panel shadow-default"
         collapsible
+        minSize={Number.isFinite(minWidth) ? minWidth : undefined}
         order={1}
         ref={leftPanelRef}
         onCollapse={(collapsed) => {

--- a/src/application/sidebar/RightSidePanelWrapper.tsx
+++ b/src/application/sidebar/RightSidePanelWrapper.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ImperativePanelHandle, Panel } from 'react-resizable-panels';
+import { useWindowSize } from 'usehooks-ts';
 
 import { VerticalResizeHandle } from '../../components/VerticalResizeHandle';
 import { ChatbotPanel } from '../../features/ai/sidebar/ChatPanel';
@@ -15,6 +16,9 @@ export function RightSidePanelWrapper({ disabled }: { disabled?: boolean }) {
   const rightPanelRef = useRef<ImperativePanelHandle>(null);
   const [isPanelCollapsed, setIsPanelCollapsed] = useState(true);
   const [activePanel, setActivePanel] = useState<SecondarySideBarPanel>('Rewriter');
+
+  const size = useWindowSize();
+  const minWidth = useMemo(() => (256 / size.width) * 100, [size.width]);
 
   const handleSideBarClick = useCallback(
     (clickedPanel: SecondarySideBarPanel) => {
@@ -67,6 +71,7 @@ export function RightSidePanelWrapper({ disabled }: { disabled?: boolean }) {
       <Panel
         className="z-sidebar-panel shadow-default"
         collapsible
+        minSize={Number.isFinite(minWidth) ? minWidth : undefined}
         order={3}
         ref={rightPanelRef}
         onCollapse={(collapsed) => {


### PR DESCRIPTION
This computes the percentage corresponding to 256px to give a min width to sidebar panels

<img width="1512" alt="image" src="https://github.com/refstudio/refstudio/assets/58954208/c1c92eb0-db99-4850-a807-e9d24e06ead6">

In a next release `react-resizable-panels` should add support for using pixels unit directly (cf. https://github.com/bvaughn/react-resizable-panels/pull/176). This PR is a temporary solution.