### PR TITLE
fix: do not indent blocks when moving them

### DIFF
--- a/src/features/textEditor/components/tipTapNodes/notionBlock/NotionBlockNode.ts
+++ b/src/features/textEditor/components/tipTapNodes/notionBlock/NotionBlockNode.ts
@@ -202,3 +202,5 @@ export const NotionBlockNode = Node.create({
     toggleOrderedList: () => toggleOrderedList,
   }),
 });
+
+export const LIST_ITEM_TYPES = ['collapsible', 'orderedList', 'unorederedList'];

--- a/src/features/textEditor/components/tipTapNodes/notionBlock/plugins/blockBrowsingPlugin.ts
+++ b/src/features/textEditor/components/tipTapNodes/notionBlock/plugins/blockBrowsingPlugin.ts
@@ -235,7 +235,7 @@ function moveBlocksDown({ depthDifference, endPos, selection, tr, dispatch }: Bl
     // If the sibling is a list item, an uncollapsed collapsible block or has children, make selected blocks its child
     if (
       (LIST_ITEM_TYPES.includes(sibling.attrs.type as string) && !sibling.attrs.collapsed) ||
-      sibling.childCount > 1
+      (!LIST_ITEM_TYPES.includes(sibling.attrs.type as string) && sibling.childCount > 1)
     ) {
       const sliceToMove = tr.doc.slice(selection.from + depthDifference, endPos);
 
@@ -324,7 +324,7 @@ function moveBlocksUp({
     // If the sibling is a list item, is a uncollapsed collapsible block or has children, indents the block
     if (
       (LIST_ITEM_TYPES.includes(sibling?.attrs.type as string) && !sibling?.attrs.collapsed) ||
-      (sibling && sibling.childCount > 1)
+      (!LIST_ITEM_TYPES.includes(sibling?.attrs.type as string) && sibling && sibling.childCount > 1)
     ) {
       const startPos = selection.from - 1; // End of sibling
 

--- a/src/features/textEditor/components/tipTapNodes/notionBlock/plugins/blockBrowsingPlugin.ts
+++ b/src/features/textEditor/components/tipTapNodes/notionBlock/plugins/blockBrowsingPlugin.ts
@@ -5,7 +5,7 @@ import { Decoration, DecorationSet } from '@tiptap/pm/view';
 
 import { toggleCollapsed } from '../commands/toggleCollapsed';
 import { addUnindentSteps } from '../commands/unindent';
-import { NotionBlockNode } from '../NotionBlockNode';
+import { LIST_ITEM_TYPES, NotionBlockNode } from '../NotionBlockNode';
 import { BlockSelection } from '../selection/BlockSelection';
 import { addIndentBlockSteps } from '../utils/addIndentBlockSteps';
 import { collapsibleArrowsPluginKey } from './collapsibleArrowPlugin';
@@ -232,8 +232,11 @@ function moveBlocksDown({ depthDifference, endPos, selection, tr, dispatch }: Bl
   // If the last selected node has a sibling
   if (indexInParent < parent.childCount - 1) {
     const sibling = parent.child(indexInParent + 1);
-    // If the sibling is collapsed, move selection after the sibling
-    if (sibling.attrs.type === 'collapsible' && sibling.attrs.collapsed) {
+    // If the sibling is not a list item or is a collapsed collapsible block, move selection after the sibling
+    if (
+      !LIST_ITEM_TYPES.includes(sibling.attrs.type as string) ||
+      (sibling.attrs.type === 'collapsible' && sibling.attrs.collapsed)
+    ) {
       const sliceToMove = tr.doc.slice(selection.from + depthDifference, endPos);
 
       tr.delete(selection.from + depthDifference, endPos);
@@ -318,8 +321,11 @@ function moveBlocksUp({
     const siblingPos = selection.$from.posAtIndex(indexInParent - 1);
     const sibling = tr.doc.nodeAt(siblingPos);
 
-    if (sibling?.attrs.type === 'collapsible' && sibling.attrs.collapsed) {
-      // If the sibling is collapsed, move the block before its sibling
+    if (
+      !LIST_ITEM_TYPES.includes(sibling?.attrs.type as string) ||
+      (sibling?.attrs.type === 'collapsible' && sibling.attrs.collapsed)
+    ) {
+      // If the sibling is not a list item or is a collapsed collapsible block, move the block before its sibling
       const sliceToMove = tr.doc.slice(selection.from + depthDifference, endPos);
       tr.replace(selection.from + depthDifference, endPos);
       tr.replace(siblingPos, siblingPos, sliceToMove);


### PR DESCRIPTION
Fixes #586

This changes the logic when moving a block up/down.
Now the block is indented only when its sibling is a list item, an uncollapsed collapsible block or a regular block with children. Otherwise, the block moves before/after its sibling.

https://github.com/refstudio/refstudio/assets/58954208/976144bf-0363-48dc-8292-ad7144360115

