### PR TITLE
chore: Bump version to 23.3.0-next

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refstudio",
   "private": true,
-  "version": "23.2.1",
+  "version": "23.3.0-next",
   "description": "An open source text editor optimized for writing that relies on references.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Configure a new release cycle for `23.3.0-next` so that we can test builds in the GH actions.