### PR TITLE
561 s2 paper id dedupe

### DIFF
--- a/src/api/referencesAPI.ts
+++ b/src/api/referencesAPI.ts
@@ -71,6 +71,7 @@ function parsePdfIngestionResponse(references: Reference[]): ReferenceItem[] {
       fullName: author.full_name,
       lastName: author.surname ?? author.full_name.split(' ').pop() ?? '',
     })),
+    metadata: reference.metadata ?? {},
   }));
 }
 

--- a/src/api/s2SearchAPI.ts
+++ b/src/api/s2SearchAPI.ts
@@ -37,6 +37,10 @@ export async function postS2Reference(projectId: string, s2SearchResult: S2Searc
     contents: '',
     published_date: getBestPublicationDate(s2SearchResult),
     authors: formatAuthorsFromS2Result(s2SearchResult.authors),
+    metadata: {
+      sourceId: s2SearchResult.paperId,
+      source: 's2',
+    },
   };
 
   const pdfRequestBody: IngestMetadataRequest = {

--- a/src/atoms/s2SearchState.ts
+++ b/src/atoms/s2SearchState.ts
@@ -4,18 +4,35 @@ import { S2SearchResult } from '../api/api-types';
 import { removeProjectReferences } from '../api/referencesAPI';
 import { getS2ReferencesByKeyword, postS2Reference } from '../api/s2SearchAPI';
 import { refreshFileTreeAtom } from './fileExplorerActions';
-import { loadReferencesAtom } from './referencesState';
+import { getReferencesAtom, loadReferencesAtom } from './referencesState';
 
 // #####################################################################################
 // Internal Atoms
 // #####################################################################################
 export const searchResultsAtom = atom<S2SearchResult[]>([]);
+export const paperIdLookupAtom = atom<Record<string,string>>({});
 
 // #####################################################################################
 // References API
 // #####################################################################################
 
 export const getSearchResultsAtom = atom((get) => Object.values(get(searchResultsAtom)));
+export const getPaperIdLookupAtom = atom((get) => get(paperIdLookupAtom));
+
+export const generatePaperIdLookupAtom = atom(null, (get, set) => {
+  const updatedReferencesPaperIdLookup:Record<string,string> = {};    
+  const refStudioReferences = get(getReferencesAtom);
+  
+  refStudioReferences.forEach((reference) => {
+    if (reference.metadata?.sourceId) {
+      updatedReferencesPaperIdLookup[reference.metadata.sourceId] = reference.id;
+    }
+  });
+
+  set(paperIdLookupAtom, updatedReferencesPaperIdLookup);
+
+});
+
 
 export const loadSearchResultsAtom = atom(null, async (_get, set, keywords: string, limit?: number) => {
   const searchResults = await getS2ReferencesByKeyword(keywords, limit);

--- a/src/atoms/s2SearchState.ts
+++ b/src/atoms/s2SearchState.ts
@@ -10,7 +10,7 @@ import { getReferencesAtom, loadReferencesAtom } from './referencesState';
 // Internal Atoms
 // #####################################################################################
 export const searchResultsAtom = atom<S2SearchResult[]>([]);
-export const paperIdLookupAtom = atom<Record<string,string>>({});
+export const paperIdLookupAtom = atom<Record<string, string>>({});
 
 // #####################################################################################
 // References API
@@ -20,9 +20,9 @@ export const getSearchResultsAtom = atom((get) => Object.values(get(searchResult
 export const getPaperIdLookupAtom = atom((get) => get(paperIdLookupAtom));
 
 export const generatePaperIdLookupAtom = atom(null, (get, set) => {
-  const updatedReferencesPaperIdLookup:Record<string,string> = {};    
+  const updatedReferencesPaperIdLookup: Record<string, string> = {};
   const refStudioReferences = get(getReferencesAtom);
-  
+
   refStudioReferences.forEach((reference) => {
     if (reference.metadata?.sourceId) {
       updatedReferencesPaperIdLookup[reference.metadata.sourceId] = reference.id;
@@ -30,9 +30,7 @@ export const generatePaperIdLookupAtom = atom(null, (get, set) => {
   });
 
   set(paperIdLookupAtom, updatedReferencesPaperIdLookup);
-
 });
-
 
 export const loadSearchResultsAtom = atom(null, async (_get, set, keywords: string, limit?: number) => {
   const searchResults = await getS2ReferencesByKeyword(keywords, limit);

--- a/src/features/references/__tests__/test-fixtures.ts
+++ b/src/features/references/__tests__/test-fixtures.ts
@@ -11,6 +11,10 @@ export const REFERENCES: ReferenceItem[] = [
     doi: '0000',
     authors: [{ fullName: 'Joe Doe', lastName: 'Doe' }],
     publishedDate: '2023-08-15',
+    metadata: {
+      sourceId: '1234',
+      source: 's2',
+    },
   },
   {
     id: '45722618-c4fb-4ae1-9230-7fc19a7219ed',

--- a/src/features/references/editor/ReferenceDetailsCard.tsx
+++ b/src/features/references/editor/ReferenceDetailsCard.tsx
@@ -122,12 +122,14 @@ const IconButton = ({ title, icon, onClick }: { title: string; icon: ReactElemen
   </button>
 );
 
+type ReferenceDetailsCardItem = Omit<ReferenceItem, 'metadata'>;
+
 export default function ReferenceDetailsCard({
   reference,
   handleReferenceChange,
   handleOpenPdf,
 }: {
-  reference: ReferenceItem;
+  reference: ReferenceDetailsCardItem;
   handleReferenceChange: (params: ReferenceItem) => void;
   handleOpenPdf?: (reference: ReferenceItem) => void;
 }) {
@@ -203,7 +205,7 @@ export default function ReferenceDetailsCard({
       </thead>
       <tbody className="divide-y">
         {Object.entries(referenceDetailsCardFormat).map(([key, rowData]) => {
-          const contentData = reference[key as keyof ReferenceItem];
+          const contentData = reference[key as keyof ReferenceDetailsCardItem];
 
           return (
             <tr key={key}>

--- a/src/features/s2search/S2SearchModal.tsx
+++ b/src/features/s2search/S2SearchModal.tsx
@@ -38,7 +38,6 @@ const SearchBar = ({ onChange }: { onChange: (value: string, limit: number) => v
 );
 
 export const SearchResult = ({ s2SearchResult, projectId }: { s2SearchResult: S2SearchResult; projectId: string }) => {
-
   let refStatusDefault = 'ready';
   let refIdDefault = '';
   const refStudioIdLookup = useAtomValue(getPaperIdLookupAtom);
@@ -47,7 +46,7 @@ export const SearchResult = ({ s2SearchResult, projectId }: { s2SearchResult: S2
     refIdDefault = refStudioIdLookup[s2SearchResult.paperId];
     refStatusDefault = 'added';
   }
-  
+
   const [refStatus, setRefStatus] = useState(refStatusDefault);
   const [refId, setRefId] = useState(refIdDefault);
   const [message, setMessage] = useState('');
@@ -55,7 +54,6 @@ export const SearchResult = ({ s2SearchResult, projectId }: { s2SearchResult: S2
   const [showRemove, setShowRemove] = useState(false);
   const saveS2Reference = useSetAtom(addS2ReferenceAtom);
   const removeS2Reference = useSetAtom(removeS2ReferenceAtom);
-
 
   const addClickHandler = useCallback(() => {
     setRefStatus('adding');
@@ -262,16 +260,15 @@ export function S2SearchModal({ open, onClose: onClose }: { open: boolean; onClo
   const clearSearchResults = useSetAtom(clearSearchResultsAtom);
   const generatePaperIdLookup = useSetAtom(generatePaperIdLookupAtom);
   const [loading, setLoading] = useState(false);
-  
-  useEffect(()=> {
+
+  useEffect(() => {
     generatePaperIdLookup();
   }, [generatePaperIdLookup]);
-
 
   const handleKeyWordsEntered = useCallback(
     (searchTerm: string, limit?: number) => {
       setLoading(true);
-      
+
       loadSearchResults(searchTerm, limit)
         .then(() => {
           setLoading(false);
@@ -280,7 +277,6 @@ export function S2SearchModal({ open, onClose: onClose }: { open: boolean; onClo
           notifyError('Could not load search results');
           console.error(err);
         });
-        
     },
     [loadSearchResults],
   );

--- a/src/features/s2search/S2SearchModal.tsx
+++ b/src/features/s2search/S2SearchModal.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue, useSetAtom } from 'jotai';
-import { ReactElement, useCallback, useState } from 'react';
+import { ReactElement, useCallback, useEffect, useState } from 'react';
 import { SiSemanticscholar } from 'react-icons/si';
 
 import { S2SearchResult } from '../../api/api-types';
@@ -8,6 +8,8 @@ import { projectIdAtom } from '../../atoms/projectState';
 import {
   addS2ReferenceAtom,
   clearSearchResultsAtom,
+  generatePaperIdLookupAtom,
+  getPaperIdLookupAtom,
   getSearchResultsAtom,
   loadSearchResultsAtom,
   removeS2ReferenceAtom,
@@ -35,18 +37,29 @@ const SearchBar = ({ onChange }: { onChange: (value: string, limit: number) => v
   </div>
 );
 
-export const SearchResult = ({ reference, projectId }: { reference: S2SearchResult; projectId: string }) => {
-  const [refStatus, setRefStatus] = useState('ready');
-  const [refId, setRefId] = useState('');
+export const SearchResult = ({ s2SearchResult, projectId }: { s2SearchResult: S2SearchResult; projectId: string }) => {
+
+  let refStatusDefault = 'ready';
+  let refIdDefault = '';
+  const refStudioIdLookup = useAtomValue(getPaperIdLookupAtom);
+
+  if (s2SearchResult.paperId && s2SearchResult.paperId in refStudioIdLookup) {
+    refIdDefault = refStudioIdLookup[s2SearchResult.paperId];
+    refStatusDefault = 'added';
+  }
+  
+  const [refStatus, setRefStatus] = useState(refStatusDefault);
+  const [refId, setRefId] = useState(refIdDefault);
   const [message, setMessage] = useState('');
 
   const [showRemove, setShowRemove] = useState(false);
   const saveS2Reference = useSetAtom(addS2ReferenceAtom);
   const removeS2Reference = useSetAtom(removeS2ReferenceAtom);
 
+
   const addClickHandler = useCallback(() => {
     setRefStatus('adding');
-    saveS2Reference(projectId, reference)
+    saveS2Reference(projectId, s2SearchResult)
       .then((result) => {
         setRefId(result.references[0].id);
         if (result.message) {
@@ -55,7 +68,7 @@ export const SearchResult = ({ reference, projectId }: { reference: S2SearchResu
         setRefStatus('added');
       })
       .catch(() => setRefStatus('error'));
-  }, [projectId, reference, saveS2Reference]);
+  }, [projectId, s2SearchResult, saveS2Reference]);
 
   const removeClickHandler = useCallback(() => {
     removeS2Reference(projectId, refId)
@@ -67,13 +80,13 @@ export const SearchResult = ({ reference, projectId }: { reference: S2SearchResu
     <div className="border-b border-modal-border px-5 py-3 text-base">
       <div className="space-y-2">
         <div className="flex">
-          <div className="basis-4/5 truncate font-semibold" title={reference.title}>
-            {reference.title}
+          <div className="basis-4/5 truncate font-semibold" title={s2SearchResult.title}>
+            {s2SearchResult.title}
           </div>
           <div className="flex h-8 basis-1/5 justify-end space-x-1">
             {refStatus === 'ready' && (
               <>
-                {!reference.openAccessPdf && (
+                {!s2SearchResult.openAccessPdf && (
                   <div
                     className="flex items-center justify-center"
                     title="This reference has no PDF. Chat functions will be limited."
@@ -101,7 +114,7 @@ export const SearchResult = ({ reference, projectId }: { reference: S2SearchResu
             )}
           </div>
         </div>
-        <MetaData reference={reference} />
+        <MetaData reference={s2SearchResult} />
       </div>
     </div>
   );
@@ -140,6 +153,7 @@ const MetaData = ({ reference }: { reference: S2SearchResult }) => {
     </>
   );
 };
+
 const formatMessage = (message: string): ReactElement[] => {
   const parts = message.split(/(https?:\/\/[^\s]+)/g);
   const formattedParts: ReactElement[] = [];
@@ -246,18 +260,27 @@ export function S2SearchModal({ open, onClose: onClose }: { open: boolean; onClo
 
   const loadSearchResults = useSetAtom(loadSearchResultsAtom);
   const clearSearchResults = useSetAtom(clearSearchResultsAtom);
-
+  const generatePaperIdLookup = useSetAtom(generatePaperIdLookupAtom);
   const [loading, setLoading] = useState(false);
+  
+  useEffect(()=> {
+    generatePaperIdLookup();
+  }, [generatePaperIdLookup]);
+
 
   const handleKeyWordsEntered = useCallback(
     (searchTerm: string, limit?: number) => {
       setLoading(true);
+      
       loadSearchResults(searchTerm, limit)
-        .then(() => setLoading(false))
+        .then(() => {
+          setLoading(false);
+        })
         .catch((err) => {
           notifyError('Could not load search results');
           console.error(err);
         });
+        
     },
     [loadSearchResults],
   );
@@ -293,7 +316,7 @@ export function S2SearchModal({ open, onClose: onClose }: { open: boolean; onClo
           )}
           {!loading &&
             searchResultsList.map((reference) => (
-              <SearchResult key={reference.paperId} projectId={projectId} reference={reference} />
+              <SearchResult key={reference.paperId} projectId={projectId} s2SearchResult={reference} />
             ))}
         </div>
       </div>

--- a/src/features/s2search/__tests__/S2SearchModal.test.tsx
+++ b/src/features/s2search/__tests__/S2SearchModal.test.tsx
@@ -4,6 +4,7 @@ import * as s2SearchAPI from '../../../api/s2SearchAPI';
 import * as S2SearchState from '../../../atoms/s2SearchState';
 import { noop } from '../../../lib/noop';
 import { render, screen, setupWithJotaiProvider, waitFor } from '../../../test/test-utils';
+import { REFERENCES } from '../../references/__tests__/test-fixtures';
 import { S2SearchModal, SearchResult } from '../S2SearchModal';
 
 const searchResults = [
@@ -38,7 +39,7 @@ const searchResults = [
       'Neural circuits sit in a dynamic balance between excitation (E) and inhibition (I). Fluctuations in this E:I balance have been shown to influence neural computation, working memory, and information processing. While more drastic shifts and aberrant E:I patterns are implicated in numerous neurological and psychiatric disorders, current methods for measuring E:I dynamics require invasive procedures that are difficult to perform in behaving animals, and nearly impossible in humans. This has limited the ability to examine the full impact that E:I shifts have in neural computation and disease. In this study, we develop a computational model to show that E:I ratio can be estimated from the power law exponent (slope) of the electrophysiological power spectrum, and validate this relationship using previously published datasets from two species (rat local field potential and macaque electrocorticography). This simple method--one that can be applied retrospectively to existing data--removes a major hurdle in understanding a currently difficult to measure, yet fundamental, aspect of neural computation.',
     venue: 'NeuroImage',
     publicationDate: '2016-10-16T00:00:00',
-    paperId: '0a2c3202a9c4c4f7709eeed324ca53e12ad4af72',
+    paperId: '1234',
     citationCount: 357,
     openAccessPdf: 'https://www.biorxiv.org/content/biorxiv/early/2016/10/16/081125.full.pdf',
     authors: ['Richard Gao', 'E. Peterson', 'Bradley Voytek'],
@@ -49,7 +50,13 @@ global.CSS.supports = () => false;
 
 vi.mock('../../events');
 vi.mock('../../api/s2SearchAPI');
-vi.mock('../../../atoms/referencesState');
+vi.mock('../../../atoms/referencesState', async (importOriginal) => {
+  const actual: object = await importOriginal();
+  return {
+    ...actual,
+    getReferencesAtom: atom(() => REFERENCES),
+  };
+});
 
 vi.mock('../../../atoms/s2SearchState', async (importOriginal) => {
   const actual: object = await importOriginal();
@@ -111,6 +118,18 @@ describe('S2SearchModal component', () => {
 
     await waitFor(() => {
       expect(screen.getAllByTitle('This reference has no PDF. Chat functions will be limited.').length).toBe(2);
+    });
+  });
+
+  it('should show Added for references with a paperId that matches an existing reference', async () => {
+    const store = createStore();
+
+    const { user } = setupWithJotaiProvider(<S2SearchModal open onClose={noop} />, store);
+    const searchBar = screen.getByPlaceholderText('Search Semantic Scholar...');
+    await user.type(searchBar, 'voytek');
+
+    await waitFor(() => {
+      expect(screen.getByText('Added')).toBeInTheDocument();
     });
   });
 

--- a/src/features/s2search/__tests__/S2SearchModal.test.tsx
+++ b/src/features/s2search/__tests__/S2SearchModal.test.tsx
@@ -119,7 +119,7 @@ describe('S2SearchModal component', () => {
   it('should attempt to add the reference', async () => {
     const store = createStore();
 
-    const { user } = setupWithJotaiProvider(<SearchResult projectId="000" reference={searchResults[0]} />, store);
+    const { user } = setupWithJotaiProvider(<SearchResult projectId="000" s2SearchResult={searchResults[0]} />, store);
     await user.click(screen.getByTitle('Add this reference to your references list'));
 
     await waitFor(() => {

--- a/src/types/ReferenceItem.ts
+++ b/src/types/ReferenceItem.ts
@@ -9,11 +9,17 @@ export interface ReferenceItem {
   status: ReferenceItemStatus;
   authors: Author[];
   doi: string;
+  metadata?: ReferenceMetadata;
 }
 
 export interface Author {
   fullName: string;
   lastName: string;
+}
+
+export interface ReferenceMetadata {
+  sourceId?: string;
+  source?: string;
 }
 
 export type ReferenceItemStatus = 'processing' | 'failure' | 'complete';


### PR DESCRIPTION
#561 
- saves the paperId from S2 search results in the metadata JSON string as {sourceId:[paperId], source:'s2'}
- uses any existing sourceId's to create a lookup table for sourceId->reference.id
- any s2 result that _can be matched_ to an existing reference shows [Added] button by default and can be removed in the modal